### PR TITLE
Better implementation

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2683,11 +2683,23 @@ class QueryStruct extends QueryNode {
         `Joined explores can only be included in queries if a primary key is defined: '${this.getFullOutputName()}' has no primary key`
       );
     }
-    const pkDef = {
-      ...this.getPrimaryKeyField(this.fieldDef).fieldDef,
-      as: `${name}_id`,
+    const pkField = this.getPrimaryKeyField(this.fieldDef);
+    const pkType = pkField.fieldDef.type;
+    if (pkType !== "string" && pkType !== "number") {
+      throw new Error(`Unknown Primary key data type for ${name}`);
+    }
+    const fieldDef: FieldDef = {
+      type: pkType,
+      name: `${name}_id`,
+      e: [
+        {
+          type: "field",
+          // path: pkField.getFullOutputName(),
+          path: pkField.getIdentifier(),
+        },
+      ],
     };
-    return new QueryFieldStruct(pkDef, this);
+    return new QueryFieldStruct(fieldDef, this);
   }
 
   // return the name of the field in SQL


### PR DESCRIPTION
Use the primary key as an field expression instead of generating a new intrinic field.  This should be much more reliable.