### PR TITLE
"day" timeframe is date, not number

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -940,7 +940,7 @@ export class Explore extends Entity {
               // field of type "date". Rather, they should be of type "number".
               if (
                 fieldDef.timeframe &&
-                ["day", "day_of_month", "day_of_week", "day_of_year"].includes(
+                ["day_of_month", "day_of_week", "day_of_year"].includes(
                   fieldDef.timeframe
                 )
               ) {


### PR DESCRIPTION
* Fix The `day` truncation to yield a `DataDate` not a `DataNumber`, e.g. 

```malloy
query: flights -> {
  group_by: flight_date is dep_time.day
  top: 5
  aggregate: flight_count
}
```

Previously `day` truncation (timeframe "day") was treated like `day` extraction (timeframe "day_of_month"), which does yield a `DataNumber`. 

