### PR TITLE
Add some postgres types to allow for querying a few of the pg_catalog tables

### DIFF
--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -32,6 +32,14 @@ const postgresToMalloyTypes: { [key: string]: AtomicFieldType } = {
   bigint: "number",
   "double precision": "number",
   "timestamp without time zone": "timestamp", // maybe not right
+  "timestamp with time zone": "timestamp", // also maybe not right?
+  boolean: "boolean",
+  smallint: "number",
+  "\"char\"": "string", // This has to be in quotes because the DB sends it back like this from the information_schema query
+  numeric: "number",
+  real: "number",
+  oid: "number", // (object identifier type) https://www.postgresql.org/docs/9.4/datatype-oid.html
+  xid: "number" // transaction ID
 };
 
 interface PostgresConnectionConfiguration {


### PR DESCRIPTION
Fixes part of #251 / #255 

There are two gotchas here:
+ Like the original author of this type system, I didn not figure out how timestamps work in postgres -- I actually think its impossible
+ Something is causing the information schema function to reutrn `”char”` instead of `char` (like all the rest of the types).

Notably in psql running a similar command as is done [here](https://github.com/looker-open-source/malloy/blob/main/packages/malloy-db-postgres/src/postgres_connection.ts#L142-L144)  it returns the `”char”`
```
test=# SELECT table_schema, table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = 'pg_catalog' and table_name = 'pg_attribute'  order by data_type  limit 20;
 table_schema |  table_name  |  column_name   | data_type 
--------------+--------------+----------------+-----------
 pg_catalog   | pg_attribute | attgenerated   | "char"
 pg_catalog   | pg_attribute | attidentity    | "char"
...
 pg_catalog   | pg_attribute | attacl         | ARRAY
...
 pg_catalog   | pg_attribute | attmissingval  | anyarray
 pg_catalog   | pg_attribute | attnotnull     | boolean
```

There are a variety of pg_catalog tables that are now possible to use, but many of the others are inaccessible due to lack of support for:
```
bytea
ARRAY (in caps for some reason)
pg_ndistinct
pg_mcv_list
pg_dependencies
interval
inet
pg_node_tree
bytea
pg_lsn
anyarray
regproc
regtype
```

Unsure if some of these should ever be supported as some of them are internal, sensitive columns used for things like query optimization statistics.