### PR TITLE
Show HTML/SQL/JSON tabs in query result panel

### DIFF
--- a/docs/_scripts/build_docs/run_code.ts
+++ b/docs/_scripts/build_docs/run_code.ts
@@ -17,7 +17,7 @@
  * that depend on that model. If `--watch` is enabled, changes to a model file
  * will cause relevant documents to recompile.
  */
-import { DataStyles, HTMLView, JSONView } from "@malloydata/render";
+import { DataStyles, HTMLView } from "@malloydata/render";
 import {
   Malloy,
   Runtime,

--- a/packages/malloy-vscode/src/extension/commands/run_named_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_named_query.ts
@@ -13,13 +13,9 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { QueryRenderMode } from "../webview_message_manager";
 import { runMalloyQuery } from "./run_query_utils";
 
-export function runNamedQuery(
-  name: string,
-  renderMode: QueryRenderMode = QueryRenderMode.HTML
-): void {
+export function runNamedQuery(name: string): void {
   const document =
     vscode.window.activeTextEditor?.document ||
     MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
@@ -27,8 +23,7 @@ export function runNamedQuery(
     runMalloyQuery(
       { type: "named", name, file: document },
       `${document.uri.toString()} ${name}`,
-      name,
-      renderMode
+      name
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query.ts
@@ -13,14 +13,9 @@
 
 import * as vscode from "vscode";
 import { MALLOY_EXTENSION_STATE } from "../state";
-import { QueryRenderMode } from "../webview_message_manager";
 import { runMalloyQuery } from "./run_query_utils";
 
-export function runQueryCommand(
-  query: string,
-  name?: string,
-  renderMode: QueryRenderMode = QueryRenderMode.HTML
-): void {
+export function runQueryCommand(query: string, name?: string): void {
   const document =
     vscode.window.activeTextEditor?.document ||
     MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
@@ -28,8 +23,7 @@ export function runQueryCommand(
     runMalloyQuery(
       { type: "string", text: query, file: document },
       `${document.uri.toString()} ${name}`,
-      name || document.uri.toString(),
-      renderMode
+      name || document.uri.toString()
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query_file.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_file.ts
@@ -12,20 +12,15 @@
  */
 
 import * as vscode from "vscode";
-import { QueryRenderMode } from "../webview_message_manager";
 import { runMalloyQuery } from "./run_query_utils";
 
-export function runQueryFileCommand(
-  queryIndex = -1,
-  renderMode: QueryRenderMode = QueryRenderMode.HTML
-): void {
+export function runQueryFileCommand(queryIndex = -1): void {
   const document = vscode.window.activeTextEditor?.document;
   if (document) {
     runMalloyQuery(
       { type: "file", index: queryIndex, file: document },
       document.uri.toString(),
-      document.fileName.split("/").pop() || document.fileName,
-      renderMode
+      document.fileName.split("/").pop() || document.fileName
     );
   }
 }

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -22,7 +22,6 @@ import { fetchFile, VSCodeURLReader } from "../utils";
 import { getWebviewHtml } from "../webviews";
 import {
   QueryMessageType,
-  QueryRenderMode,
   QueryRunStatus,
   WebviewMessageManager,
 } from "../webview_message_manager";
@@ -112,12 +111,8 @@ class HackyDataStylesAccumulator implements URLReader {
 export function runMalloyQuery(
   query: QuerySpec,
   panelId: string,
-  name: string,
-  renderMode: QueryRenderMode = QueryRenderMode.HTML
+  name: string
 ): void {
-  if (renderMode === QueryRenderMode.JSON) {
-    panelId += " Data";
-  }
   vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -273,7 +268,6 @@ export function runMalloyQuery(
             status: QueryRunStatus.Done,
             result: queryResult.toJSON(),
             styles,
-            mode: renderMode,
           });
           current.result = queryResult;
           progress.report({ increment: 100, message: "Rendering" });

--- a/packages/malloy-vscode/src/extension/webview_message_manager.ts
+++ b/packages/malloy-vscode/src/extension/webview_message_manager.ts
@@ -90,11 +90,6 @@ export enum QueryMessageType {
   AppReady = "app-ready",
 }
 
-export enum QueryRenderMode {
-  HTML = "html",
-  JSON = "json",
-}
-
 interface QueryMessageStatusCompiling {
   type: QueryMessageType.QueryStatus;
   status: QueryRunStatus.Compiling;
@@ -116,7 +111,6 @@ interface QueryMessageStatusDone {
   status: QueryRunStatus.Done;
   result: ResultJSON;
   styles: DataStyles;
-  mode: QueryRenderMode;
 }
 
 type QueryMessageStatus =

--- a/packages/malloy-vscode/src/extension/webviews/connections_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/connections_page/App.tsx
@@ -23,6 +23,7 @@ import {
 import { useConnectionsVSCodeContext } from "./connections_vscode_context";
 import { ConnectionEditorList } from "./ConnectionEditorList";
 import { Spinner } from "../components";
+import styled from "styled-components";
 
 export const App: React.FC = () => {
   const vscode = useConnectionsVSCodeContext();
@@ -96,9 +97,13 @@ export const App: React.FC = () => {
     return () => window.removeEventListener("message", listener);
   });
 
-  return (
+  return connections === undefined ? (
     <div style={{ height: "100%" }}>
-      {connections !== undefined && (
+      <Spinner text="Loading" />
+    </div>
+  ) : (
+    <Scroll>
+      <div style={{ margin: "0 10px 10px 10px" }}>
         <ConnectionEditorList
           connections={connections}
           setConnections={setConnections}
@@ -107,12 +112,12 @@ export const App: React.FC = () => {
           testStatuses={testStatuses}
           requestServiceAccountKeyPath={requestServiceAccountKeyPath}
         />
-      )}
-      {connections === undefined && (
-        <div style={{ height: "100%" }}>
-          <Spinner text="Loading" />
-        </div>
-      )}
-    </div>
+      </div>
+    </Scroll>
   );
 };
+
+const Scroll = styled.div`
+  height: 100%;
+  overflow: auto;
+`;

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -12,15 +12,19 @@
  */
 
 import { Result } from "@malloydata/malloy";
-import { HTMLView, JSONView } from "@malloydata/render";
+import { HTMLView } from "@malloydata/render";
 import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import {
   QueryMessageType,
   QueryPanelMessage,
-  QueryRenderMode,
   QueryRunStatus,
 } from "../../webview_message_manager";
 import { Spinner } from "../components";
+import { ResultKind, ResultKindToggle } from "./ResultKindToggle";
+import Prism from "prismjs";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-sql";
 
 enum Status {
   Ready = "ready",
@@ -34,8 +38,11 @@ enum Status {
 
 export const App: React.FC = () => {
   const [status, setStatus] = useState<Status>(Status.Ready);
-  const [rendered, setRendered] = useState("");
+  const [html, setHTML] = useState("");
+  const [json, setJSON] = useState("");
+  const [sql, setSQL] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
+  const [resultKind, setResultKind] = useState<ResultKind>(ResultKind.HTML);
 
   useEffect(() => {
     const listener = (event: MessageEvent<QueryPanelMessage>) => {
@@ -52,18 +59,32 @@ export const App: React.FC = () => {
           if (message.status === QueryRunStatus.Done) {
             setStatus(Status.Rendering);
             setTimeout(async () => {
-              const result = Result.fromJSON(message.result).data;
-              const rendered = await (message.mode === QueryRenderMode.HTML
-                ? new HTMLView().render(result, message.styles)
-                : new JSONView().render(result));
+              const result = Result.fromJSON(message.result);
+              const data = result.data;
+              setJSON(
+                Prism.highlight(
+                  JSON.stringify(data.toObject(), null, 2),
+                  Prism.languages["json"],
+                  "sql"
+                )
+              );
+              setSQL(
+                Prism.highlight(result.sql, Prism.languages["sql"], "sql")
+              );
+              const rendered = await new HTMLView().render(
+                data,
+                message.styles
+              );
               setStatus(Status.Displaying);
               setTimeout(() => {
-                setRendered(rendered);
+                setHTML(rendered);
                 setStatus(Status.Done);
               }, 0);
             }, 0);
           } else {
-            setRendered("");
+            setHTML("");
+            setJSON("");
+            setSQL("");
             switch (message.status) {
               case QueryRunStatus.Compiling:
                 setStatus(Status.Compiling);
@@ -80,7 +101,14 @@ export const App: React.FC = () => {
   });
 
   return (
-    <div style={{ height: "100%" }}>
+    <div
+      style={{
+        height: "100%",
+        margin: "0",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       {[
         Status.Compiling,
         Status.Running,
@@ -91,10 +119,35 @@ export const App: React.FC = () => {
       ) : (
         ""
       )}
-      <div
-        dangerouslySetInnerHTML={{ __html: rendered }}
-        style={{ padding: "10px" }}
-      ></div>
+      {!error && <ResultKindToggle kind={resultKind} setKind={setResultKind} />}
+      {!error && resultKind === ResultKind.HTML && (
+        <Scroll>
+          <div
+            dangerouslySetInnerHTML={{ __html: html }}
+            style={{ margin: "10px" }}
+          />
+        </Scroll>
+      )}
+      {!error && resultKind === ResultKind.JSON && (
+        <Scroll>
+          <PrismContainer style={{ margin: "10px" }}>
+            <div
+              dangerouslySetInnerHTML={{ __html: json }}
+              style={{ margin: "10px" }}
+            />
+          </PrismContainer>
+        </Scroll>
+      )}
+      {!error && resultKind === ResultKind.SQL && (
+        <Scroll>
+          <PrismContainer style={{ margin: "10px" }}>
+            <div
+              dangerouslySetInnerHTML={{ __html: sql }}
+              style={{ margin: "10px" }}
+            />
+          </PrismContainer>
+        </Scroll>
+      )}
       {error && <div>{error}</div>}
     </div>
   );
@@ -112,3 +165,59 @@ function getStatusLabel(status: Status) {
       return "Displaying";
   }
 }
+
+const Scroll = styled.div`
+  height: 100%;
+  overflow: auto;
+`;
+
+const PrismContainer = styled.pre`
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+  font-size: 14px;
+  color: #333388;
+
+  span.token.keyword {
+    color: #af00db;
+  }
+
+  span.token.comment {
+    color: #4f984f;
+  }
+
+  span.token.function,
+  span.token.function_keyword {
+    color: #795e26;
+  }
+
+  span.token.string {
+    color: #ca4c4c;
+  }
+
+  span.token.regular_expression {
+    color: #88194d;
+  }
+
+  span.token.operator,
+  span.token.punctuation {
+    color: #505050;
+  }
+
+  span.token.number {
+    color: #09866a;
+  }
+
+  span.token.type,
+  span.token.timeframe {
+    color: #0070c1;
+  }
+
+  span.token.date {
+    color: #09866a;
+    /* color: #8730b3; */
+  }
+
+  span.token.property {
+    color: #b98f13;
+  }
+`;

--- a/packages/malloy-vscode/src/extension/webviews/query_page/ResultKindToggle.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/ResultKindToggle.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import React from "react";
+import styled from "styled-components";
+
+export enum ResultKind {
+  HTML = "html",
+  JSON = "json",
+  SQL = "sql",
+}
+
+interface ResultKindToggleProps {
+  kind: ResultKind;
+  setKind: (kind: ResultKind) => void;
+}
+
+export const ResultKindToggle: React.FC<ResultKindToggleProps> = ({
+  kind,
+  setKind,
+}) => {
+  return (
+    <ResultControlsBar>
+      <ResultLabel>QUERY RESULTS</ResultLabel>
+      <ResultControls>
+        <ResultControl
+          data-selected={kind === ResultKind.HTML}
+          onClick={() => setKind(ResultKind.HTML)}
+        >
+          HTML
+        </ResultControl>
+        <ResultControl
+          data-selected={kind === ResultKind.JSON}
+          onClick={() => setKind(ResultKind.JSON)}
+        >
+          JSON
+        </ResultControl>
+        <ResultControl
+          data-selected={kind === ResultKind.SQL}
+          onClick={() => setKind(ResultKind.SQL)}
+        >
+          SQL
+        </ResultControl>
+      </ResultControls>
+    </ResultControlsBar>
+  );
+};
+
+const ResultControlsBar = styled.div`
+  display: flex;
+  border-bottom: 1px solid #efefef;
+  justify-content: space-between;
+  align-items: center;
+  color: #b1b1b1;
+`;
+
+const ResultLabel = styled.span`
+  font-weight: 500;
+  font-size: 12px;
+  padding: 0 10px;
+`;
+
+const ResultControls = styled.div`
+  display: flex;
+  justify-content: end;
+  padding: 5px 5px 0 5px;
+  font-size: 12px;
+  gap: 3px;
+`;
+
+const ResultControl = styled.button`
+  border: 0;
+  border-bottom: 1px solid white;
+  cursor: pointer;
+  background-color: white;
+  padding: 3px 5px;
+  color: #b1b1b1;
+
+  &:hover,
+  &[data-selected="true"] {
+    border-bottom: 1px solid #4285f4;
+    color: #4285f4;
+  }
+`;

--- a/packages/malloy-vscode/src/extension/webviews/webview_html.ts
+++ b/packages/malloy-vscode/src/extension/webviews/webview_html.ts
@@ -23,6 +23,8 @@ export function getWebviewHtml(entrySrc: string): string {
     html,body,#app {
       height: 100%;
       margin: 0;
+      padding: 0;
+      overflow: hidden;
     }
     body {
       background-color: transparent;

--- a/packages/malloy-vscode/src/server/lenses/lenses.ts
+++ b/packages/malloy-vscode/src/server/lenses/lenses.ts
@@ -47,15 +47,7 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         command: {
           title: "Run",
           command: "malloy.runNamedQuery",
-          arguments: [symbol.name, "json"],
-        },
-      });
-      lenses.push({
-        range: symbol.range.toJSON(),
-        command: {
-          title: "Render",
-          command: "malloy.runNamedQuery",
-          arguments: [symbol.name, "html"],
+          arguments: [symbol.name],
         },
       });
     } else if (symbol.type === "unnamed_query") {
@@ -64,15 +56,7 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
         command: {
           title: "Run",
           command: "malloy.runQueryFile",
-          arguments: [currentUnnamedQueryIndex, "json"],
-        },
-      });
-      lenses.push({
-        range: symbol.range.toJSON(),
-        command: {
-          title: "Render",
-          command: "malloy.runQueryFile",
-          arguments: [currentUnnamedQueryIndex, "html"],
+          arguments: [currentUnnamedQueryIndex],
         },
       });
       currentUnnamedQueryIndex++;
@@ -116,18 +100,6 @@ export function getMalloyLenses(document: TextDocument): CodeLens[] {
             range: child.range.toJSON(),
             command: {
               title: "Run",
-              command: "malloy.runQuery",
-              arguments: [
-                `query: ${exploreName}->${queryName}`,
-                `${exploreName}->${queryName}`,
-                "json",
-              ],
-            },
-          });
-          lenses.push({
-            range: child.range.toJSON(),
-            command: {
-              title: "Render",
               command: "malloy.runQuery",
               arguments: [
                 `query: ${exploreName}->${queryName}`,


### PR DESCRIPTION
Removes the "Render" code lens, and instead add HTML / SQL / JSON toggles in the webview. Defaults to HTML. SQL and JSON are currently highlighted the same way as in the docs, and does not respect the user's VSCode theme. This is because theme colors aren't passed into the webview nicely. See [here](https://stackoverflow.com/questions/55877879/vs-code-webview-css-variable-names-for-used-theme-tokencolors) and [here](https://github.com/Microsoft/vscode/issues/56356). A possible solution is to use [shiki](https://shiki.matsu.io/) which can highlight according to TextMate themes.

Closes https://github.com/looker-open-source/malloy/issues/273

<img width="1904" alt="Screen Shot 2022-01-26 at 11 36 24 AM" src="https://user-images.githubusercontent.com/3538955/151216513-4e9d2daa-9055-4ddc-96bf-4e188040780d.png">
<img width="1904" alt="Screen Shot 2022-01-26 at 11 36 28 AM" src="https://user-images.githubusercontent.com/3538955/151216497-70255f82-aaba-4560-8df2-2ac2f933b98c.png">
<img width="1904" alt="Screen Shot 2022-01-26 at 11 36 31 AM" src="https://user-images.githubusercontent.com/3538955/151216486-c98d81dd-4b0e-4b85-b955-05ab6fb520b7.png">

