### PR TITLE
Fix issue where filterList is mutated incorrectly

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -901,10 +901,12 @@ export class QOPDesc extends ListOf<QueryProperty> {
     const pfs = this.getInputSpace(inputFS);
     let didOrderBy: OrderBy | undefined;
     let didLimit: Limit | undefined;
-    const segProp: Partial<model.QuerySegment> = { ...this.refineThis };
-    if (segProp.fields) {
-      delete segProp.fields;
-    }
+    const segProp: Partial<model.QuerySegment> = {
+      ...this.refineThis,
+      filterList: this.refineThis?.filterList
+        ? [...this.refineThis.filterList]
+        : undefined,
+    };
     for (const qp of this.list) {
       const errTo = qp;
       if (


### PR DESCRIPTION
Fixes an issue where the `filterList` of a query is mutated incorrectly.

Minimal example:

```
explore: base is table('malloy-data.faa.flights') {
  query: base_query is {
    where: true
    group_by: one is 1
  }
}

explore: extended is base {
  query: extended_query is {
    nest: base_query
    nest: no_data is base_query {? false }
  }
}
```

Running `extended_query` should yield:

```
[
  {
    "base_query": [
      {
        "one": 1
      }
    ],
    "no_data": []
  }
]
```

But instead it yielded:

```
[
  {
    "base_query": [],
    "no_data": []
  }
]
```

Because `base_query`'s `filterList` was mutated to include the `false` filter. 

The fix just copies the `filterList` array when creating the new query.