### PR TITLE
Put React into the query result WebView

### DIFF
--- a/packages/malloy-render/src/html/dashboard.ts
+++ b/packages/malloy-render/src/html/dashboard.ts
@@ -15,6 +15,7 @@ import { DataArrayOrRecord } from "@malloy-lang/malloy";
 import { StyleDefaults } from "../data_styles";
 import { ContainerRenderer } from "./container";
 import { HTMLTextRenderer } from "./text";
+import { yieldTask } from "./utils";
 
 export class HTMLDashboardRenderer extends ContainerRenderer {
   protected childrenStyleDefaults: StyleDefaults = {
@@ -45,6 +46,7 @@ export class HTMLDashboardRenderer extends ContainerRenderer {
       let renderedMeasures = "";
       for (const field of measures) {
         const childRenderer = this.childRenderers[field.name];
+        await yieldTask();
         const rendered = await childRenderer.render(row.cell(field));
         if (childRenderer instanceof HTMLDashboardRenderer) {
           renderedMeasures += rendered;

--- a/packages/malloy-render/src/html/list.ts
+++ b/packages/malloy-render/src/html/list.ts
@@ -14,6 +14,7 @@
 import { DataColumn, Field, Explore } from "@malloy-lang/malloy";
 import { StyleDefaults } from "../data_styles";
 import { ContainerRenderer } from "./container";
+import { yieldTask } from "./utils";
 
 export class HTMLListRenderer extends ContainerRenderer {
   protected childrenStyleDefaults: StyleDefaults = {
@@ -47,6 +48,7 @@ export class HTMLListRenderer extends ContainerRenderer {
       renderedItem += rendered;
       if (detailField) {
         const childRenderer = this.childRenderers[detailField.name];
+        await yieldTask();
         const rendered = await childRenderer.render(row.cell(detailField));
         renderedItem += ` (${rendered})`;
       }

--- a/packages/malloy-render/src/html/table.ts
+++ b/packages/malloy-render/src/html/table.ts
@@ -16,6 +16,7 @@ import { StyleDefaults } from "../data_styles";
 // import { getDrillPath, getDrillQuery } from "../drill";
 import { ContainerRenderer } from "./container";
 import { HTMLNumberRenderer } from "./number";
+import { yieldTask } from "./utils";
 
 export class HTMLTableRenderer extends ContainerRenderer {
   protected childrenStyleDefaults: StyleDefaults = {
@@ -42,6 +43,7 @@ export class HTMLTableRenderer extends ContainerRenderer {
       for (const field of table.field.intrinsicFields) {
         const childRenderer = this.childRenderers[field.name];
         const isNumeric = childRenderer instanceof HTMLNumberRenderer;
+        await yieldTask();
         const rendered = await childRenderer.render(row.cell(field));
         renderedRow += `<td style="padding: ${
           childRenderer instanceof HTMLTableRenderer ? "0" : "8px"

--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -128,3 +128,18 @@ export function timeToString(
       throw new Error("Unknown timeframe.");
   }
 }
+
+/**
+ * Use this function to break up expensive computation over multiple tasks.
+ *
+ * @returns A promise, which when awaited, puts subsequent code in a separate task.
+ *
+ * This is useful for cases when expensive code needs to run "concurrently" with a
+ * rendering / UI task. Sprinkling in `yieldTask`s into a long task allows other
+ * tasks to run periodically.
+ */
+export async function yieldTask(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -115,18 +115,20 @@
   "scripts": {
     "vscode:prepublish": "yarn licenses generate-disclaimer --prod > third_party_notices.txt && webpack --mode production",
     "webpack": "webpack --mode development",
-    "webpack-dev": "webpack --mode development --watch --stats='summary'",
+    "webpack-dev": "webpack --mode development --watch",
     "build": "yarn tsc --build && yarn package",
     "pretest": "yarn run package",
     "test": "echo 'no tests for vscode yet'",
     "package": "yarn vsce package --yarn"
   },
   "dependencies": {
-    "@observablehq/plot": "^0.1.0",
-    "@malloy-lang/malloy": "*",
     "@malloy-lang/db-bigquery": "*",
     "@malloy-lang/db-postgres": "*",
+    "@malloy-lang/malloy": "*",
     "@malloy-lang/render": "*",
+    "@observablehq/plot": "^0.1.0",
+    "react": "^17.0.2",
+    "styled-components": "^5.3.3",
     "us-atlas": "^3.0.0",
     "vega": "5.17.3",
     "vega-lite": "4.17.0",
@@ -140,16 +142,22 @@
     "@types/jsdom": "^16.2.11",
     "@types/mocha": "^8.2.2",
     "@types/node": "^12.19.8",
+    "@types/react": "^17.0.38",
+    "@types/react-dom": "^17.0.11",
+    "@types/styled-components": "^5.1.19",
     "@types/vscode": "1.56.0",
+    "@types/vscode-webview": "^1.57.0",
     "copy-webpack-plugin": "^9.0.1",
     "file-loader": "^6.2.0",
     "glob": "^7.1.7",
     "mocha": "^9.0.0",
+    "react-dom": "^17.0.2",
+    "source-map-loader": "^3.0.0",
     "ts-loader": "^9.2.3",
     "vsce": "^1.95.0",
     "vscode-test": "^1.5.2",
+    "vscode-webview": "^1.0.1-beta.1",
     "webpack": "^5.41.1",
-    "webpack-cli": "^4.7.2",
-    "source-map-loader": "^3.0.0"
+    "webpack-cli": "^4.7.2"
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_named_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_named_query.ts
@@ -18,7 +18,7 @@ import { runMalloyQuery } from "./run_query_utils";
 
 export function runNamedQuery(
   name: string,
-  renderStyle: QueryRenderMode = QueryRenderMode.HTML
+  renderMode: QueryRenderMode = QueryRenderMode.HTML
 ): void {
   const document =
     vscode.window.activeTextEditor?.document ||
@@ -28,7 +28,7 @@ export function runNamedQuery(
       { type: "named", name, file: document },
       `${document.uri.toString()} ${name}`,
       name,
-      renderStyle
+      renderMode
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_named_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_named_query.ts
@@ -13,9 +13,13 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { runMalloyQuery, RunRenderStyle } from "./run_query_utils";
+import { QueryRenderMode } from "../webview_message_manager";
+import { runMalloyQuery } from "./run_query_utils";
 
-export function runNamedQuery(name: string, renderStyle: RunRenderStyle): void {
+export function runNamedQuery(
+  name: string,
+  renderStyle: QueryRenderMode = QueryRenderMode.HTML
+): void {
   const document =
     vscode.window.activeTextEditor?.document ||
     MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;

--- a/packages/malloy-vscode/src/extension/commands/run_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query.ts
@@ -19,7 +19,7 @@ import { runMalloyQuery } from "./run_query_utils";
 export function runQueryCommand(
   query: string,
   name?: string,
-  renderStyle: QueryRenderMode = QueryRenderMode.HTML
+  renderMode: QueryRenderMode = QueryRenderMode.HTML
 ): void {
   const document =
     vscode.window.activeTextEditor?.document ||
@@ -29,7 +29,7 @@ export function runQueryCommand(
       { type: "string", text: query, file: document },
       `${document.uri.toString()} ${name}`,
       name || document.uri.toString(),
-      renderStyle
+      renderMode
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query.ts
@@ -13,12 +13,13 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { runMalloyQuery, RunRenderStyle } from "./run_query_utils";
+import { QueryRenderMode } from "../webview_message_manager";
+import { runMalloyQuery } from "./run_query_utils";
 
 export function runQueryCommand(
   query: string,
   name?: string,
-  renderStyle: RunRenderStyle = "html"
+  renderStyle: QueryRenderMode = QueryRenderMode.HTML
 ): void {
   const document =
     vscode.window.activeTextEditor?.document ||

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -115,7 +115,7 @@ export function runMalloyQuery(
   name: string,
   renderMode: QueryRenderMode = QueryRenderMode.HTML
 ): void {
-  if (renderStyle === "json") {
+  if (renderMode === QueryRenderMode.JSON) {
     panelId += " Data";
   }
   vscode.window.withProgress(

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -16,7 +16,6 @@ import { performance } from "perf_hooks";
 import * as vscode from "vscode";
 import { URL, Runtime, URLReader } from "@malloy-lang/malloy";
 import { DataStyles } from "@malloy-lang/render";
-import { renderErrorHTML } from "../html";
 import { CONNECTION_MAP, MALLOY_EXTENSION_STATE, RunState } from "../state";
 import turtleIcon from "../../media/turtle.svg";
 import { fetchFile, VSCodeURLReader } from "../utils";

--- a/packages/malloy-vscode/src/extension/state.ts
+++ b/packages/malloy-vscode/src/extension/state.ts
@@ -15,6 +15,10 @@ import { TextDocument, WebviewPanel } from "vscode";
 import { Connection, FixedConnectionMap, Result } from "@malloy-lang/malloy";
 import { BigQueryConnection } from "@malloy-lang/db-bigquery";
 import { PostgresConnection } from "@malloy-lang/db-postgres";
+import {
+  QueryPanelMessage,
+  WebviewMessageManager,
+} from "./webview_message_manager";
 
 export const CONNECTION_MAP = new FixedConnectionMap(
   new Map<string, Connection>(
@@ -31,6 +35,7 @@ export const CONNECTION_MAP = new FixedConnectionMap(
 export interface RunState {
   cancel: () => void;
   panel: WebviewPanel;
+  messages: WebviewMessageManager<QueryPanelMessage>;
   panelId: string;
   document: TextDocument;
   result?: Result;

--- a/packages/malloy-vscode/src/extension/webview_message_manager.ts
+++ b/packages/malloy-vscode/src/extension/webview_message_manager.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResultJSON } from "@malloy-lang/malloy";
+import { DataStyles } from "@malloy-lang/render";
+import { WebviewPanel } from "vscode";
+
+export class WebviewMessageManager<T> {
+  constructor(private panel: WebviewPanel) {
+    this.panel.webview.onDidReceiveMessage((message: T) => {
+      if (!this.panelCanReceiveMessages) {
+        this.onPanelCanReceiveMessages();
+      }
+      this.callback(message);
+    });
+    this.panel.onDidChangeViewState(() => {
+      if (this.panelCanReceiveMessages && !this.panel.visible) {
+        this.panelCanReceiveMessages = false;
+      } else if (!this.panelCanReceiveMessages && this.panel.visible) {
+        this.onPanelCanReceiveMessages();
+      }
+    });
+  }
+
+  private pendingMessages: T[] = [];
+  private panelCanReceiveMessages = false;
+  private callback: (message: T) => void = () => {
+    /* Do nothing by default */
+  };
+
+  public postMessage(message: T): void {
+    if (this.panelCanReceiveMessages) {
+      this.panel.webview.postMessage(message);
+    } else {
+      this.pendingMessages.push(message);
+    }
+  }
+
+  public onReceiveMessage(callback: (message: T) => void): void {
+    this.callback = callback;
+  }
+
+  private flushPendingMessages() {
+    this.pendingMessages.forEach((message) => {
+      this.panel.webview.postMessage(message);
+    });
+    this.pendingMessages.splice(0, this.pendingMessages.length);
+  }
+
+  private onPanelCanReceiveMessages() {
+    this.panelCanReceiveMessages = true;
+    this.flushPendingMessages();
+  }
+}
+
+export enum QueryRunStatus {
+  Compiling = "compiling",
+  Running = "running",
+  Error = "error",
+  Done = "done",
+}
+
+export enum QueryMessageType {
+  QueryStatus = "query-status",
+  AppReady = "app-ready",
+}
+
+export enum QueryRenderMode {
+  HTML = "html",
+  JSON = "json",
+}
+
+interface QueryMessageStatusCompiling {
+  type: QueryMessageType.QueryStatus;
+  status: QueryRunStatus.Compiling;
+}
+
+interface QueryMessageStatusRunning {
+  type: QueryMessageType.QueryStatus;
+  status: QueryRunStatus.Running;
+}
+
+interface QueryMessageStatusError {
+  type: QueryMessageType.QueryStatus;
+  status: QueryRunStatus.Error;
+  error: string;
+}
+
+interface QueryMessageStatusDone {
+  type: QueryMessageType.QueryStatus;
+  status: QueryRunStatus.Done;
+  result: ResultJSON;
+  styles: DataStyles;
+  mode: QueryRenderMode;
+}
+
+type QueryMessageStatus =
+  | QueryMessageStatusCompiling
+  | QueryMessageStatusError
+  | QueryMessageStatusRunning
+  | QueryMessageStatusDone;
+
+interface QueryMessageAppReady {
+  type: QueryMessageType.AppReady;
+}
+
+export type QueryPanelMessage = QueryMessageStatus | QueryMessageAppReady;

--- a/packages/malloy-vscode/src/extension/webviews/components/Spinner/Spinner.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/components/Spinner/Spinner.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import styled, { keyframes } from "styled-components";
+
+interface SpinnerProps {
+  text: string;
+}
+
+const SpinnerSVG: React.FC = () => {
+  return (
+    <svg
+      width="25px"
+      height="25px"
+      viewBox="0 0 15 15"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <title>malloy-icon-status-progress</title>
+      <defs>
+        <circle id="path-1" cx="7.5" cy="7.5" r="7.5"></circle>
+        <mask
+          id="mask-2"
+          maskContentUnits="userSpaceOnUse"
+          maskUnits="objectBoundingBox"
+          x="0"
+          y="0"
+          width="15"
+          height="15"
+          fill="white"
+        >
+          <use xlinkHref="#path-1"></use>
+        </mask>
+      </defs>
+      <g
+        id="malloy-icon-status-progress"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+        strokeDasharray="16"
+      >
+        <use
+          id="Oval-Copy-3"
+          stroke="#1a73e8"
+          mask="url(#mask-2)"
+          strokeWidth="3"
+          transform="translate(7.500000, 7.500000) rotate(-240.000000) translate(-7.500000, -7.500000) "
+          xlinkHref="#path-1"
+        ></use>
+      </g>
+    </svg>
+  );
+};
+
+export const Spinner: React.FC<SpinnerProps> = ({ text }) => {
+  return (
+    <VerticalCenter>
+      <HorizontalCenter>
+        <Label>{text}</Label>
+        <SpinningSVG>
+          <SpinnerSVG />
+        </SpinningSVG>
+      </HorizontalCenter>
+    </VerticalCenter>
+  );
+};
+
+const rotation = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+`;
+
+const SpinningSVG = styled.div`
+  width: 25px;
+  height: 25px;
+  animation: ${rotation} 2s infinite linear;
+`;
+
+const Label = styled.div`
+  margin-bottom: 10px;
+  color: #505050;
+  font-size: 15px;
+`;
+
+const VerticalCenter = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1 0 auto;
+  width: 100%;
+  height: 100%;
+`;
+
+const HorizontalCenter = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;

--- a/packages/malloy-vscode/src/extension/webviews/components/Spinner/index.ts
+++ b/packages/malloy-vscode/src/extension/webviews/components/Spinner/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Spinner } from "./Spinner";

--- a/packages/malloy-vscode/src/extension/webviews/components/Spinner/spinner.svg
+++ b/packages/malloy-vscode/src/extension/webviews/components/Spinner/spinner.svg
@@ -1,0 +1,12 @@
+<svg width="25px" height="25px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>malloy-icon-status-progress</title>
+  <defs>
+      <circle id="path-1" cx="7.5" cy="7.5" r="7.5"></circle>
+      <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="15" height="15" fill="white">
+          <use xlink:href="#path-1"></use>
+      </mask>
+  </defs>
+  <g id="malloy-icon-status-progress" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-dasharray="16">
+      <use id="Oval-Copy-3" stroke="#1a73e8" mask="url(#mask-2)" stroke-width="3" transform="translate(7.500000, 7.500000) rotate(-240.000000) translate(-7.500000, -7.500000) " xlink:href="#path-1"></use>
+  </g>
+</svg>

--- a/packages/malloy-vscode/src/extension/webviews/components/index.ts
+++ b/packages/malloy-vscode/src/extension/webviews/components/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Spinner } from "./Spinner";

--- a/packages/malloy-vscode/src/extension/webviews/index.ts
+++ b/packages/malloy-vscode/src/extension/webviews/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { getWebviewHtml } from "./webview_html";

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Result } from "@malloy-lang/malloy";
+import { HTMLView, JSONView } from "@malloy-lang/render";
+import React, { useEffect, useState } from "react";
+import {
+  QueryMessageType,
+  QueryPanelMessage,
+  QueryRenderMode,
+  QueryRunStatus,
+} from "../../webview_message_manager";
+import { Spinner } from "../components";
+
+enum Status {
+  Ready = "ready",
+  Compiling = "compiling",
+  Running = "running",
+  Error = "error",
+  Displaying = "displaying",
+  Rendering = "rendering",
+  Done = "done",
+}
+
+export const App: React.FC = () => {
+  const [status, setStatus] = useState<Status>(Status.Ready);
+  const [rendered, setRendered] = useState("");
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const listener = (event: MessageEvent<QueryPanelMessage>) => {
+      const message = event.data;
+
+      switch (message.type) {
+        case QueryMessageType.QueryStatus:
+          if (message.status === QueryRunStatus.Error) {
+            setStatus(Status.Error);
+            setError(message.error);
+          } else {
+            setError(undefined);
+          }
+          if (message.status === QueryRunStatus.Done) {
+            setStatus(Status.Rendering);
+            setTimeout(async () => {
+              const result = Result.fromJSON(message.result).data;
+              const rendered = await (message.mode === QueryRenderMode.HTML
+                ? new HTMLView().render(result, message.styles)
+                : new JSONView().render(result));
+              setStatus(Status.Displaying);
+              setTimeout(() => {
+                setRendered(rendered);
+                setStatus(Status.Done);
+              }, 0);
+            }, 0);
+          } else {
+            setRendered("");
+            switch (message.status) {
+              case QueryRunStatus.Compiling:
+                setStatus(Status.Compiling);
+                break;
+              case QueryRunStatus.Running:
+                setStatus(Status.Running);
+                break;
+            }
+          }
+      }
+    };
+    window.addEventListener("message", listener);
+    return () => window.removeEventListener("message", listener);
+  });
+
+  return (
+    <div style={{ height: "100%" }}>
+      {[
+        Status.Compiling,
+        Status.Running,
+        Status.Rendering,
+        Status.Displaying,
+      ].includes(status) ? (
+        <Spinner text={getStatusLabel(status) || ""} />
+      ) : (
+        ""
+      )}
+      <div
+        dangerouslySetInnerHTML={{ __html: rendered }}
+        style={{ padding: "10px" }}
+      ></div>
+      {error && <div>{error}</div>}
+    </div>
+  );
+};
+
+function getStatusLabel(status: Status) {
+  switch (status) {
+    case Status.Compiling:
+      return "Compiling";
+    case Status.Running:
+      return "Running";
+    case Status.Rendering:
+      return "Rendering";
+    case Status.Displaying:
+      return "Displaying";
+  }
+}

--- a/packages/malloy-vscode/src/extension/webviews/query_page/entry.ts
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/entry.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as _webviewAPI from "vscode-webview";
+
+import ReactDOM from "react-dom";
+import React from "react";
+import { App } from "./app";
+import { QueryPanelMessage } from "../../webview_message_manager";
+
+(() => {
+  const vscode = acquireVsCodeApi<unknown>();
+  vscode.postMessage({ type: "app-ready" } as QueryPanelMessage);
+
+  const el = React.createElement(App, {}, null);
+  ReactDOM.render(el, document.getElementById("app"));
+})();

--- a/packages/malloy-vscode/src/extension/webviews/query_page/entry.ts
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/entry.ts
@@ -18,7 +18,7 @@ import * as _webviewAPI from "vscode-webview";
 
 import ReactDOM from "react-dom";
 import React from "react";
-import { App } from "./app";
+import { App } from "./App";
 import { QueryPanelMessage } from "../../webview_message_manager";
 
 (() => {

--- a/packages/malloy-vscode/src/extension/webviews/webview_html.ts
+++ b/packages/malloy-vscode/src/extension/webviews/webview_html.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function getWebviewHtml(entrySrc: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Malloy Query Results</title>
+  </head>
+  <style>
+    html,body,#app {
+      height: 100%;
+      margin: 0;
+    }
+    body {
+      background-color: transparent;
+      font-size: 11px;
+    }
+  </style>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script src="${entrySrc}"></script>
+</html>`;
+}

--- a/packages/malloy-vscode/tsconfig.json
+++ b/packages/malloy-vscode/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "out",
     "rootDir": "src"
   },

--- a/packages/malloy-vscode/webpack.config.js
+++ b/packages/malloy-vscode/webpack.config.js
@@ -19,72 +19,146 @@ const webpack = require("webpack");
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 
-const config = {
-  target: "node",
+const config = [
+  {
+    target: "node",
 
-  entry: {
-    extension: "./src/extension/extension.ts",
-    server: "./src/server/server.ts",
-  },
-  output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: "[name].js",
-    libraryTarget: "commonjs2",
-    devtoolModuleFilenameTemplate: "../[resource-path]",
-  },
-  devtool: "inline-cheap-module-source-map",
-  externals: {
-    vscode: "commonjs vscode",
-  },
-  resolve: {
-    extensions: [".ts", ".js", ".svg"],
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: "ts-loader",
-            options: {
-              projectReferences: true,
+    entry: {
+      extension: "./src/extension/extension.ts",
+      server: "./src/server/server.ts",
+    },
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "[name].js",
+      libraryTarget: "commonjs2",
+      devtoolModuleFilenameTemplate: "../[resource-path]",
+    },
+    devtool: "inline-cheap-module-source-map",
+    externals: {
+      vscode: "commonjs vscode",
+    },
+    resolve: {
+      extensions: [".ts", ".js", ".svg"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: [
+            {
+              loader: "ts-loader",
+              options: {
+                projectReferences: true,
+              },
             },
+          ],
+        },
+        {
+          test: /\.svg/,
+          use: {
+            loader: "file-loader",
           },
-        ],
-      },
-      {
-        test: /\.svg/,
-        use: {
-          loader: "file-loader",
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        enforce: "pre",
-        use: ["source-map-loader"],
-      },
-    ],
-  },
-  plugins: [
-    new webpack.IgnorePlugin({ resourceRegExp: /^pg-native$/ }),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: "language.json",
-          to: "language.json",
         },
         {
-          from: "src/media/refresh.svg",
-          to: "src/media/refresh.svg",
-        },
-        {
-          from: "src/media/play.svg",
-          to: "src/media/play.svg",
+          test: /\.js$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["source-map-loader"],
         },
       ],
-    }),
-  ],
-};
+    },
+    plugins: [
+      new webpack.IgnorePlugin({ resourceRegExp: /^pg-native$/ }),
+      new CopyPlugin({
+        patterns: [
+          {
+            from: "language.json",
+            to: "language.json",
+          },
+          {
+            from: "src/media/refresh.svg",
+            to: "src/media/refresh.svg",
+          },
+          {
+            from: "src/media/play.svg",
+            to: "src/media/play.svg",
+          },
+        ],
+      }),
+    ],
+  },
+  {
+    target: "web",
+    entry: {
+      query_webview: "./src/extension/webviews/query_page/entry.ts",
+    },
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "[name].js",
+      libraryTarget: "umd",
+      devtoolModuleFilenameTemplate: "../[resource-path]",
+    },
+    devtool: "inline-cheap-module-source-map",
+    resolve: {
+      extensions: [".ts", ".js", ".tsx"],
+      fallback: {
+        fs: false,
+        stream: false,
+        assert: false,
+        util: false,
+        events: false,
+        http: false,
+        https: false,
+        tls: false,
+        net: false,
+        crypto: false,
+        url: false,
+        buffer: false,
+        zlib: false,
+        querystring: false,
+        path: false,
+        os: false,
+        child_process: false,
+        process: false,
+      },
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          exclude: /node_modules/,
+          use: [
+            {
+              loader: "ts-loader",
+              options: {
+                projectReferences: true,
+              },
+            },
+          ],
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          enforce: "pre",
+          use: ["source-map-loader"],
+        },
+        {
+          test: /\.svg$/,
+          use: [
+            {
+              loader: "babel-loader",
+            },
+            {
+              loader: "react-svg-loader",
+              options: {
+                jsx: true,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
 module.exports = config;

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -46,6 +46,7 @@ export {
   SourceRelationship,
   DateTimeframe,
   TimestampTimeframe,
+  Result,
 } from "./malloy";
 export type {
   Explore,
@@ -56,13 +57,13 @@ export type {
   AtomicField,
   ExploreField,
   QueryField,
-  Result,
   DataArray,
   DataColumn,
   DataArrayOrRecord,
   ModelMaterializer,
   DocumentSymbol,
   DocumentHighlight,
+  ResultJSON,
 } from "./malloy";
 export type {
   URLReader,

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1896,6 +1896,11 @@ class ExploreMaterializer extends FluentState<Explore> {
   }
 }
 
+export type ResultJSON = {
+  queryResult: QueryResult;
+  modelDef: ModelDef;
+};
+
 /**
  * The result of running a Malloy query.
  *
@@ -1918,6 +1923,14 @@ export class Result extends PreparedResult {
    */
   public get data(): DataArray {
     return new DataArray(this.inner.result, this.resultExplore);
+  }
+
+  public toJSON(): ResultJSON {
+    return { queryResult: this.inner, modelDef: this._modelDef };
+  }
+
+  public static fromJSON({ queryResult, modelDef }: ResultJSON): Result {
+    return new Result(queryResult, modelDef);
   }
 }
 

--- a/postgres_test/dump_malloytest.sh
+++ b/postgres_test/dump_malloytest.sh
@@ -1,1 +1,1 @@
-pg_dump -n malloytest | gzip > malloytest-postgres.sql.gz
+pg_dump -n malloytest -O -x  | gzip > malloytest-postgres.sql.gz

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
+"@babel/code-frame@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.0.tgz#ea269d7f78deb3a7826c39a4048eecda541ebdaa"
@@ -51,6 +58,22 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.7.tgz#b42bf46a3079fa65e1544135f32e7958f048adbb"
+  integrity sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==
+  dependencies:
+    "@babel/types" "^7.16.7"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/helper-annotate-as-pure@^7.16.0":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
+  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-compilation-targets@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz#01d615762e796c17952c29e3ede9d6de07d235a8"
@@ -61,6 +84,13 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-function-name@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz#b7dd0797d00bbfee4f07e9c4ea5b0e30c8bb1481"
@@ -70,12 +100,28 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-function-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
+  integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-get-function-arity@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz#0088c7486b29a9cb5d948b1a1de46db66e089cfa"
   integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-get-function-arity@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
+  integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-hoist-variables@^7.16.0":
   version "7.16.0"
@@ -84,12 +130,26 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-hoist-variables@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-member-expression-to-functions@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz#29287040efd197c77636ef75188e81da8bccd5a4"
   integrity sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-module-imports@^7.16.0":
   version "7.16.0"
@@ -148,10 +208,22 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-split-export-declaration@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -185,10 +257,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.7.tgz#81a01d7d675046f0d96f82450d9d9578bdfd6b0b"
+  integrity sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0":
   version "7.16.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
   integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
+
+"@babel/parser@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.7.tgz#d372dda9c89fcec340a82630a9f533f2fe15877e"
+  integrity sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -283,6 +369,15 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/template@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.0.tgz#965df6c6bfc0a958c1e739284d3c9fa4a6e3c45b"
@@ -298,12 +393,36 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.4.5":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.7.tgz#dac01236a72c2560073658dd1a285fe4e0865d76"
+  integrity sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.7.tgz#4ed19d51f840ed4bd5645be6ce40775fecf03159"
+  integrity sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -323,6 +442,28 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
+
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -773,6 +914,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -894,10 +1043,45 @@
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.6.tgz#377054f72f671b36dbe78c517ce2b279d83ecc40"
   integrity sha512-dTvnamRITNqNkqhlBd235kZl3KfVJQQoT5jkXeiWSBK7i4/TLKBNLV0S1wOt8gy4E2TY722KLtdmv2xc6+Wevg==
 
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^17.0.38":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/styled-components@^5.1.19":
+  version "5.1.19"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.19.tgz#d76f431ee49d0a222ab4e758dcd540b01987652d"
+  integrity sha512-hNj14Oamk7Jhb/fMMQG7TUkd3e8uMMgxsCTH+ueJNGdFo/PuhlGDQTPChqyilpZP0WttgBHkc2YyT5UG+yc6Yw==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/tough-cookie@*":
   version "4.0.1"
@@ -908,6 +1092,11 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@types/vscode-webview@^1.57.0":
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode-webview/-/vscode-webview-1.57.0.tgz#bad5194d45ae8d03afc1c0f67f71ff5e7a243bbf"
+  integrity sha512-x3Cb/SMa1IwRHfSvKaZDZOTh4cNoG505c3NjTqGlMC082m++x/ETUmtYniDsw6SSmYzZXO8KBNhYxR0+VqymqA==
 
 "@types/vscode@1.56.0":
   version "1.56.0"
@@ -1426,6 +1615,21 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+"babel-plugin-styled-components@>= 1.12.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz#0fac11402dc9db73698b55847ab1dc73f5197c54"
+  integrity sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.0"
+    "@babel/helper-module-imports" "^7.16.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -1667,6 +1871,11 @@ camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001248:
   version "1.0.30001271"
@@ -1994,6 +2203,11 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-select@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
@@ -2004,6 +2218,15 @@ css-select@^4.1.3:
     domhandler "^4.2.0"
     domutils "^2.6.0"
     nth-check "^2.0.0"
+
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-what@^5.0.0, css-what@^5.0.1:
   version "5.0.1"
@@ -2026,6 +2249,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 csv-stringify@^5.6.5:
   version "5.6.5"
@@ -3018,6 +3246,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -3204,7 +3441,7 @@ google-p12-pem@^3.0.3:
   dependencies:
     node-forge "^0.10.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -3285,6 +3522,13 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -4129,7 +4373,7 @@ joi@^17.4.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -4230,6 +4474,15 @@ json5@2.x, json5@^2.1.2:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jwa@^2.0.0:
   version "2.0.0"
@@ -4358,7 +4611,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4375,6 +4628,13 @@ longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
+loose-envify@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -4864,6 +5124,11 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -5186,6 +5451,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-value-parser@^4.0.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
 postgres-array@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
@@ -5315,10 +5585,32 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -5577,6 +5869,14 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^3.0.0, schema-utils@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
@@ -5636,6 +5936,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5950,6 +6255,22 @@ stubs@^3.0.0:
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha1-6NK6H6nJBXAwPAMLaQD31fiavls=
 
+styled-components@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.3.tgz#312a3d9a549f4708f0fb0edc829eb34bde032743"
+  integrity sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1.12.0"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
@@ -5957,7 +6278,7 @@ supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -6333,6 +6654,11 @@ universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -6868,6 +7194,13 @@ vscode-test@^1.5.2:
     https-proxy-agent "^5.0.0"
     rimraf "^3.0.2"
     unzipper "^0.10.11"
+
+vscode-webview@^1.0.1-beta.1:
+  version "1.0.1-beta.1"
+  resolved "https://registry.yarnpkg.com/vscode-webview/-/vscode-webview-1.0.1-beta.1.tgz#64911f19bff3d62c5897b13bb0a9c9a47d2cb463"
+  integrity sha512-8H2icqlb93qIvZs7Me/0sALMqJrX2e2W7JVE0mfK8exUPETP9Bmg+feivaByd1Xbg78lcKaNF9ZRrIFSenUVxQ==
+  dependencies:
+    fs-extra "^10.0.0"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add the plumbing to put arbitrary React interactiveness into the query result webview. 

For now, the way the webview behaves does not visibly change much, but it will be possible to add interactive features.

This PR also adds `setTimeout`s into the `render` methods of collection renderers between the rendering of each cell. This makes the overall render span multiple JS tasks, allowing other tasks, e.g. React rendering, to occur during a "slow" render. This dramatically improves the responsiveness of an app that uses the rendering library.