### PR TITLE
Remove unnecessary capability registration from server

### DIFF
--- a/packages/malloy-vscode/src/server/server.ts
+++ b/packages/malloy-vscode/src/server/server.ts
@@ -19,7 +19,6 @@ import {
   TextDocumentSyncKind,
   InitializeResult,
   SemanticTokensBuilder,
-  DidChangeConfigurationNotification,
 } from "vscode-languageserver/node";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -65,10 +64,6 @@ connection.onInitialize((params: InitializeParams) => {
       },
     };
   }
-
-  connection.client.register(DidChangeConfigurationNotification.type, {
-    section: "malloy.connections",
-  });
 
   return result;
 });


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/254

Apparently the call to `connection.client.register(DidChangeConfigurationNotification.type, ...)` was not necessary.