### PR TITLE
`Malloy.parse`, `.run`, and `.compile` instead of `Runner` and `Compiler`

### DIFF
--- a/packages/malloy-db-test/src/handexpr.spec.ts
+++ b/packages/malloy-db-test/src/handexpr.spec.ts
@@ -30,7 +30,7 @@ async function validateCompilation(
       throw new Error(`Unknown database ${databaseName}`);
     }
     await (
-      await runtime.getRunner().getSQLRunner(databaseName)
+      await runtime.getLookupSQLRunner().lookupSQLRunner(databaseName)
     ).runSQL(`WITH test AS(\n${sql}) SELECT 1`);
   } catch (e) {
     console.log(`SQL: didn't compile\n=============\n${sql}`);

--- a/packages/malloy-db-test/src/orderby.spec.ts
+++ b/packages/malloy-db-test/src/orderby.spec.ts
@@ -27,7 +27,7 @@ async function validateCompilation(
       throw new Error(`Unknown database ${databaseName}`);
     }
     await (
-      await runtime.getRunner().getSQLRunner(databaseName)
+      await runtime.getLookupSQLRunner().lookupSQLRunner(databaseName)
     ).runSQL(`WITH test AS(\n${sql}) SELECT 1`);
   } catch (e) {
     console.log(`SQL: didn't compile\n=============\n${sql}`);

--- a/packages/malloy-vscode/src/server/highlights/highlights.ts
+++ b/packages/malloy-vscode/src/server/highlights/highlights.ts
@@ -44,7 +44,7 @@ export function getMalloyHighlights(document: TextDocument): SemanticTokens {
 
   const text = document.getText();
   const textLines = text.split("\n");
-  const parse = Malloy.parse(text);
+  const parse = Malloy.parse({ source: text });
 
   const highlights = parse.getHighlights();
 

--- a/packages/malloy-vscode/src/server/highlights/highlights.ts
+++ b/packages/malloy-vscode/src/server/highlights/highlights.ts
@@ -12,7 +12,7 @@
  */
 
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { HighlightType, MalloyTranslator } from "@malloy-lang/malloy";
+import { HighlightType, Malloy } from "@malloy-lang/malloy";
 import {
   SemanticTokens,
   SemanticTokensBuilder,
@@ -42,36 +42,35 @@ export const TOKEN_MODIFIERS = ["declaration", "documentation"];
 export function getMalloyHighlights(document: TextDocument): SemanticTokens {
   const tokensBuilder = new SemanticTokensBuilder();
 
-  const uri = document.uri.toString();
   const text = document.getText();
   const textLines = text.split("\n");
-  const translator = new MalloyTranslator(uri, {
-    urls: {
-      [uri]: text,
-    },
-  });
+  const parse = Malloy.parse(text);
 
-  const metadata = translator.metadata();
-  const highlights = metadata.highlights || [];
+  const highlights = parse.getHighlights();
 
   highlights.forEach((highlight) => {
     for (
-      let line = highlight.range.start.line;
-      line <= highlight.range.end.line;
+      let line = highlight.getRange().getStart().getLine();
+      line <= highlight.getRange().getEnd().getLine();
       line++
     ) {
       const lineText = textLines[line];
       let length;
       let start;
-      if (highlight.range.start.line === highlight.range.end.line) {
+      if (
+        highlight.getRange().getStart().getLine() ===
+        highlight.getRange().getEnd().getLine()
+      ) {
         length =
-          highlight.range.end.character - highlight.range.start.character;
-        start = highlight.range.start.character;
-      } else if (line === highlight.range.start.line) {
-        length = lineText.length - highlight.range.start.character;
-        start = highlight.range.start.character;
-      } else if (line === highlight.range.end.line) {
-        length = highlight.range.end.character;
+          highlight.getRange().getEnd().getCharacter() -
+          highlight.getRange().getStart().getCharacter();
+        start = highlight.getRange().getStart().getCharacter();
+      } else if (line === highlight.getRange().getStart().getLine()) {
+        length =
+          lineText.length - highlight.getRange().getStart().getCharacter();
+        start = highlight.getRange().getStart().getCharacter();
+      } else if (line === highlight.getRange().getEnd().getLine()) {
+        length = highlight.getRange().getEnd().getCharacter();
         start = 0;
       } else {
         length = lineText.length;
@@ -81,7 +80,7 @@ export function getMalloyHighlights(document: TextDocument): SemanticTokens {
         line,
         start,
         length,
-        TOKEN_TYPES.indexOf(mapTypes(highlight.type)),
+        TOKEN_TYPES.indexOf(mapTypes(highlight.getType())),
         0
       );
     }

--- a/packages/malloy-vscode/src/server/lenses/lenses.ts
+++ b/packages/malloy-vscode/src/server/lenses/lenses.ts
@@ -37,7 +37,7 @@ const explain = `
 
 export function getMalloyLenses(document: TextDocument): CodeLens[] {
   const lenses: CodeLens[] = [];
-  const symbols = Malloy.parse(document.getText()).getSymbols();
+  const symbols = Malloy.parse({ source: document.getText() }).getSymbols();
 
   let currentUnnamedQueryIndex = 0;
   symbols.forEach((symbol) => {

--- a/packages/malloy-vscode/src/server/lenses/lenses.ts
+++ b/packages/malloy-vscode/src/server/lenses/lenses.ts
@@ -12,7 +12,7 @@
  */
 
 import { CodeLens } from "vscode-languageserver/node";
-import { MalloyTranslator } from "@malloy-lang/malloy";
+import { Malloy } from "@malloy-lang/malloy";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 const explain = `
@@ -37,31 +37,22 @@ const explain = `
 
 export function getMalloyLenses(document: TextDocument): CodeLens[] {
   const lenses: CodeLens[] = [];
-
-  const uri = document.uri.toString();
-  const translator = new MalloyTranslator(uri, {
-    urls: {
-      [uri]: document.getText(),
-    },
-  });
-
-  const metadata = translator.metadata();
-  const symbols = metadata.symbols || [];
+  const symbols = Malloy.parse(document.getText()).getSymbols();
 
   let currentUnnamedQueryIndex = 0;
   symbols.forEach((symbol) => {
-    if (symbol.type === "query") {
+    if (symbol.getType() === "query") {
       lenses.push({
-        range: symbol.range,
+        range: symbol.getRange().toJSON(),
         command: {
           title: "Run",
           command: "malloy.runNamedQuery",
-          arguments: [symbol.name],
+          arguments: [symbol.getName()],
         },
       });
-    } else if (symbol.type === "unnamed_query") {
+    } else if (symbol.getType() === "unnamed_query") {
       lenses.push({
-        range: symbol.range,
+        range: symbol.getRange().toJSON(),
         command: {
           title: "Run",
           command: "malloy.runQueryFile",
@@ -69,11 +60,11 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         },
       });
       currentUnnamedQueryIndex++;
-    } else if (symbol.type === "explore") {
-      const children = symbol.children;
-      const exploreName = symbol.name;
+    } else if (symbol.getType() === "explore") {
+      const children = symbol.getChildren();
+      const exploreName = symbol.getName();
       lenses.push({
-        range: symbol.range,
+        range: symbol.getRange().toJSON(),
         command: {
           title: "Query",
           command: "malloy.runQueryWithEdit",
@@ -81,7 +72,7 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         },
       });
       lenses.push({
-        range: symbol.range,
+        range: symbol.getRange().toJSON(),
         command: {
           title: "Preview",
           command: "malloy.runQuery",
@@ -92,7 +83,7 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         },
       });
       lenses.push({
-        range: symbol.range,
+        range: symbol.getRange().toJSON(),
         command: {
           title: "Explain",
           command: "malloy.runQuery",
@@ -103,10 +94,10 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         },
       });
       children.forEach((child) => {
-        if (child.type === "turtle") {
-          const turtleName = child.name;
+        if (child.getType() === "turtle") {
+          const turtleName = child.getName();
           lenses.push({
-            range: child.range,
+            range: child.getRange().toJSON(),
             command: {
               title: "Run",
               command: "malloy.runQuery",
@@ -117,7 +108,7 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
             },
           });
           lenses.push({
-            range: child.range,
+            range: child.getRange().toJSON(),
             command: {
               title: "Edit and Run",
               command: "malloy.runQueryWithEdit",

--- a/packages/malloy-vscode/src/server/symbols/symbols.ts
+++ b/packages/malloy-vscode/src/server/symbols/symbols.ts
@@ -14,36 +14,29 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   DocumentSymbol as MalloyDocumentSymbol,
-  MalloyTranslator,
+  Malloy,
 } from "@malloy-lang/malloy";
 import { DocumentSymbol, SymbolKind } from "vscode-languageserver/node";
 
 function mapSymbol(symbol: MalloyDocumentSymbol): DocumentSymbol {
+  const type = symbol.getType();
   return {
-    name: symbol.name,
-    range: symbol.range,
-    detail: symbol.type,
+    name: symbol.getName(),
+    range: symbol.getRange().toJSON(),
+    detail: symbol.getType(),
     kind:
-      symbol.type === "explore"
+      type === "explore"
         ? SymbolKind.Namespace
-        : symbol.type === "turtle"
+        : type === "turtle"
         ? SymbolKind.Class
-        : symbol.type === "join"
+        : type === "join"
         ? SymbolKind.Interface
         : SymbolKind.Field,
-    selectionRange: symbol.range,
-    children: symbol.children.map(mapSymbol),
+    selectionRange: symbol.getRange().toJSON(),
+    children: symbol.getChildren().map(mapSymbol),
   };
 }
 
 export function getMalloySymbols(document: TextDocument): DocumentSymbol[] {
-  const uri = document.uri.toString();
-  const translator = new MalloyTranslator(uri, {
-    urls: {
-      [uri]: document.getText(),
-    },
-  });
-
-  const metadata = translator.metadata();
-  return metadata.symbols?.map(mapSymbol) || [];
+  return Malloy.parse(document.getText()).getSymbols().map(mapSymbol);
 }

--- a/packages/malloy-vscode/src/server/symbols/symbols.ts
+++ b/packages/malloy-vscode/src/server/symbols/symbols.ts
@@ -38,5 +38,7 @@ function mapSymbol(symbol: MalloyDocumentSymbol): DocumentSymbol {
 }
 
 export function getMalloySymbols(document: TextDocument): DocumentSymbol[] {
-  return Malloy.parse(document.getText()).getSymbols().map(mapSymbol);
+  return Malloy.parse({ source: document.getText() })
+    .getSymbols()
+    .map(mapSymbol);
 }

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -16,7 +16,6 @@ export * from "./model";
 export * from "./lang";
 export {
   Malloy,
-  Runner,
   Runtime,
   EmptyURLReader,
   InMemoryURLReader,
@@ -37,6 +36,8 @@ export type {
   Result,
   DataArray,
   ModelMaterializer,
+  DocumentSymbol,
+  DocumentHighlight,
 } from "./malloy";
 export type {
   URLReader,

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -13,6 +13,9 @@
 
 import { MalloyQueryData, StructDef } from "./model";
 
+/**
+ * A URL.
+ */
 export class URL {
   private _url: string;
 
@@ -20,38 +23,104 @@ export class URL {
     this._url = stringURL;
   }
 
+  /**
+   * @returns The string form of this URL.
+   */
   public toString(): string {
     return this._url;
   }
 
+  /**
+   * Construct a URL from string.
+   *
+   * @param stringURL The string form of the URL.
+   * @returns A URL.
+   */
   public static fromString(stringURL: string): URL {
     return new URL(stringURL);
   }
 }
 
+/**
+ * The contents of a Malloy query document.
+ */
 export type QueryString = string;
+
+/**
+ * The contents of a Malloy model document.
+ */
 export type ModelString = string;
+
+/**
+ * A URL whose contents is a Malloy model.
+ */
 export type ModelURL = URL;
+
+/**
+ * A URL whose contents is a Malloy query.
+ */
 export type QueryURL = URL;
 
+/**
+ * An object capable of reading the contents of a URL in some context.
+ */
 export interface URLReader {
+  /**
+   * Read the contents of the given URL.
+   *
+   * @param url The URL to read.
+   * @returns A promise to the contents of the URL.
+   */
   readURL: (url: URL) => Promise<string>;
 }
 
+/**
+ * An object capable of reading schemas for given table names.
+ */
 export interface SchemaReader {
   // TODO should we really be exposing StructDef like this?
   // TODO should this be a Map instead of a Record in the public interface?
+  /**
+   * Fetch schemas for multiple tables.
+   *
+   * @param tables The names of tables to fetch schemas for.
+   * @returns A mapping of table names to schemas.
+   */
   fetchSchemaForTables(tables: string[]): Promise<Record<string, StructDef>>;
 }
 
+/**
+ * A mapping of connection names to `SchemaReader`s.
+ */
 export interface LookupSchemaReader {
+  /**
+   * @param connectionName The name of the connection for which a `SchemaReader` is required.
+   * @returns A promise to a `SchemaReader` for the connection named `connectionName`.
+   */
   lookupSchemaReader(connectionName?: string): Promise<SchemaReader>;
 }
 
+/**
+ * An object capable of running SQL.
+ */
 export interface SQLRunner {
+  /**
+   * Run some SQL and yield results.
+   *
+   * @param sql The SQL to run.
+   * @returns The rows of data resulting from running the given SQL query
+   * and the total number of rows available.
+   */
   runSQL(sql: string): Promise<MalloyQueryData>;
 }
 
+/**
+ * A mapping of connection names to `SQLRunner`s.
+ */
 export interface LookupSQLRunner {
+  /**
+   * @param connectionName The name of the connection for which a `SQLRunner` is required.
+   * @returns A promise to a `SQLRunner` for the connection named `connectionName`.
+   */
   lookupSQLRunner(connectionName?: string): Promise<SQLRunner>;
 }


### PR DESCRIPTION
This PR removed the `Runner` and `Compiler` classes, as they didn't feel like the right abstraction — all they really did was encapsulate some state (the `urlReader`, `lookupSQLRunner`, and `lookupSchemaReader`), and the `Compiler` did two logical steps, _parse_, and _compile_, because that's how it's implemented under the hood.

We think it makes more sense to think of `parse` and `compile` as two steps. 

The functions `parse`, `compile, and `run` have been added as static methods on the `Malloy` class for now. They may move elsewhere.

The logical flow for running a query using the underlying API is now:

```ts
const parse = Malloy.parse(file.text, file.url);
const queryModel = await Malloy.compile(urlReader, lookupSchemaReader, parse);
const query = queryModel.getPreparedQuery();
const preparedResult = query.getPreparedResult();
const result = await Malloy.run(lookupSqlRunner, preparedResult);
```

This removes the reliance on `MalloyTranslator` from the VSCode extension.

# ALSO PR #100!!! 🎉 🥳 