### PR TITLE
move our packages to use "@malloy-lang" scope (which we own on npm)

### DIFF
--- a/docs/_scripts/build_docs/index.ts
+++ b/docs/_scripts/build_docs/index.ts
@@ -13,8 +13,8 @@
 
 import path from "path";
 import fs from "fs";
-import { Malloy } from "malloy";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { Malloy } from "@malloy-lang/malloy";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 import { performance } from "perf_hooks";
 import { renderDoc } from "./render_document";
 import { renderFooter, renderSidebar, Section } from "./page";

--- a/docs/_scripts/build_docs/render_document.ts
+++ b/docs/_scripts/build_docs/render_document.ts
@@ -21,8 +21,8 @@ import "prismjs/components/prism-json";
 import "prismjs/components/prism-sql";
 import { runCode } from "./run_code";
 import { log } from "./log";
-import { Malloy } from "malloy";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { Malloy } from "@malloy-lang/malloy";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("docs");
 

--- a/docs/_scripts/build_docs/run_code.ts
+++ b/docs/_scripts/build_docs/run_code.ts
@@ -17,8 +17,8 @@
  * that depend on that model. If `--watch` is enabled, changes to a model file
  * will cause relevant documents to recompile.
  */
-import { DataStyles, DataTreeRoot, HtmlView } from "malloy-render";
-import { Malloy, MalloyTranslator } from "malloy";
+import { DataStyles, DataTreeRoot, HtmlView } from "@malloy-lang/malloy-render";
+import { Malloy, MalloyTranslator } from "@malloy-lang/malloy";
 import path from "path";
 import fs from "fs";
 import { performance } from "perf_hooks";

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "version": "0.0.1",
   "license": "GPL-2.0",
-  "name": "@looker-open-source/malloy",
+  "name": "@malloy-lang/malloy",
   "workspaces": {
     "packages": [
       "packages/*"
@@ -15,8 +15,8 @@
     "samples"
   ],
   "scripts": {
-    "clean": "yarn workspace malloy clean && yarn tsc --build --clean",
-    "build": "yarn workspace malloy build-parser && yarn tsc --build",
+    "clean": "yarn workspace @malloy-lang/malloy clean && yarn tsc --build --clean",
+    "build": "yarn workspace @malloy-lang/malloy build-parser && yarn tsc --build",
     "lint": "yarn eslint '**/*.ts{,x}'",
     "test": "yarn lint && yarn build && yarn workspaces run test",
     "test-fast": "yarn workspaces run test",
@@ -26,7 +26,7 @@
     "docs-preprocess": "ts-node docs/_scripts/build_docs/index.ts --watch",
     "docs-postprocess": "yarn wait-on ./docs/_includes/generated/toc.html && cd docs && bundle exec jekyll serve -l -o",
     "docs-serve": "yarn docs-prebuild && yarn concurrently --kill-others 'yarn docs-preprocess' 'yarn docs-postprocess'",
-    "vscode-webpack-dev": "yarn workspace malloy-vscode webpack-dev",
+    "vscode-webpack-dev": "yarn workspace @malloy-lang/malloy-vscode webpack-dev",
     "third-party-licenses": "ts-node scripts/third_party_licenses"
   },
   "resolutions": {},
@@ -45,9 +45,9 @@
     "jest": "26.6.0",
     "jest-diff": "^27.0.6",
     "jest-expect-message": "^1.0.2",
-    "malloy": "*",
-    "malloy-db-bigquery": "*",
-    "malloy-render": "*",
+    "@malloy-lang/malloy": "*",
+    "@malloy-lang/malloy-db-bigquery": "*",
+    "@malloy-lang/malloy-render": "*",
     "md5": "^2.3.0",
     "prettier": "^2.3.2",
     "prismjs": "^1.24.1",

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloy-db-bigquery",
+  "name": "@malloy-lang/malloy-db-bigquery",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -14,6 +14,6 @@
     "@google-cloud/bigquery": "^5.5.0",
     "@google-cloud/common": "^3.6.0",
     "gaxios": "^4.2.0",
-    "malloy": "*"
+    "@malloy-lang/malloy": "*"
   }
 }

--- a/packages/malloy-db-bigquery/src/bigquery.spec.ts
+++ b/packages/malloy-db-bigquery/src/bigquery.spec.ts
@@ -1,4 +1,4 @@
-import { Malloy } from "malloy";
+import { Malloy } from "@malloy-lang/malloy";
 import { BigQueryConnection } from "./bigquery_connection";
 import { BigQuery as BigQuerySDK, TableMetadata } from "@google-cloud/bigquery";
 

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -32,7 +32,7 @@ import {
   FieldTypeDef,
   NamedStructDefs,
   Connection,
-} from "malloy";
+} from "@malloy-lang/malloy";
 
 export interface BigQueryManagerOptions {
   credentials?: {

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloy-db-postgres",
+  "name": "@malloy-lang/malloy-db-postgres",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@types/pg": "^8.6.1",
-    "malloy": "*",
+    "@malloy-lang/malloy": "*",
     "pg": "^8.7.1"
   }
 }

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -19,7 +19,7 @@ import {
   NamedStructDefs,
   AtomicFieldType,
   QueryData,
-} from "malloy";
+} from "@malloy-lang/malloy";
 import { Client } from "pg";
 
 const postgresToMalloyTypes: { [key: string]: AtomicFieldType } = {

--- a/packages/malloy-db-test/package.json
+++ b/packages/malloy-db-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloy-db-test",
+  "name": "@malloy-lang/malloy-db-test",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -11,7 +11,7 @@
     "build": "yarn tsc --build"
   },
   "dependencies": {
-    "malloy": "*",
-    "malloy-db-bigquery": "*"
+    "@malloy-lang/malloy": "*",
+    "@malloy-lang/malloy-db-bigquery": "*"
   }
 }

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -12,8 +12,14 @@
  * GNU General Public License for more details.
  */
 
-import { Malloy, ModelDef, QueryModel, QueryResult, StructDef } from "malloy";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import {
+  Malloy,
+  ModelDef,
+  QueryModel,
+  QueryResult,
+  StructDef,
+} from "@malloy-lang/malloy";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 import { fStringEq, fStringLike } from "./test_utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/malloy-db-test/src/join.spec.ts
+++ b/packages/malloy-db-test/src/join.spec.ts
@@ -12,8 +12,8 @@
  */
 /* eslint-disable no-console */
 
-import { Malloy, QueryModel } from "malloy";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { Malloy, QueryModel } from "@malloy-lang/malloy";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-db-test/src/malloy-to-json.ts
+++ b/packages/malloy-db-test/src/malloy-to-json.ts
@@ -12,8 +12,8 @@
  */
 /* eslint-disable no-console */
 import * as readline from "readline";
-import { Malloy, MalloyTranslator } from "malloy";
-import { pretty } from "malloy/src/lang/jest-factories";
+import { Malloy, MalloyTranslator } from "@malloy-lang/malloy";
+import { pretty } from "@malloy-lang/malloy/src/lang/jest-factories";
 import { readFileSync } from "fs";
 
 /*

--- a/packages/malloy-db-test/src/malloy_query.spec.ts
+++ b/packages/malloy-db-test/src/malloy_query.spec.ts
@@ -12,14 +12,14 @@
  */
 
 import { test } from "@jest/globals";
-import { Malloy, QueryModel } from "malloy";
+import { Malloy, QueryModel } from "@malloy-lang/malloy";
 import { testModel } from "./models/faa_model";
 import { fStringEq } from "./test_utils";
 
-import "malloy/src/lang/jestery";
-import { TestTranslator } from "malloy/src/lang/jest-factories";
+import "@malloy-lang/malloy/src/lang/jestery";
+import { TestTranslator } from "@malloy-lang/malloy/src/lang/jest-factories";
 import { FLIGHTS_EXPLORE } from "./models/faa_model";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-db-test/src/models/faa_model.ts
+++ b/packages/malloy-db-test/src/models/faa_model.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { ModelDef, StructDef } from "malloy/src/model/malloy_types";
+import { ModelDef, StructDef } from "@malloy-lang/malloy";
 import { medicareModel, medicareStateFacts } from "./medicare_model";
 import { fStringEq, fYearEq } from "../test_utils";
 

--- a/packages/malloy-db-test/src/models/medicare_model.ts
+++ b/packages/malloy-db-test/src/models/medicare_model.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { StructDef } from "malloy";
+import { StructDef } from "@malloy-lang/malloy";
 
 /** Medicare Model */
 export const medicareModel: StructDef = {

--- a/packages/malloy-db-test/src/production-models.spec.ts
+++ b/packages/malloy-db-test/src/production-models.spec.ts
@@ -11,12 +11,12 @@
  * GNU General Public License for more details.
  */
 
-import "malloy/src/lang/jestery";
+import "@malloy-lang/malloy/src/lang/jestery";
 import fs from "fs";
 import path from "path";
-import { Malloy } from "malloy/src/malloy";
-import { MalloyTranslator, TranslateResponse } from "malloy";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { Malloy } from "@malloy-lang/malloy/src/malloy";
+import { MalloyTranslator, TranslateResponse } from "@malloy-lang/malloy";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-db-test/src/test_utils.ts
+++ b/packages/malloy-db-test/src/test_utils.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, Fragment } from "malloy";
+import { FilterExpression, Fragment } from "@malloy-lang/malloy";
 
 export function fStringEq(field: string, value: string): FilterExpression {
   return {

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloy-render",
+  "name": "@malloy-lang/malloy-render",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -11,6 +11,6 @@
     "build": "yarn tsc --build"
   },
   "dependencies": {
-    "malloy": "*"
+    "@malloy-lang/malloy": "*"
   }
 }

--- a/packages/malloy-render/src/data_table.ts
+++ b/packages/malloy-render/src/data_table.ts
@@ -17,7 +17,7 @@ import {
   QueryScalar,
   FieldDef,
   FilterExpression,
-} from "malloy";
+} from "@malloy-lang/malloy";
 
 export type DataValue = QueryScalar | DataTree;
 

--- a/packages/malloy-render/src/drill.ts
+++ b/packages/malloy-render/src/drill.ts
@@ -20,7 +20,7 @@ import {
   isValueDate,
   TimeTimeframe,
   isFieldTimeBased,
-} from "malloy";
+} from "@malloy-lang/malloy";
 import { DataPointer, DataTree, DataTreeRoot, isDataTree } from "./data_table";
 
 type FilterItem = { key: string; value: string | undefined };

--- a/packages/malloy-render/src/html/bar_chart.ts
+++ b/packages/malloy-render/src/html/bar_chart.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, isMeasureLike } from "malloy";
+import { FieldDef, isMeasureLike } from "@malloy-lang/malloy";
 import {
   BarChartRenderOptions,
   ChartSize,

--- a/packages/malloy-render/src/html/cartesian_chart.ts
+++ b/packages/malloy-render/src/html/cartesian_chart.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { QueryData, StructDef } from "malloy";
+import { QueryData, StructDef } from "@malloy-lang/malloy";
 import * as lite from "vega-lite";
 import { HtmlChartRenderer } from "./chart";
 import { getColorScale } from "./utils";

--- a/packages/malloy-render/src/html/chart.ts
+++ b/packages/malloy-render/src/html/chart.ts
@@ -19,7 +19,7 @@ import {
   QueryDataRow,
   QueryValue,
   StructDef,
-} from "malloy";
+} from "@malloy-lang/malloy";
 import { Renderer } from "../renderer";
 import { DataPointer, DataValue, isDataTree } from "../data_table";
 import { StyleDefaults } from "../data_styles";

--- a/packages/malloy-render/src/html/container.ts
+++ b/packages/malloy-render/src/html/container.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, StructDef } from "malloy";
+import { FieldDef, StructDef } from "@malloy-lang/malloy";
 import { DataStyles, StyleDefaults } from "../data_styles";
 import { ChildRenderers, RenderTree } from "../renderer";
 import { makeRenderer } from "./html_view";

--- a/packages/malloy-render/src/html/dashboard.ts
+++ b/packages/malloy-render/src/html/dashboard.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { isDimensional, isMeasureLike } from "malloy";
+import { isDimensional, isMeasureLike } from "@malloy-lang/malloy";
 import { StyleDefaults } from "../data_styles";
 import { DataPointer, DataValue, isDataTree } from "../data_table";
 import { ContainerRenderer } from "./container";

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, StructDef } from "malloy";
+import { FieldDef, StructDef } from "@malloy-lang/malloy";
 import { TopLevelSpec } from "vega-lite";
 import { DataStyles, StyleDefaults } from "../data_styles";
 import { Renderer } from "../renderer";

--- a/packages/malloy-render/src/html/line_chart.ts
+++ b/packages/malloy-render/src/html/line_chart.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, QueryValue } from "malloy";
+import { FieldDef, QueryValue } from "@malloy-lang/malloy";
 import { HtmlCartesianChartRenderer } from "./cartesian_chart";
 
 export class HtmlLineChartRenderer extends HtmlCartesianChartRenderer {

--- a/packages/malloy-render/src/html/list.ts
+++ b/packages/malloy-render/src/html/list.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, StructDef } from "malloy";
+import { FieldDef, StructDef } from "@malloy-lang/malloy";
 import { StyleDefaults } from "../data_styles";
 import { DataPointer, DataValue, isDataTree } from "../data_table";
 import { ContainerRenderer } from "./container";

--- a/packages/malloy-render/src/html/list_detail.ts
+++ b/packages/malloy-render/src/html/list_detail.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, StructDef } from "malloy";
+import { FieldDef, StructDef } from "@malloy-lang/malloy";
 import { HtmlListRenderer } from "./list";
 
 export class HtmlListDetailRenderer extends HtmlListRenderer {

--- a/packages/malloy-render/src/html/point_map.ts
+++ b/packages/malloy-render/src/html/point_map.ts
@@ -12,7 +12,12 @@
  */
 
 import * as lite from "vega-lite";
-import { FieldDef, QueryData, QueryValue, StructDef } from "malloy";
+import {
+  FieldDef,
+  QueryData,
+  QueryValue,
+  StructDef,
+} from "@malloy-lang/malloy";
 import usAtlas from "us-atlas/states-10m.json";
 import { HtmlChartRenderer } from "./chart";
 import { getColorScale } from "./utils";

--- a/packages/malloy-render/src/html/scatter_chart.ts
+++ b/packages/malloy-render/src/html/scatter_chart.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, QueryValue } from "malloy";
+import { FieldDef, QueryValue } from "@malloy-lang/malloy";
 import { HtmlCartesianChartRenderer } from "./cartesian_chart";
 
 export class HtmlScatterChartRenderer extends HtmlCartesianChartRenderer {

--- a/packages/malloy-render/src/html/segment_map.ts
+++ b/packages/malloy-render/src/html/segment_map.ts
@@ -12,7 +12,12 @@
  */
 
 import * as lite from "vega-lite";
-import { FieldDef, QueryData, QueryValue, StructDef } from "malloy";
+import {
+  FieldDef,
+  QueryData,
+  QueryValue,
+  StructDef,
+} from "@malloy-lang/malloy";
 import usAtlas from "us-atlas/states-10m.json";
 import { HtmlChartRenderer } from "./chart";
 import { getColorScale } from "./utils";

--- a/packages/malloy-render/src/html/shape_map.ts
+++ b/packages/malloy-render/src/html/shape_map.ts
@@ -12,7 +12,12 @@
  */
 
 import * as lite from "vega-lite";
-import { FieldDef, QueryData, QueryValue, StructDef } from "malloy";
+import {
+  FieldDef,
+  QueryData,
+  QueryValue,
+  StructDef,
+} from "@malloy-lang/malloy";
 import usAtlas from "us-atlas/states-10m.json";
 import { HtmlChartRenderer } from "./chart";
 import { STATE_CODES } from "./state_codes";

--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { TimeTimeframe } from "malloy";
+import { TimeTimeframe } from "@malloy-lang/malloy";
 
 function numberFixedDigits(value: number, digits: number) {
   return value.toString().padStart(digits, "0");

--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -12,7 +12,12 @@
  */
 
 import * as lite from "vega-lite";
-import { FieldDef, QueryDataRow, QueryValue, StructDef } from "malloy";
+import {
+  FieldDef,
+  QueryDataRow,
+  QueryValue,
+  StructDef,
+} from "@malloy-lang/malloy";
 import { HtmlChartRenderer } from "./chart";
 import { cloneDeep } from "lodash";
 import { getColorScale } from "./utils";

--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "malloy-vscode",
-  "publisher": "malloy",
+  "publisher": "malloy-lang",
   "displayName": "Malloy",
   "description": "",
   "version": "0.0.1",
@@ -123,10 +123,10 @@
   },
   "dependencies": {
     "@observablehq/plot": "^0.1.0",
-    "malloy": "*",
-    "malloy-db-bigquery": "*",
-    "malloy-db-postgres": "*",
-    "malloy-render": "*",
+    "@malloy-lang/malloy": "*",
+    "@malloy-lang/malloy-db-bigquery": "*",
+    "@malloy-lang/malloy-db-postgres": "*",
+    "@malloy-lang/malloy-render": "*",
     "us-atlas": "^3.0.0",
     "vega": "5.17.3",
     "vega-lite": "4.17.0",

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -14,8 +14,8 @@
 import * as path from "path";
 import { performance } from "perf_hooks";
 import * as vscode from "vscode";
-import { Malloy, MalloyTranslator, ModelDef } from "malloy";
-import { DataStyles, HtmlView, DataTreeRoot } from "malloy-render";
+import { Malloy, MalloyTranslator, ModelDef } from "@malloy-lang/malloy";
+import { DataStyles, HtmlView, DataTreeRoot } from "@malloy-lang/malloy-render";
 import { loadingIndicator, renderErrorHtml, wrapHTMLSnippet } from "../html";
 import { MALLOY_EXTENSION_STATE, RunState } from "../state";
 import turtleIcon from "../../media/turtle.svg";

--- a/packages/malloy-vscode/src/extension/extension.ts
+++ b/packages/malloy-vscode/src/extension/extension.ts
@@ -31,9 +31,9 @@ import {
   runQueryWithEdit,
   showLicensesCommand,
 } from "./commands";
-import { Malloy } from "malloy";
+import { Malloy } from "@malloy-lang/malloy";
 import { showResultJsonCommand } from "./commands/show_result_json";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("vsCode");
 

--- a/packages/malloy-vscode/src/extension/state.ts
+++ b/packages/malloy-vscode/src/extension/state.ts
@@ -12,7 +12,7 @@
  */
 
 import { TextDocument, WebviewPanel } from "vscode";
-import { QueryResult } from "malloy";
+import { QueryResult } from "@malloy-lang/malloy";
 
 export interface RunState {
   cancel: () => void;

--- a/packages/malloy-vscode/src/extension/tree_views/schema_view.ts
+++ b/packages/malloy-vscode/src/extension/tree_views/schema_view.ts
@@ -13,7 +13,12 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { Malloy, FieldDef, MalloyTranslator, NamedMalloyObject } from "malloy";
+import {
+  Malloy,
+  FieldDef,
+  MalloyTranslator,
+  NamedMalloyObject,
+} from "@malloy-lang/malloy";
 import numberIcon from "../../media/number.svg";
 import numberAggregateIcon from "../../media/number-aggregate.svg";
 import booleanIcon from "../../media/boolean.svg";

--- a/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
+++ b/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
@@ -16,10 +16,10 @@ import {
   DiagnosticSeverity,
   TextDocuments,
 } from "vscode-languageserver/node";
-import { Malloy, MalloyTranslator, LogMessage } from "malloy";
+import { Malloy, MalloyTranslator, LogMessage } from "@malloy-lang/malloy";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as fs from "fs";
-import { BigQueryConnection } from "malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
 
 Malloy.db = new BigQueryConnection("vsCode");
 

--- a/packages/malloy-vscode/src/server/highlights/highlights.ts
+++ b/packages/malloy-vscode/src/server/highlights/highlights.ts
@@ -12,7 +12,7 @@
  */
 
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { HighlightType, MalloyTranslator } from "malloy";
+import { HighlightType, MalloyTranslator } from "@malloy-lang/malloy";
 import {
   SemanticTokens,
   SemanticTokensBuilder,

--- a/packages/malloy-vscode/src/server/lenses/lenses.ts
+++ b/packages/malloy-vscode/src/server/lenses/lenses.ts
@@ -12,7 +12,7 @@
  */
 
 import { CodeLens } from "vscode-languageserver/node";
-import { MalloyTranslator } from "malloy";
+import { MalloyTranslator } from "@malloy-lang/malloy";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 const explain = `

--- a/packages/malloy-vscode/src/server/symbols/symbols.ts
+++ b/packages/malloy-vscode/src/server/symbols/symbols.ts
@@ -15,7 +15,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   DocumentSymbol as MalloyDocumentSymbol,
   MalloyTranslator,
-} from "malloy";
+} from "@malloy-lang/malloy";
 import { DocumentSymbol, SymbolKind } from "vscode-languageserver/node";
 
 function mapSymbol(symbol: MalloyDocumentSymbol): DocumentSymbol {

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "malloy",
+  "name": "@malloy-lang/malloy",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { indent } from "malloy/src/model/utils";
+import { indent } from "../model/utils";
 import { Dialect, DialectFieldList } from "./dialect";
 
 export class StandardSQLDialect extends Dialect {


### PR DESCRIPTION
There is a concern that perhaps someone would think we have published npm packages (we have not) and if some nefarious actor grabs a package on npm with a name we're using, some other developer might intend to install a malloy package and accidentally install the bad package.

This change resolves that concern by scoping the packages to `@malloy-lang/{package-name}` - an organization name in npm that we own - with the exception of the VScode extension. VSCode extensions have chosen (possibly poorly?) to utilize `package.json` as the manifest file for an extension - but they do not support all possible values for the `name` property and as such [do not support scoped names](https://github.com/microsoft/vscode-vsce/issues/186).

While it is not intended to be installed via npm, we have reserved the `malloy-vscode` name on npm by [publishing the vs-code package to it](https://www.npmjs.com/package/malloy-vscode).

