### PR TITLE
shorten package names for simpler imports

### DIFF
--- a/docs/_scripts/build_docs/index.ts
+++ b/docs/_scripts/build_docs/index.ts
@@ -14,7 +14,7 @@
 import path from "path";
 import fs from "fs";
 import { Malloy } from "@malloy-lang/malloy";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 import { performance } from "perf_hooks";
 import { renderDoc } from "./render_document";
 import { renderFooter, renderSidebar, Section } from "./page";

--- a/docs/_scripts/build_docs/render_document.ts
+++ b/docs/_scripts/build_docs/render_document.ts
@@ -22,7 +22,7 @@ import "prismjs/components/prism-sql";
 import { runCode } from "./run_code";
 import { log } from "./log";
 import { Malloy } from "@malloy-lang/malloy";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("docs");
 

--- a/docs/_scripts/build_docs/run_code.ts
+++ b/docs/_scripts/build_docs/run_code.ts
@@ -17,7 +17,7 @@
  * that depend on that model. If `--watch` is enabled, changes to a model file
  * will cause relevant documents to recompile.
  */
-import { DataStyles, DataTreeRoot, HtmlView } from "@malloy-lang/malloy-render";
+import { DataStyles, DataTreeRoot, HtmlView } from "@malloy-lang/render";
 import { Malloy, MalloyTranslator } from "@malloy-lang/malloy";
 import path from "path";
 import fs from "fs";

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "version": "0.0.1",
   "license": "GPL-2.0",
-  "name": "@malloy-lang/malloy",
+  "name": "malloy",
   "workspaces": {
     "packages": [
       "packages/*"
@@ -46,8 +46,8 @@
     "jest-diff": "^27.0.6",
     "jest-expect-message": "^1.0.2",
     "@malloy-lang/malloy": "*",
-    "@malloy-lang/malloy-db-bigquery": "*",
-    "@malloy-lang/malloy-render": "*",
+    "@malloy-lang/db-bigquery": "*",
+    "@malloy-lang/render": "*",
     "md5": "^2.3.0",
     "prettier": "^2.3.2",
     "prismjs": "^1.24.1",

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@malloy-lang/malloy-db-bigquery",
+  "name": "@malloy-lang/db-bigquery",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@malloy-lang/malloy-db-postgres",
+  "name": "@malloy-lang/db-postgres",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint '**/*.ts{,x}'",
     "lint-fix": "eslint '**/*.ts{,x}' --fix",
-    "test": "echo 'no tests for 'malloy-db-postgres' yet'",
+    "test": "echo 'no tests for 'db-postgres' yet'",
     "build": "yarn tsc --build"
   },
   "dependencies": {

--- a/packages/malloy-db-test/package.json
+++ b/packages/malloy-db-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@malloy-lang/malloy-db-test",
+  "name": "@malloy-lang/db-test",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "@malloy-lang/malloy": "*",
-    "@malloy-lang/malloy-db-bigquery": "*"
+    "@malloy-lang/db-bigquery": "*"
   }
 }

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -19,7 +19,7 @@ import {
   QueryResult,
   StructDef,
 } from "@malloy-lang/malloy";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 import { fStringEq, fStringLike } from "./test_utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/malloy-db-test/src/join.spec.ts
+++ b/packages/malloy-db-test/src/join.spec.ts
@@ -13,7 +13,7 @@
 /* eslint-disable no-console */
 
 import { Malloy, QueryModel } from "@malloy-lang/malloy";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-db-test/src/malloy_query.spec.ts
+++ b/packages/malloy-db-test/src/malloy_query.spec.ts
@@ -19,7 +19,7 @@ import { fStringEq } from "./test_utils";
 import "@malloy-lang/malloy/src/lang/jestery";
 import { TestTranslator } from "@malloy-lang/malloy/src/lang/jest-factories";
 import { FLIGHTS_EXPLORE } from "./models/faa_model";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-db-test/src/production-models.spec.ts
+++ b/packages/malloy-db-test/src/production-models.spec.ts
@@ -16,7 +16,7 @@ import fs from "fs";
 import path from "path";
 import { Malloy } from "@malloy-lang/malloy/src/malloy";
 import { MalloyTranslator, TranslateResponse } from "@malloy-lang/malloy";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("test");
 

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@malloy-lang/malloy-render",
+  "name": "@malloy-lang/render",
   "version": "0.0.1",
   "license": "GPL-2.0",
   "main": "dist/index.js",

--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -124,9 +124,9 @@
   "dependencies": {
     "@observablehq/plot": "^0.1.0",
     "@malloy-lang/malloy": "*",
-    "@malloy-lang/malloy-db-bigquery": "*",
-    "@malloy-lang/malloy-db-postgres": "*",
-    "@malloy-lang/malloy-render": "*",
+    "@malloy-lang/db-bigquery": "*",
+    "@malloy-lang/db-postgres": "*",
+    "@malloy-lang/render": "*",
     "us-atlas": "^3.0.0",
     "vega": "5.17.3",
     "vega-lite": "4.17.0",

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -15,7 +15,7 @@ import * as path from "path";
 import { performance } from "perf_hooks";
 import * as vscode from "vscode";
 import { Malloy, MalloyTranslator, ModelDef } from "@malloy-lang/malloy";
-import { DataStyles, HtmlView, DataTreeRoot } from "@malloy-lang/malloy-render";
+import { DataStyles, HtmlView, DataTreeRoot } from "@malloy-lang/render";
 import { loadingIndicator, renderErrorHtml, wrapHTMLSnippet } from "../html";
 import { MALLOY_EXTENSION_STATE, RunState } from "../state";
 import turtleIcon from "../../media/turtle.svg";

--- a/packages/malloy-vscode/src/extension/extension.ts
+++ b/packages/malloy-vscode/src/extension/extension.ts
@@ -33,7 +33,7 @@ import {
 } from "./commands";
 import { Malloy } from "@malloy-lang/malloy";
 import { showResultJsonCommand } from "./commands/show_result_json";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("vsCode");
 

--- a/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
+++ b/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
@@ -19,7 +19,7 @@ import {
 import { Malloy, MalloyTranslator, LogMessage } from "@malloy-lang/malloy";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as fs from "fs";
-import { BigQueryConnection } from "@malloy-lang/malloy-db-bigquery";
+import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 
 Malloy.db = new BigQueryConnection("vsCode");
 

--- a/scripts/third_party_licenses.ts
+++ b/scripts/third_party_licenses.ts
@@ -42,7 +42,14 @@ if (fs.existsSync(outputFile)) throw new Error("Output file exists already");
 axios.defaults.timeout = 500000;
 axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });
 
-const malloyPackages = ["malloy", "malloy-render", "malloy-vscode"];
+const malloyPackages = [
+  "@malloy-lang/malloy",
+  "@malloy-lang/render",
+  "malloy-vscode",
+  "@malloy-lang/db-test",
+  "@malloy-lang/db-bigquery",
+  "@malloy-lang/db-postgres",
+];
 
 // licenses that we would need to mirror source for, if we included (we don't today)
 const sourceMirrorLicenses = [


### PR DESCRIPTION
Remove "malloy-" from packages, as it's implied with the organizational scope `@malloy-lang/`. This should make it simpler to import. Following [babel](https://github.com/babel/babel/tree/main/packages) conventions (package folder is `babel-x`, package name is `@babel/x`.