### PR TITLE
Fix refined queries which contain field expressions

### DIFF
--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -397,13 +397,14 @@ export abstract class QueryFieldSpace extends NewFieldSpace {
     };
     if (exisitingFields) {
       const newDefinition: Record<string, boolean> = {};
-      for (const fieldName in seg.fields) {
+      for (const field in seg.fields) {
+        const fieldName = nameOf(field);
         newDefinition[fieldName] = true;
       }
       for (const field of exisitingFields) {
         const fieldName = nameOf(field);
         if (!newDefinition[fieldName]) {
-          seg.fields.push(fieldName);
+          seg.fields.push(field);
         }
       }
     }


### PR DESCRIPTION
@mtoy-googly-moogly fixed an issue where no fields would show up when a query was refined, e.g.

```
query: flights -> airport_dashboard {? origin.code: 'SJC' }
```

However, if the query contained any field definitions rather than field references, the resulting query would not correctly re-define those fields. 

This PR should fix that.

Two sample models (`iowa.malloy` and `flights_beta.malloy`) are now compiling again with this change.