### PR TITLE
Cloudbuild and Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ gcloud config set project my_project_id --installation
 
 _Replace `my_project_id` with the name of the bigquery project you want to use & bill to. If you're not sure what this ID is, open Cloud Console, and click on the dropdown at the top to view projects you have access to. If you don't already have a project, [create one](https://cloud.google.com/resource-manager/docs/creating-managing-projects)._
 
-You will need to have [node.js](https://nodejs.org/en/download/), [yarn](https://classic.yarnpkg.com/en/docs/install/), and a [Java Runtime Environment](https://www.oracle.com/java/technologies/javase-jre8-downloads.html) (JRE 1.6 or higher, 1.8 recommended) installed on your system in order to build the Malloy project.
+You will need to have [node.js](https://nodejs.org/en/download/), [yarn](https://classic.yarnpkg.com/en/docs/install/), and a [Java Runtime Environment](https://www.oracle.com/java/technologies/javase-jre8-downloads.html) (JRE 1.6 or higher, 1.8 recommended) installed on your system in order to build the Malloy projecti.
+
+Alternatively, you can use [nix](https://nixos.org/) to install these dependencies. To use nix, install it with `curl -L https://nixos.org/nix/install | sh` and then run `nix-shell` from the `malloy/` directory. Nix is what _CI_ uses to run builds.
 
 The following will install dependencies for the entire set of packages and compile both the Malloy language and the VSCode extension.
 

--- a/cloudbuild/README.md
+++ b/cloudbuild/README.md
@@ -1,0 +1,51 @@
+# Cloudbuild CI
+
+## What is Cloudbuild?
+
+Cloudbuild is a GCP solution for running tests and other continuous integration tasks in the cloud
+
+## Our Testing Architecture
+
+There are several technologies to be aware of:
+* **cloudbuild**: infrastructure to run tests; automatically provisions machines, communicates with GitHub (i.e. updates PRs with status), and furnishes UX for viewing test results
+* **docker**: cloudbuild runs test scripts inside a _docker image_
+* **nix**: a technology that provides furnishes an environment with binaries; it can be thought of like `apt-get`, but allows for isolated "virtual" environments that set `$PATH` to binaries managed by nix
+
+The way that we run tests:
+* we have a `cloudbuild.yaml` file that specifies the build -- see `cloudbuild/build-test/cloudbuild.yaml`
+* the build runs the `nixos/nix` docker image -- this ensures that `nix` is installed
+* we run the file `cloudbuild/build-test/build-test.sh` -- this _enters_ into a nix environment and runs `yarn build`, etc. 
+
+### Our Testing Architecture: Cloudbuild
+
+#### Our Testing Architecture: Cloudbuild: Adding Checks
+
+Navigate to the Google Cloud console, go to the triggers section. If you are a maintainer, you will have access to this infrastructure.
+
+### Our Testing Architecture: Nix: Adding dependencies in nix
+
+### Our Testing Architecture: Nix: Adding dependencies
+
+Here, a dependency means something like yarn or bash or node.
+
+If you need to add a dependency, see `default.nix`. `buildInputs = [ ... ]` is a list of dependencies. One can search for the names of available dependencies at [https://search.nixos.org/packages](https://search.nixos.org/packages).
+
+## Our Testing Architecture: Future Directions
+
+## Our Testing Architecture: Future Directions: Custom Docker Image
+
+You will notice that when a build runs, nix dependencies are installed.
+
+These both take a meaningful amount of time. We can reduce the amount of time this takes by creating a docker image based on `nixos/nix`, which pre-installs nix dependencies. 
+
+## Our Testing Architecture: Future Directions: Pinning Nix Dependencies
+
+We can pin nix dependencies; `.envrc with NIX_PATH set to a stable channel URL` (via nix-users Google-internal gChat channel).
+
+## Debugging test failures on CI
+
+One can install nix locally for themselves by using the instructions at [https://nixos.org/download.html](https://nixos.org/download.html). Note that this script is not well supported on MacOS (your mileage may vary) and on systems with one root user. In most Linux setups, it will just work. 
+
+Once nix is installed, `cd` into the `malloy` repo, run `nix-shell --pure` and then run your commands (e.g. `yarn test`).
+
+This will ensure a similar environment to CI.

--- a/cloudbuild/build-test/build-test.sh
+++ b/cloudbuild/build-test/build-test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -euxo pipefail
+
+nix-shell --pure --command "$(cat <<NIXCMD
+  yarn install
+  yarn build
+  yarn test
+NIXCMD
+)"

--- a/cloudbuild/build-test/cloudbuild.yaml
+++ b/cloudbuild/build-test/cloudbuild.yaml
@@ -1,0 +1,4 @@
+steps:
+  - name: 'nixos/nix'
+    args: ['sh', './cloudbuild/build-test/build-test.sh']
+

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+with import <nixpkgs> {}; stdenv.mkDerivation { name = "malloy"; buildInputs = [ nodejs-16_x yarn jdk8 google-cloud-sdk ]; }


### PR DESCRIPTION
cloudbuild: infra for running tests, config checked in
nix: environment for furnishing required binaries for ci build (e.g. jvm, node, yarn, etc.)

--

Flow:
* cloudbuild trigger picks up PR
* docker image with nix is started
* `build_run.sh` script is run
* `yarn install`, etc. is run in nix (specifically in `nix-shell`) context
* build status is reported back to PRs

--

For contributors, CI will automatically run. For non-contributor submitted PRs, contributors must comment `/gcbrun` to kick off the build. Once we decide we like cloudbuild, we'll change an admin setting to block mering of PRs unless cloudbuild passes.

--

Future directions:
* support for postgresql tests
* migrate to a different GCP project
* building a docker image based on `nixos/nix` which has packages pre-downloaded for performance