### PR TITLE
Make a new panel when querying for data.

### DIFF
--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -119,6 +119,9 @@ export function runMalloyQuery(
   name: string,
   renderStyle: RunRenderStyle = "html"
 ): void {
+  if (renderStyle === "json") {
+    panelId += " Data";
+  }
   vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,


### PR DESCRIPTION
Simple change to open an new panel for run vs render (don't reuse the same one)