### PR TITLE
When saving connections, update workspace config only if already set. Always update user config.

### DIFF
--- a/packages/malloy-vscode/src/extension/commands/edit_connections.ts
+++ b/packages/malloy-vscode/src/extension/commands/edit_connections.ts
@@ -57,9 +57,21 @@ export function editConnectionsCommand(): void {
     switch (message.type) {
       case ConnectionMessageType.SetConnections: {
         const connections = await handleConnectionsPreSave(message.connections);
-        vscode.workspace
-          .getConfiguration("malloy")
-          .update("connections", connections);
+        const malloyConfig = vscode.workspace.getConfiguration("malloy");
+        const hasWorkspaceConfig =
+          malloyConfig.inspect("connections")?.workspaceValue !== undefined;
+        malloyConfig.update(
+          "connections",
+          connections,
+          vscode.ConfigurationTarget.Global
+        );
+        if (hasWorkspaceConfig) {
+          malloyConfig.update(
+            "connections",
+            connections,
+            vscode.ConfigurationTarget.Workspace
+          );
+        }
         messageManager.postMessage({
           type: ConnectionMessageType.SetConnections,
           connections,


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/256

In the future we can give the user more options here. But for now, this is the least likely to cause problems. When you click "Save" in the connections editor:
* If `malloy.connections` is unset, or is only set in user config, user config is updated
* If `malloy.connections` is set in workspace config, both user config and workspace config are updated