### PR TITLE
keep old fields first when refining a query

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -966,7 +966,7 @@ function getRefinedFields(
   if (!exisitingFields) {
     return addingFields;
   }
-  const newFields = [...addingFields];
+  const newFields: model.QueryFieldDef[] = [];
   const newDefinition: Record<string, boolean> = {};
   for (const field of newFields) {
     const fieldName = nameOf(field);
@@ -978,6 +978,7 @@ function getRefinedFields(
       newFields.push(field);
     }
   }
+  newFields.push(...addingFields);
   return newFields;
 }
 


### PR DESCRIPTION
Fixes #310

At least I think it should. I have zero ability to write tests for things like field order in lang/ write now.