### PR TITLE
Add join_cross: with optional ON

### DIFF
--- a/docs/_src/examples/wordle/wordle1a.md
+++ b/docs/_src/examples/wordle/wordle1a.md
@@ -33,7 +33,7 @@ The result is a table with nested data.  Each word contans a sub-table with a le
 -- define the query
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word

--- a/docs/_src/examples/wordle/wordle2.md
+++ b/docs/_src/examples/wordle/wordle2.md
@@ -16,7 +16,7 @@ explore: numbers is table('malloy-data.malloytest.numbers'){
 -- Build a new table of word and each letter in position
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word

--- a/docs/_src/examples/wordle/wordle215.md
+++ b/docs/_src/examples/wordle/wordle215.md
@@ -76,7 +76,7 @@ explore: numbers is table('malloy-data.malloytest.numbers'){
 -- Build a new table of word and each letter in position
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word

--- a/docs/_src/examples/wordle/wordle217.md
+++ b/docs/_src/examples/wordle/wordle217.md
@@ -104,7 +104,7 @@ explore: numbers is table('malloy-data.malloytest.numbers'){
 -- Build a new table of word and each letter in position
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word

--- a/docs/_src/examples/wordle/wordle4.md
+++ b/docs/_src/examples/wordle/wordle4.md
@@ -20,7 +20,7 @@ explore: numbers is table('malloy-data.malloytest.numbers'){
 -- Build a new table of word and each letter in position
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word

--- a/packages/malloy-db-test/src/nomodel.spec.ts
+++ b/packages/malloy-db-test/src/nomodel.spec.ts
@@ -140,7 +140,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         `
       explore: a is table('malloytest.state_facts')
       explore: f is a{
-        join_many: a
+        join_cross: a
       }
       query: f->{aggregate:[c is count(distinct concat(state,a.state))]}
       `

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -631,8 +631,11 @@ export class QuerySource extends Mallobj {
 export abstract class Join extends MalloyElement {
   abstract name: string;
   abstract structDef(): model.StructDef;
-  onExpression(_outer: FieldSpace): model.Expr | undefined {
-    return undefined;
+  needsFixup(): boolean {
+    return false;
+  }
+  fixupJoinOn(_outer: FieldSpace, _inStruct: model.StructDef): void {
+    return;
   }
 }
 
@@ -666,59 +669,68 @@ export class KeyJoin extends Join {
   }
 }
 
+type ExpressionJoinType = "many" | "one" | "cross";
 export class ExpressionJoin extends Join {
   elementType = "joinOnExpr";
-  many = true;
-  outer?: model.StructDef;
-  constructor(
-    readonly name: string,
-    readonly source: Mallobj,
-    readonly expr: ExpressionDef
-  ) {
-    super({ source, expr });
-  }
-
-  onExpression(outer: FieldSpace): model.Expr | undefined {
-    const exprX = this.expr.getExpression(outer);
-    if (exprX.dataType !== "boolean") {
-      this.log("join conditions must be boolean expressions");
-      return undefined;
-    }
-    const ret = compressExpr(exprX.value);
-    return ret;
-  }
-
-  structDef(): model.StructDef {
-    const sourceDef = this.source.structDef();
-
-    const joinStruct: model.StructDef = {
-      ...sourceDef,
-      structRelationship: {
-        type: "condition",
-        onExpression: [],
-        many: this.many,
-      },
-    };
-    if (sourceDef.structSource.type === "query") {
-      // the name from query does not need to be preserved
-      joinStruct.name = this.name;
-    } else {
-      joinStruct.as = this.name;
-    }
-    return joinStruct;
-  }
-}
-
-export class CrossJoin extends Join {
-  elementType = "crossJoin";
+  joinType: ExpressionJoinType = "one";
+  private expr?: ExpressionDef;
   constructor(readonly name: string, readonly source: Mallobj) {
     super({ source });
   }
+
+  needsFixup(): boolean {
+    return this.expr != undefined;
+  }
+
+  set joinOn(joinExpr: ExpressionDef | undefined) {
+    this.expr = joinExpr;
+    this.has({ on: joinExpr });
+  }
+
+  get joinOn(): ExpressionDef | undefined {
+    return this.expr;
+  }
+
+  fixupJoinOn(
+    outer: FieldSpace,
+    inStruct: model.StructDef
+  ): model.Expr | undefined {
+    if (this.expr == undefined) {
+      return;
+    }
+    const exprX = this.expr.getExpression(outer);
+    if (exprX.dataType !== "boolean") {
+      this.log("join conditions must be boolean expressions");
+      return;
+    }
+    const joinRel = inStruct.structRelationship;
+    if (joinRel.type === "crossJoin" || joinRel.type === "condition") {
+      joinRel.onExpression = compressExpr(exprX.value);
+    }
+  }
+
+  condition(): model.JoinLeft {
+    return {
+      type: "condition",
+      onExpression: [],
+      many: this.joinType === "many",
+    };
+  }
+
+  cross(): model.JoinCross {
+    const crossJoin: model.JoinCross = { type: "crossJoin" };
+    if (this.expr) {
+      crossJoin.onExpression = [];
+    }
+    return crossJoin;
+  }
+
   structDef(): model.StructDef {
     const sourceDef = this.source.structDef();
     const joinStruct: model.StructDef = {
       ...sourceDef,
-      structRelationship: { type: "crossJoin" },
+      structRelationship:
+        this.joinType === "cross" ? this.cross() : this.condition(),
     };
     if (sourceDef.structSource.type === "query") {
       // the name from query does not need to be preserved
@@ -726,7 +738,6 @@ export class CrossJoin extends Join {
     } else {
       joinStruct.as = this.name;
     }
-
     return joinStruct;
   }
 }

--- a/packages/malloy/src/lang/beta.spec.ts
+++ b/packages/malloy/src/lang/beta.spec.ts
@@ -302,8 +302,9 @@ describe("explore properties", () => {
       "many is on",
       modelOK("explore: y is a { join_many: x is b on astr = x.astr }")
     );
-    test("cross", modelOK("explore: nab is a { join_many: b }"));
-    test("cross is", modelOK("explore: nab is a { join_many: xb is b }"));
+    test("cross", modelOK("explore: nab is a { join_cross: b }"));
+    test("cross is", modelOK("explore: nab is a { join_cross: xb is b }"));
+    test("cross on", modelOK("explore: nab is a { join_cross: b on true}"));
     test(
       "multiple joins",
       modelOK(`
@@ -311,10 +312,6 @@ describe("explore properties", () => {
           join_one: [
             b with astr,
             br is b with astr
-          ]
-          join_many: [
-            bm is b on bm.astr = astr,
-            bx is b
           ]
         }
       `)

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -112,6 +112,7 @@ exploreStatement
   | MEASURE measureDefList             # defExploreMeasure
   | JOIN_ONE joinList                  # defJoinOne
   | JOIN_MANY joinList                 # defJoinMany
+  | JOIN_CROSS joinList                # defJoinCross
   | whereStatement                     # defExploreWhere
   | PRIMARY_KEY fieldName              # defExplorePrimaryKey
   | RENAME fieldName IS fieldName      # defExploreRename
@@ -144,9 +145,8 @@ joinList
   ;
 
 joinDef
-  : joinNameDef (IS explore)?                   # joinCross
-  | joinNameDef (IS explore)? WITH fieldName    # joinWith
-  | joinNameDef (IS explore)? ON joinExpression # joinOn
+  : joinNameDef (IS explore)? WITH fieldName       # joinWith
+  | joinNameDef (IS explore)? (ON joinExpression)? # joinOn
   ;
 
 joinExpression: fieldExpr;
@@ -438,6 +438,7 @@ EXPLORE: E X P L O R E SPACE_CHAR* ':';
 GROUP_BY: G R O U P '_' B Y SPACE_CHAR* ':';
 HAVING: H A V I N G SPACE_CHAR* ':';
 INDEX: I N D E X SPACE_CHAR* ':';
+JOIN_CROSS: J O I N '_' C R O S S ':';
 JOIN_ONE: J O I N '_' O N E SPACE_CHAR* ':';
 JOIN_MANY: J O I N '_' M A N Y SPACE_CHAR* ':';
 LIMIT: L I M I T SPACE_CHAR* ':';

--- a/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-highlight-walker.ts
@@ -159,6 +159,9 @@ export function passForHighlights(
       case MalloyParser.INDEX:
         register(token, HighlightType.Property.Index, true);
         break;
+      case MalloyParser.JOIN_CROSS:
+        register(token, HighlightType.Property.Join, true);
+        break;
       case MalloyParser.JOIN_ONE:
         register(token, HighlightType.Property.Join, true);
         break;

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -408,6 +408,7 @@ export interface JoinLeft {
 
 export interface JoinCross {
   type: "crossJoin";
+  onExpression?: Expr;
 }
 
 /** types of joins. */

--- a/samples/wordle/wordlebot.malloy
+++ b/samples/wordle/wordlebot.malloy
@@ -14,7 +14,7 @@ explore: numbers is table('malloy-data.malloytest.numbers'){
 -- Build a new table of word and each letter in position
 query: words_and_position is from(words->five_letter_words){
   -- Cross join is missing at the moment
-  join_many: numbers
+  join_cross: numbers
   }
 ->{
   group_by: word


### PR DESCRIPTION
Currently just the parser work for this.

Need malloy_query work to  finish, a join of `type: "crossJoin"` now will have a optional `onExpression:`