### PR TITLE
Get document symbols and highlights even for bad parse

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -434,11 +434,21 @@ export abstract class MalloyTranslation {
       if (!tryParse.parse) {
         this.metadataResponse = tryParse;
       } else {
-        this.metadataResponse = {
-          symbols: walkForDocumentSymbols(
+        // Wrap the parse tree walker in a try block -- if the parse is bad, this walk
+        // could result in unexpected errors due to the parse tree not looking as expected.
+        // We still want to attempt to walk the tree, to preserve document symbols even
+        // when there's a bad parse, but we also want to be safe about it.
+        let symbols;
+        try {
+          symbols = walkForDocumentSymbols(
             tryParse.parse.tokens,
             tryParse.parse.root
-          ),
+          );
+        } catch {
+          // Do nothing, symbols already `undefined`
+        }
+        this.metadataResponse = {
+          symbols,
           highlights: passForHighlights(tryParse.parse.tokens),
           final: true,
         };


### PR DESCRIPTION
@mtoy-googly-moogly 

It is _really unpleasant_ when highlights and symbol information disappear when the document fails to parse.

Compare highlighting/lensing only when there is a valid parse:
![Screen Recording 2021-08-25 at 12 28 04 PM](https://user-images.githubusercontent.com/3538955/130837609-12159a82-2a67-434e-9007-5058108db61d.gif)

With highlighting/lensing always:
![Screen Recording 2021-08-25 at 12 26 34 PM](https://user-images.githubusercontent.com/3538955/130837518-e22ca933-852a-4e1e-a071-6ca53fd18b97.gif)

Re: the comments:
```
// Walks of a parse tree with errors are more dangerous, lots of
// unexpected undefined references, so there is no walking of the
// parse tree unless the parse was clean.
```
```
// Don't attempt to walk a parse tree with errors
```
I haven't come across any noticeable cases where there are real problems that arise from doing so... If you know of cases where this becomes an issue, pleas let me know.

_Note: in the "new" example video, the highlighting of `is` within the comment shouldn't happen, but the correct fix for that is different: the grammar for block comments should allow the block comment to end with an EOF instead of a `*/`, in which case you get an error that says you're missing a `*/`_

<img width="375" alt="Screen Shot 2021-08-25 at 12 35 13 PM" src="https://user-images.githubusercontent.com/3538955/130838416-86b0cd81-72e2-4eac-b479-86a69826f43a.png">


