### PR TITLE
remove default keybinding for cmd-enter

### DIFF
--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -98,13 +98,6 @@
 				"configuration": "language.json"
 			}
 		],
-		"keybindings": [
-			{
-				"command": "malloy.runQueryFile",
-				"key": "ctrl+enter",
-				"mac": "cmd+enter"
-			}
-		],
 		"views": {
 			"explorer": [
 				{


### PR DESCRIPTION
Remove the cmd-Enter behavior.  If we add it back, make sure it is local to Malloy.

Anika, you want to test and merge?