### PR TITLE
Language server: do not send diagnostics for old document versions

### DIFF
--- a/packages/malloy-vscode/src/server/server.ts
+++ b/packages/malloy-vscode/src/server/server.ts
@@ -75,8 +75,17 @@ connection.onInitialize((params: InitializeParams) => {
 
 async function diagnoseDocument(document: TextDocument) {
   if (haveConnectionsBeenSet) {
+    // Necessary to copy the version, because it's mutated in the same document object
+    const versionAtRequestTime = document.version;
     const diagnostics = await getMalloyDiagnostics(documents, document);
-    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+    // Only send diagnostics if the document hasn't changed since this request started
+    if (versionAtRequestTime === document.version) {
+      connection.sendDiagnostics({
+        uri: document.uri,
+        diagnostics,
+        version: document.version,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/272

This solves a race condition where an old version of a document finishes validating after a new version, and so overrides the diagnostics for the newest version with those of the older version.