### PR TITLE
Allow inline models in docs

### DIFF
--- a/docs/_scripts/build_docs/render_document.ts
+++ b/docs/_scripts/build_docs/render_document.ts
@@ -33,9 +33,15 @@ Malloy.db = new BigQueryConnection("docs");
 class Renderer {
   // The path where the document being rendered exists.
   private readonly path: string;
+  private models: Map<string, string>;
 
   constructor(path: string) {
     this.path = path;
+    this.models = new Map();
+  }
+
+  private setModel(modelPath: string, source: string) {
+    this.models.set(modelPath, source);
   }
 
   protected async code(
@@ -50,7 +56,7 @@ class Renderer {
         ? MALLOY_GRAMMAR
         : Prism.languages[lang] || Prism.languages.text;
 
-    let hidden;
+    let hidden = false;
     if (grammar) {
       let result = "";
       if (lang === "malloy") {
@@ -59,12 +65,14 @@ class Renderer {
             const options = JSON.parse(
               code.split("\n")[0].substring("--! ".length).trim()
             );
+            code = code.split("\n").slice(1).join("\n");
+            if (options.isHidden) {
+              hidden = true;
+            }
             if (options.isRunnable) {
-              code = code.split("\n").slice(1).join("\n");
-              result = await runCode(code, this.path, options);
-              if (options.isHidden) {
-                hidden = true;
-              }
+              result = await runCode(code, this.path, options, this.models);
+            } else if (options.isModel) {
+              this.setModel(options.modelPath, code);
             }
           } catch (error) {
             log(`  !! Error: ${error.toString()}`);

--- a/docs/_src/language/basic.md
+++ b/docs/_src/language/basic.md
@@ -112,13 +112,16 @@ One of the main benefits of Malloy is the ability to save common calculations in
 add calculations for `county_and_state` and `airport_count`.
 
 ```malloy
---! {"isRunnable": true, "runMode": "auto", "isPaginationEnabled": true}
+--! {"isModel": true, "modelPath": "/inline/airports_mini.malloy"}
 explore: airports is table('malloy-data.faa.airports'){
   dimension: county_and_state is concat(county, ', ', state)
   measure: airport_count is count()
   measure: average_elevation is avg(elevation)
 }
+```
 
+```malloy
+--! {"isRunnable": true, "runMode": "auto", "isPaginationEnabled": true, "source": "/inline/airports_mini.malloy"}
 query: airports->{
   group_by:county_and_state
   aggregate: airport_count


### PR DESCRIPTION
Allows model files to be defined inline in a doc.

To define a model in queries appearing _later in the document_, use snippet parameters `isModel` with value `true` and `modelPath` with a path (rooted at the sample model directory). This defines a virtual file at that path for later snippets to use. 

````md
```malloy
--! {"isModel": true, "modelPath": "/inline/airports_mini.malloy"}
explore: airports is table('malloy-data.faa.airports'){
  dimension: county_and_state is concat(county, ', ', state)
  measure: airport_count is count()
  measure: average_elevation is avg(elevation)
}
```

```malloy
--! {"isRunnable": true, "runMode": "auto", "isPaginationEnabled": true, "source": "/inline/airports_mini.malloy"}
query: airports->{
  group_by:county_and_state
  aggregate: airport_count
}
```
````

Note this is not currently compatible with imports. So don't try to write `import "/inline/airports_mini.malloy"`. It won't work.