### PR TITLE
Use real activation events, rather than * (startup)

### DIFF
--- a/packages/malloy-vscode/package.json
+++ b/packages/malloy-vscode/package.json
@@ -24,7 +24,21 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onCommand:malloy.showLicenses",
+    "onCommand:malloy.runQueryFile",
+    "onCommand:malloy.runQuery",
+    "onCommand:malloy.runNamedQuery",
+    "onCommand:malloy.runTurtleFromSchema",
+    "onCommand:malloy.runTurtleWithFilters",
+    "onCommand:malloy.copyFieldPath",
+    "onCommand:malloy.refreshSchema",
+    "onCommand:malloy.editConnections",
+    "onLanguage:malloy",
+    "workspaceContains:**/.malloy",
+    "onView:malloyConnections",
+    "onView:malloySchema",
+    "onWebviewPanel:malloyQuery",
+    "onWebviewPanel:malloyConnections"
   ],
   "main": "./dist/extension",
   "configurationDefaults": {


### PR DESCRIPTION
In https://github.com/looker-open-source/malloy/pull/241, we made the extension activate on VSCode startup in order to quickly fix issues with the Edit Connections command not being available when the button is clicked. This is bad practice, and causes VSCode startup to be slow. 

In this PR, we instead flesh out the list of activation events, so that any time Malloy-related things happen, the extension activates.

Fixes https://github.com/looker-open-source/malloy/issues/245