### PR TITLE
Activate VSCode extension on startup

### DIFF
--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -24,9 +24,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:malloy.runQueryFile",
-    "onCommand:malloy.showLicenses",
-    "onLanguage:malloy"
+    "*"
   ],
   "main": "./dist/extension",
   "configurationDefaults": {


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/239

This change makes the Malloy extension activate when VSCode starts up, rather than at specific activation points. This has the downside that users who have the Malloy extension installed will _always_ have the Malloy extension activated, instead of having it activated only when they use Malloy-specific features. But this is less likely for us to accidentally run into issues like https://github.com/looker-open-source/malloy/issues/238 in the future. For now, we make `"*"` an activation event. Later, we can use specific activation events instead.