### PR TITLE
Change the Run buttons to Run | Render

### DIFF
--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -62,6 +62,21 @@ export class HTMLView {
   }
 }
 
+export class JSONView {
+  async render(table: DataArray): Promise<string> {
+    const renderer = new HTMLJSONRenderer();
+    try {
+      return await renderer.render(table);
+    } catch (error) {
+      if (error instanceof Error) {
+        return error.toString();
+      } else {
+        return "Internal error - Exception not an Error object.";
+      }
+    }
+  }
+}
+
 function getRendererOptions(field: Field | Explore, dataStyles: DataStyles) {
   let renderer = dataStyles[field.name];
   if (!renderer) {

--- a/packages/malloy-render/src/index.ts
+++ b/packages/malloy-render/src/index.ts
@@ -11,5 +11,5 @@
  * GNU General Public License for more details.
  */
 
-export { HTMLView } from "./html/html_view";
+export { HTMLView, JSONView } from "./html/html_view";
 export { DataStyles } from "./data_styles";

--- a/packages/malloy-vscode/src/extension/commands/run_named_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_named_query.ts
@@ -13,9 +13,9 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { runMalloyQuery } from "./run_query_utils";
+import { runMalloyQuery, RunRenderStyle } from "./run_query_utils";
 
-export function runNamedQuery(name: string): void {
+export function runNamedQuery(name: string, renderStyle: RunRenderStyle): void {
   const document =
     vscode.window.activeTextEditor?.document ||
     MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
@@ -23,7 +23,8 @@ export function runNamedQuery(name: string): void {
     runMalloyQuery(
       { type: "named", name, file: document },
       `${document.uri.toString()} ${name}`,
-      name
+      name,
+      renderStyle
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query.ts
@@ -13,9 +13,13 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { runMalloyQuery } from "./run_query_utils";
+import { runMalloyQuery, RunRenderStyle } from "./run_query_utils";
 
-export function runQueryCommand(query: string, name?: string): void {
+export function runQueryCommand(
+  query: string,
+  name?: string,
+  renderStyle: RunRenderStyle = "html"
+): void {
   const document =
     vscode.window.activeTextEditor?.document ||
     MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
@@ -23,7 +27,8 @@ export function runQueryCommand(query: string, name?: string): void {
     runMalloyQuery(
       { type: "string", text: query, file: document },
       `${document.uri.toString()} ${name}`,
-      name || document.uri.toString()
+      name || document.uri.toString(),
+      renderStyle
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -15,7 +15,7 @@ import * as path from "path";
 import { performance } from "perf_hooks";
 import * as vscode from "vscode";
 import { URL, Runtime, URLReader } from "@malloy-lang/malloy";
-import { DataStyles, HTMLView } from "@malloy-lang/render";
+import { DataStyles, HTMLView, JSONView } from "@malloy-lang/render";
 import { loadingIndicator, renderErrorHTML, wrapHTMLSnippet } from "../html";
 import { CONNECTION_MAP, MALLOY_EXTENSION_STATE, RunState } from "../state";
 import turtleIcon from "../../media/turtle.svg";
@@ -111,10 +111,13 @@ class HackyDataStylesAccumulator implements URLReader {
   }
 }
 
+export type RunRenderStyle = "html" | "json";
+
 export function runMalloyQuery(
   query: QuerySpec,
   panelId: string,
-  name: string
+  name: string,
+  renderStyle: RunRenderStyle = "html"
 ): void {
   vscode.window.withProgress(
     {
@@ -263,10 +266,16 @@ export function runMalloyQuery(
               const resultExplore = queryResult.resultExplore;
 
               if (resultExplore) {
-                // TODO replace the DataTree with DataArray
-                current.panel.webview.html = wrapHTMLSnippet(
-                  css + (await new HTMLView().render(data, styles))
-                );
+                if (renderStyle === "html") {
+                  // TODO replace the DataTree with DataArray
+                  current.panel.webview.html = wrapHTMLSnippet(
+                    css + (await new HTMLView().render(data, styles))
+                  );
+                } else if (renderStyle === "json") {
+                  current.panel.webview.html = wrapHTMLSnippet(
+                    css + (await new JSONView().render(data))
+                  );
+                }
 
                 const renderEnd = performance.now();
                 logTime("Render", renderBegin, renderEnd);

--- a/packages/malloy-vscode/src/server/lenses/lenses.ts
+++ b/packages/malloy-vscode/src/server/lenses/lenses.ts
@@ -47,7 +47,15 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         command: {
           title: "Run",
           command: "malloy.runNamedQuery",
-          arguments: [symbol.name],
+          arguments: [symbol.name, "json"],
+        },
+      });
+      lenses.push({
+        range: symbol.range.toJSON(),
+        command: {
+          title: "Render",
+          command: "malloy.runNamedQuery",
+          arguments: [symbol.name, "html"],
         },
       });
     } else if (symbol.type === "unnamed_query") {
@@ -104,17 +112,29 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
               arguments: [
                 `explore ${exploreName} | ${turtleName}`,
                 `${exploreName} | ${turtleName}`,
+                "json",
               ],
             },
           });
           lenses.push({
             range: child.range.toJSON(),
             command: {
-              title: "Edit and Run",
-              command: "malloy.runQueryWithEdit",
-              arguments: [exploreName, turtleName],
+              title: "Render",
+              command: "malloy.runQuery",
+              arguments: [
+                `explore ${exploreName} | ${turtleName}`,
+                `${exploreName} | ${turtleName}`,
+              ],
             },
           });
+          // lenses.push({
+          //   range: child.range.toJSON(),
+          //   command: {
+          //     title: "Run With Filters",
+          //     command: "malloy.runQueryWithEdit",
+          //     arguments: [exploreName, turtleName],
+          //   },
+          // });
         }
       });
     }


### PR DESCRIPTION
Experimental, but I think we should just have two lenses over queries Run and Render.   Since we are a data tool, the Run button should show the raw data.  The Render button passes these results to the renderer.  I think this will make Malloy more comprehensible.