### PR TITLE
Render DOM elements, not strings

### DIFF
--- a/docs/_scripts/build_docs/run_code.ts
+++ b/docs/_scripts/build_docs/run_code.ts
@@ -32,6 +32,7 @@ import { performance } from "perf_hooks";
 import { timeString } from "./utils";
 import { log } from "./log";
 import Prism from "prismjs";
+import { JSDOM } from "jsdom";
 
 const SAMPLES_PATH = path.join(__dirname, "../../../samples");
 
@@ -223,7 +224,12 @@ export async function runCode(
     Prism.languages["json"],
     "json"
   );
-  const htmlResult = await new HTMLView().render(queryResult.data, dataStyles);
+  const document = new JSDOM().window.document;
+  const element = await new HTMLView(document).render(
+    queryResult.data,
+    dataStyles
+  );
+  const htmlResult = element.outerHTML;
   const sqlResult = Prism.highlight(
     queryResult.sql,
     Prism.languages["sql"],

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jest": "^26.6.0",
     "jest-diff": "^27.0.6",
     "jest-expect-message": "^1.0.2",
+    "jsdom": "^19.0.0",
     "md5": "^2.3.0",
     "prettier": "^2.3.2",
     "prismjs": "^1.24.1",

--- a/packages/malloy-render/src/html/bar_chart.ts
+++ b/packages/malloy-render/src/html/bar_chart.ts
@@ -18,6 +18,7 @@ import {
   ChartSize,
   StyleDefaults,
 } from "../data_styles";
+import { createErrorElement } from "./utils";
 import { HTMLVegaSpecRenderer, vegaSpecs } from "./vega_spec";
 
 function isOrdninal(field: Field): boolean {
@@ -32,18 +33,28 @@ function isOrdninal(field: Field): boolean {
 
 export class HTMLBarChartRenderer extends HTMLVegaSpecRenderer {
   size: ChartSize;
-  constructor(styleDefaults: StyleDefaults, options: BarChartRenderOptions) {
-    super(styleDefaults, vegaSpecs["bar_SM"]);
+  constructor(
+    document: Document,
+    styleDefaults: StyleDefaults,
+    options: BarChartRenderOptions
+  ) {
+    super(document, styleDefaults, vegaSpecs["bar_SM"]);
     this.size = options.size || this.styleDefaults.size || "medium";
   }
 
-  async render(table: DataColumn): Promise<string> {
+  async render(table: DataColumn): Promise<Element> {
     if (!table.isArray()) {
-      throw new Error("Invalid type for chart renderer");
+      return createErrorElement(
+        this.document,
+        "Invalid type for bar chart renderer"
+      );
     }
     const fields = table.field.intrinsicFields;
     if (fields.length < 2) {
-      return "Need at least 2 fields for a bar chart.";
+      return createErrorElement(
+        this.document,
+        "Need at least 2 fields for a bar chart."
+      );
     }
     let specName = "bar_";
     if (isOrdninal(fields[0])) {
@@ -54,7 +65,10 @@ export class HTMLBarChartRenderer extends HTMLVegaSpecRenderer {
     ) {
       specName += "N";
     } else {
-      return "Invalid type for first field of a bar_chart";
+      return createErrorElement(
+        this.document,
+        "Invalid type for first field of a bar_chart"
+      );
     }
     specName += "M";
     if (fields.length >= 3 && fields[2].isAtomicField()) {
@@ -70,7 +84,10 @@ export class HTMLBarChartRenderer extends HTMLVegaSpecRenderer {
       spec = vegaSpecs[specName];
     }
     if (spec === undefined) {
-      return `Unknown renderer ${specName}`;
+      return createErrorElement(
+        this.document,
+        `Unknown vega spec '${specName}'`
+      );
     }
     this.spec = spec;
     return super.render(table);

--- a/packages/malloy-render/src/html/chart.ts
+++ b/packages/malloy-render/src/html/chart.ts
@@ -42,11 +42,14 @@ export abstract class HTMLChartRenderer implements Renderer {
     return mappedRows;
   }
 
-  constructor(protected styleDefaults: StyleDefaults) {}
+  constructor(
+    protected readonly document: Document,
+    protected styleDefaults: StyleDefaults
+  ) {}
 
   abstract getVegaLiteSpec(data: DataArray): lite.TopLevelSpec;
 
-  async render(table: DataColumn): Promise<string> {
+  async render(table: DataColumn): Promise<Element> {
     if (!table.isArray()) {
       throw new Error("Invalid type for chart renderer");
     }
@@ -81,6 +84,8 @@ export abstract class HTMLChartRenderer implements Renderer {
       renderer: "none",
     });
     view.logger().level(-1);
-    return await view.toSVG();
+    const element = this.document.createElement("div");
+    element.innerHTML = await view.toSVG();
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/container.ts
+++ b/packages/malloy-render/src/html/container.ts
@@ -20,11 +20,16 @@ export abstract class ContainerRenderer extends RenderTree {
   childRenderers: ChildRenderers = {};
   protected abstract childrenStyleDefaults: StyleDefaults;
 
-  makeChildRenderers(explore: Explore, dataStyles: DataStyles): void {
+  makeChildRenderers(
+    explore: Explore,
+    document: Document,
+    dataStyles: DataStyles
+  ): void {
     const result: ChildRenderers = {};
     explore.intrinsicFields.forEach((field: Field) => {
       result[field.name] = makeRenderer(
         field,
+        document,
         dataStyles,
         this.childrenStyleDefaults
       );
@@ -36,12 +41,13 @@ export abstract class ContainerRenderer extends RenderTree {
   //  we need to be fully constructed before we construct
   //  our children.
   static make<Type extends ContainerRenderer>(
-    c: new () => Type,
+    c: new (document: Document) => Type,
+    document: Document,
     exploreField: Explore,
     dataStyles: DataStyles
   ): Type {
-    const n = new c();
-    n.makeChildRenderers(exploreField, dataStyles);
+    const n = new c(document);
+    n.makeChildRenderers(exploreField, document, dataStyles);
     return n;
   }
 }

--- a/packages/malloy-render/src/html/dashboard.ts
+++ b/packages/malloy-render/src/html/dashboard.ts
@@ -15,16 +15,19 @@ import { DataArrayOrRecord } from "@malloydata/malloy";
 import { StyleDefaults } from "../data_styles";
 import { ContainerRenderer } from "./container";
 import { HTMLTextRenderer } from "./text";
-import { yieldTask } from "./utils";
+import { createErrorElement, yieldTask } from "./utils";
 
 export class HTMLDashboardRenderer extends ContainerRenderer {
   protected childrenStyleDefaults: StyleDefaults = {
     size: "medium",
   };
 
-  async render(table: DataArrayOrRecord): Promise<string> {
+  async render(table: DataArrayOrRecord): Promise<Element> {
     if (!table.isArrayOrRecord()) {
-      return "Invalid data for dashboard renderer.";
+      return createErrorElement(
+        this.document,
+        "Invalid data for dashboard renderer."
+      );
     }
 
     const fields = table.field.intrinsicFields;
@@ -35,67 +38,91 @@ export class HTMLDashboardRenderer extends ContainerRenderer {
       (field) => !field.isAtomicField() || field.sourceWasMeasureLike()
     );
 
-    let renderedBody = "";
+    const body = this.document.createElement("div");
     for (const row of table) {
-      let renderedDimensions = "";
+      const dimensionsContainer = this.document.createElement("div");
+      dimensionsContainer.classList.add("dimensions");
+      dimensionsContainer.style.display = "flex";
+      dimensionsContainer.style.flexWrap = "wrap";
+      const rowElement = this.document.createElement("div");
       for (const field of dimensions) {
         const renderer = this.childRenderers[field.name];
         const rendered = await renderer.render(row.cell(field));
-        renderedDimensions += `<div style="${DIMENSION_BOX}"><div style="${DIMENSION_TITLE}">${field.name}</div><div style="${VERTICAL_CENTER}">${rendered}</div></div>\n`;
+        const renderedDimension = this.document.createElement("div");
+        renderedDimension.style.cssText = DIMENSION_BOX;
+        const dimensionTitle = this.document.createElement("div");
+        dimensionTitle.style.cssText = DIMENSION_TITLE;
+        dimensionTitle.appendChild(this.document.createTextNode(field.name));
+        const dimensionInner = this.document.createElement("div");
+        dimensionInner.style.cssText = VERTICAL_CENTER;
+        dimensionInner.appendChild(rendered);
+        renderedDimension.appendChild(dimensionTitle);
+        renderedDimension.appendChild(dimensionInner);
+        dimensionsContainer.appendChild(renderedDimension);
       }
-      let renderedMeasures = "";
+      if (dimensions.length > 0) {
+        const rowSeparatorOuter = this.document.createElement("div");
+        rowSeparatorOuter.classList.add("row-separator-outer");
+        rowSeparatorOuter.style.cssText = ROW_SEPARATOR_OUTER;
+        const rowSeparator = this.document.createElement("div");
+        rowSeparator.style.cssText = ROW_SEPARATOR;
+        rowSeparatorOuter.appendChild(rowSeparator);
+        dimensionsContainer.appendChild(rowSeparatorOuter);
+      }
+      const measuresContainer = this.document.createElement("div");
+      measuresContainer.style.cssText = MEASURE_BOXES;
       for (const field of measures) {
         const childRenderer = this.childRenderers[field.name];
         await yieldTask();
         const rendered = await childRenderer.render(row.cell(field));
         if (childRenderer instanceof HTMLDashboardRenderer) {
-          renderedMeasures += rendered;
+          measuresContainer.appendChild(rendered);
         } else if (childRenderer instanceof HTMLTextRenderer) {
-          renderedMeasures += `
-            <div style="${MEASURE_BOX}">
-              <div style="${TITLE}">${field.name}</div>
-              <div style="${VERTICAL_CENTER}">
-                <div style="${SINGLE_VALUE}">
-                  ${rendered}
-                </div>
-              </div>
-            </div>`;
+          const measureBox = this.document.createElement("div");
+          measureBox.style.cssText = MEASURE_BOX;
+          const measureTitle = this.document.createElement("div");
+          measureTitle.style.cssText = TITLE;
+          measureTitle.appendChild(this.document.createTextNode(field.name));
+          const measureInner = this.document.createElement("div");
+          measureInner.style.cssText = VERTICAL_CENTER;
+          const innerInner = this.document.createElement("div");
+          innerInner.style.cssText = SINGLE_VALUE;
+          innerInner.appendChild(rendered);
+          measureInner.appendChild(innerInner);
+          measureBox.appendChild(measureTitle);
+          measureBox.appendChild(measureInner);
+          measuresContainer.appendChild(measureBox);
         } else {
-          renderedMeasures += `
-            <div style="${MEASURE_BOX}">
-              <div style="${TITLE}">${field.name}</div>
-              <div style="${VERTICAL_CENTER}">
-                <div style="${HORIZONTAL_CENTER}">
-                  ${rendered}
-                </div>
-              </div>
-            </div>`;
+          const measureBox = this.document.createElement("div");
+          measureBox.style.cssText = MEASURE_BOX;
+          const measureTitle = this.document.createElement("div");
+          measureTitle.style.cssText = TITLE;
+          measureTitle.appendChild(this.document.createTextNode(field.name));
+          const measureInner = this.document.createElement("div");
+          measureInner.style.cssText = VERTICAL_CENTER;
+          const innerInner = this.document.createElement("div");
+          innerInner.style.cssText = HORIZONTAL_CENTER;
+          innerInner.appendChild(rendered);
+          measureInner.appendChild(innerInner);
+          measureBox.appendChild(measureTitle);
+          measureBox.appendChild(measureInner);
+          measuresContainer.appendChild(measureBox);
         }
       }
-      renderedBody += `
-          <div>
-            <div class="dimensions" style="display: flex; flex-wrap: wrap;">
-              ${renderedDimensions}
-              ${
-                dimensions.length > 0
-                  ? `<div class="row-separator-outer" style="${ROW_SEPARATOR_OUTER}"><div style="${ROW_SEPARATOR}"></div></div>`
-                  : ""
-              }
-            </div>
-            <div class="dashboard-outer" style="${DASHBOARD_OUTER}">
-              ${
-                dimensions.length > 0
-                  ? `<div class="nest-indicator" style="${NEST_INDICATOR}"></div>`
-                  : ""
-              }
-              <div style="${MEASURE_BOXES}">
-                ${renderedMeasures}
-              </div>
-            </div>
-          </div>
-      `;
+      rowElement.appendChild(dimensionsContainer);
+      const dashboardOuter = this.document.createElement("div");
+      dashboardOuter.classList.add("dashboard-outer");
+      dashboardOuter.style.cssText = DASHBOARD_OUTER;
+      if (dimensions.length > 0) {
+        const nestIndicator = this.document.createElement("div");
+        nestIndicator.style.cssText = NEST_INDICATOR;
+        dashboardOuter.appendChild(nestIndicator);
+      }
+      dashboardOuter.appendChild(measuresContainer);
+      rowElement.appendChild(dashboardOuter);
+      body.appendChild(rowElement);
     }
-    return `<div>${renderedBody}</div>`;
+    return body;
   }
 }
 

--- a/packages/malloy-render/src/html/date.ts
+++ b/packages/malloy-render/src/html/date.ts
@@ -17,22 +17,31 @@ import {
   TimestampTimeframe,
 } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
-import { timeToString } from "./utils";
+import { createErrorElement, createNullElement, timeToString } from "./utils";
 
 export class HTMLDateRenderer implements Renderer {
-  async render(data: DataColumn): Promise<string> {
+  constructor(private readonly document: Document) {}
+
+  async render(data: DataColumn): Promise<Element> {
     if (!data.isDate() && !data.isTimestamp()) {
-      return "Invalid field for date renderer";
+      return createErrorElement(
+        this.document,
+        "Invalid field for date renderer"
+      );
     }
 
     if (data.isNull()) {
-      return "∅";
+      return createNullElement(this.document);
     }
 
     const timeframe =
       data.field.timeframe ||
       (data.isTimestamp() ? TimestampTimeframe.Second : DateTimeframe.Date);
 
-    return timeToString(data.value, timeframe);
+    const timestring = timeToString(data.value, timeframe);
+
+    const element = this.document.createElement("span");
+    element.appendChild(this.document.createTextNode(timestring));
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -38,10 +38,17 @@ import { HTMLTextRenderer } from "./text";
 import { HTMLVegaSpecRenderer } from "./vega_spec";
 import { ContainerRenderer } from "./container";
 import { AtomicFieldType } from "@malloydata/malloy/src/malloy";
+import { createErrorElement } from "./utils";
 
 export class HTMLView {
-  async render(table: DataArray, dataStyles: DataStyles): Promise<string> {
-    const renderer = makeRenderer(table.field, dataStyles, {
+  private readonly document: Document;
+
+  constructor(document: Document) {
+    this.document = document;
+  }
+
+  async render(table: DataArray, dataStyles: DataStyles): Promise<Element> {
+    const renderer = makeRenderer(table.field, this.document, dataStyles, {
       size: "large",
     });
     try {
@@ -54,24 +61,36 @@ export class HTMLView {
       return await renderer.render(table);
     } catch (error) {
       if (error instanceof Error) {
-        return error.toString();
+        return createErrorElement(this.document, error);
       } else {
-        return "Internal error - Exception not an Error object.";
+        return createErrorElement(
+          this.document,
+          "Internal error - Exception not an Error object."
+        );
       }
     }
   }
 }
 
 export class JSONView {
-  async render(table: DataArray): Promise<string> {
-    const renderer = new HTMLJSONRenderer();
+  private readonly document: Document;
+
+  constructor(document: Document) {
+    this.document = document;
+  }
+
+  async render(table: DataArray): Promise<Element> {
+    const renderer = new HTMLJSONRenderer(this.document);
     try {
       return await renderer.render(table);
     } catch (error) {
       if (error instanceof Error) {
-        return error.toString();
+        return createErrorElement(this.document, error);
       } else {
-        return "Internal error - Exception not an Error object.";
+        return createErrorElement(
+          this.document,
+          "Internal error - Exception not an Error object."
+        );
       }
     }
   }
@@ -101,59 +120,66 @@ function isContainer(field: Field | Explore): Explore {
 
 export function makeRenderer(
   field: Explore | Field,
+  document: Document,
   dataStyles: DataStyles,
   styleDefaults: StyleDefaults
 ): Renderer {
   const renderDef = getRendererOptions(field, dataStyles) || {};
 
   if (renderDef.renderer === "shape_map" || field.name.endsWith("_shape_map")) {
-    return new HTMLShapeMapRenderer(styleDefaults);
+    return new HTMLShapeMapRenderer(document, styleDefaults);
   } else if (
     renderDef.renderer === "point_map" ||
     field.name.endsWith("_point_map")
   ) {
-    return new HTMLPointMapRenderer(styleDefaults);
+    return new HTMLPointMapRenderer(document, styleDefaults);
   } else if (renderDef.renderer === "image" || field.name.endsWith("_image")) {
-    return new HTMLImageRenderer();
+    return new HTMLImageRenderer(document);
   } else if (
     renderDef.renderer === "segment_map" ||
     field.name.endsWith("_segment_map")
   ) {
-    return new HTMLSegmentMapRenderer(styleDefaults);
+    return new HTMLSegmentMapRenderer(document, styleDefaults);
   } else if (
     renderDef.renderer === "dashboard" ||
     field.name.endsWith("_dashboard")
   ) {
     return ContainerRenderer.make(
       HTMLDashboardRenderer,
+      document,
       isContainer(field),
       dataStyles
     );
   } else if (renderDef.renderer === "json" || field.name.endsWith("_json")) {
-    return new HTMLJSONRenderer();
+    return new HTMLJSONRenderer(document);
   } else if (
     renderDef.renderer === "line_chart" ||
     field.name.endsWith("_line_chart")
   ) {
-    return new HTMLLineChartRenderer(styleDefaults);
+    return new HTMLLineChartRenderer(document, styleDefaults);
   } else if (
     renderDef.renderer === "scatter_chart" ||
     field.name.endsWith("_scatter_chart")
   ) {
-    return new HTMLScatterChartRenderer(styleDefaults);
+    return new HTMLScatterChartRenderer(document, styleDefaults);
   } else if (renderDef.renderer === "bar_chart") {
-    return new HTMLBarChartRenderer(styleDefaults, renderDef);
+    return new HTMLBarChartRenderer(document, styleDefaults, renderDef);
   } else if (field.name.endsWith("_bar_chart")) {
-    return new HTMLBarChartRenderer(styleDefaults, {});
+    return new HTMLBarChartRenderer(document, styleDefaults, {});
   } else if (renderDef.renderer === "vega") {
     const spec = renderDef.spec;
     if (spec) {
-      return new HTMLVegaSpecRenderer(styleDefaults, spec as TopLevelSpec);
+      return new HTMLVegaSpecRenderer(
+        document,
+        styleDefaults,
+        spec as TopLevelSpec
+      );
     } else if (renderDef.spec_name) {
       const vegaRenderer = dataStyles[renderDef.spec_name];
       if (vegaRenderer !== undefined && vegaRenderer.renderer === "vega") {
         if (vegaRenderer.spec) {
           return new HTMLVegaSpecRenderer(
+            document,
             styleDefaults,
             vegaRenderer.spec as TopLevelSpec
           );
@@ -174,32 +200,33 @@ export function makeRenderer(
         (field.type === AtomicFieldType.Date ||
           field.type === AtomicFieldType.Timestamp))
     ) {
-      return new HTMLDateRenderer();
+      return new HTMLDateRenderer(document);
     } else if (renderDef.renderer === "currency") {
-      return new HTMLCurrencyRenderer();
+      return new HTMLCurrencyRenderer(document);
     } else if (renderDef.renderer === "percent") {
-      return new HTMLPercentRenderer();
+      return new HTMLPercentRenderer(document);
     } else if (
       renderDef.renderer === "number" ||
       (field.hasParentExplore() &&
         field.isAtomicField() &&
         field.type === AtomicFieldType.Number)
     ) {
-      return new HTMLNumberRenderer();
+      return new HTMLNumberRenderer(document);
     } else if (renderDef.renderer === "bytes") {
-      return new HTMLBytesRenderer();
+      return new HTMLBytesRenderer(document);
     } else if (
       renderDef.renderer === "boolean" ||
       (field.hasParentExplore() &&
         field.isAtomicField() &&
         field.type === AtomicFieldType.Boolean)
     ) {
-      return new HTMLBooleanRenderer();
+      return new HTMLBooleanRenderer(document);
     } else if (renderDef.renderer === "link") {
-      return new HTMLLinkRenderer();
+      return new HTMLLinkRenderer(document);
     } else if (renderDef.renderer === "list" || field.name.endsWith("_list")) {
       return ContainerRenderer.make(
         HTMLListRenderer,
+        document,
         isContainer(field),
         dataStyles
       );
@@ -209,6 +236,7 @@ export function makeRenderer(
     ) {
       return ContainerRenderer.make(
         HTMLListDetailRenderer,
+        document,
         isContainer(field),
         dataStyles
       );
@@ -219,11 +247,12 @@ export function makeRenderer(
     ) {
       return ContainerRenderer.make(
         HTMLTableRenderer,
+        document,
         isContainer(field),
         dataStyles
       );
     } else {
-      return new HTMLTextRenderer();
+      return new HTMLTextRenderer(document);
     }
   }
 }

--- a/packages/malloy-render/src/html/image.ts
+++ b/packages/malloy-render/src/html/image.ts
@@ -13,17 +13,25 @@
 
 import { DataColumn } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
+import { createErrorElement, createNullElement } from "./utils";
 
 export class HTMLImageRenderer implements Renderer {
-  async render(data: DataColumn): Promise<string> {
+  constructor(private readonly document: Document) {}
+
+  async render(data: DataColumn): Promise<Element> {
     if (!data.isString()) {
-      return "Invalid field for Image renderer";
+      return createErrorElement(
+        this.document,
+        "Invalid field for Image renderer"
+      );
     }
 
     if (data.isNull()) {
-      return "∅";
+      return createNullElement(this.document);
     }
 
-    return `<img src="${data.value}">`;
+    const element = this.document.createElement("img");
+    element.src = data.value;
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/json.ts
+++ b/packages/malloy-render/src/html/json.ts
@@ -13,12 +13,20 @@
 
 import { DataColumn } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
+import { createErrorElement } from "./utils";
 
 export class HTMLJSONRenderer implements Renderer {
-  async render(table: DataColumn): Promise<string> {
+  constructor(private readonly document: Document) {}
+
+  async render(table: DataColumn): Promise<Element> {
     if (!table.isArray() && !table.isRecord()) {
-      return "Invalid data for chart renderer.";
+      createErrorElement(this.document, "Invalid data for chart renderer.");
     }
-    return `<pre>${JSON.stringify(table.value, undefined, 2)}</pre>`;
+
+    const element = this.document.createElement("pre");
+    element.appendChild(
+      this.document.createTextNode(JSON.stringify(table.value, undefined, 2))
+    );
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/link.ts
+++ b/packages/malloy-render/src/html/link.ts
@@ -13,12 +13,26 @@
 
 import { DataColumn } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
+import { createErrorElement, createNullElement } from "./utils";
 
 export class HTMLLinkRenderer implements Renderer {
-  async render(data: DataColumn): Promise<string> {
-    if (data === null) {
-      return `⌀`;
+  constructor(private readonly document: Document) {}
+
+  async render(data: DataColumn): Promise<Element> {
+    if (data.isNull()) {
+      return createNullElement(this.document);
     }
-    return `<a href="${data}">${data}</a>`;
+
+    if (!data.isString()) {
+      return createErrorElement(
+        this.document,
+        "Invalid type for link renderer."
+      );
+    }
+
+    const element = document.createElement("a");
+    element.href = data.value;
+    element.appendChild(this.document.createTextNode(data.value));
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/list.ts
+++ b/packages/malloy-render/src/html/list.ts
@@ -14,7 +14,7 @@
 import { DataColumn, Field, Explore } from "@malloydata/malloy";
 import { StyleDefaults } from "../data_styles";
 import { ContainerRenderer } from "./container";
-import { yieldTask } from "./utils";
+import { createErrorElement, yieldTask } from "./utils";
 
 export class HTMLListRenderer extends ContainerRenderer {
   protected childrenStyleDefaults: StyleDefaults = {
@@ -29,31 +29,34 @@ export class HTMLListRenderer extends ContainerRenderer {
     return undefined;
   }
 
-  async render(table: DataColumn): Promise<string> {
+  async render(table: DataColumn): Promise<Element> {
     if (!table.isArray()) {
-      return "Invalid data for chart renderer.";
+      return createErrorElement(
+        this.document,
+        "Invalid data for chart renderer."
+      );
     }
     if (table.rowCount === 0) {
-      return "⌀";
+      return this.document.createElement("span");
     }
 
     const valueField = this.getValueField(table.field);
     const detailField = this.getDetailField(table.field);
 
-    const renderedItems = [];
+    const element = this.document.createElement("span");
     for (const row of table) {
-      let renderedItem = "";
       const childRenderer = this.childRenderers[valueField.name];
       const rendered = await childRenderer.render(row.cell(valueField));
-      renderedItem += rendered;
+      element.appendChild(rendered);
       if (detailField) {
         const childRenderer = this.childRenderers[detailField.name];
         await yieldTask();
         const rendered = await childRenderer.render(row.cell(detailField));
-        renderedItem += ` (${rendered})`;
+        element.appendChild(this.document.createTextNode("("));
+        element.appendChild(rendered);
+        element.appendChild(this.document.createTextNode(")"));
       }
-      renderedItems.push(renderedItem);
     }
-    return `<span>${renderedItems.join(", ")}</span>`;
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/text.ts
+++ b/packages/malloy-render/src/html/text.ts
@@ -13,17 +13,23 @@
 
 import { DataColumn } from "@malloydata/malloy";
 import { Renderer } from "../renderer";
+import { createNullElement } from "./utils";
 
 export class HTMLTextRenderer implements Renderer {
+  constructor(private readonly document: Document) {}
+
   getText(data: DataColumn): string | null {
     return `${data.value}`;
   }
 
-  async render(data: DataColumn): Promise<string> {
+  async render(data: DataColumn): Promise<Element> {
     const text = this.getText(data);
     if (text === null) {
-      return `⌀`;
+      return createNullElement(this.document);
     }
-    return text;
+
+    const element = this.document.createElement("span");
+    element.appendChild(this.document.createTextNode(text));
+    return element;
   }
 }

--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -143,3 +143,22 @@ export async function yieldTask(): Promise<void> {
     setTimeout(resolve, 0);
   });
 }
+
+export function createErrorElement(
+  document: Document,
+  error: string | Error
+): Element {
+  const element = document.createElement("span");
+  element.classList.add("error");
+  element.appendChild(
+    document.createTextNode(typeof error === "string" ? error : error.message)
+  );
+  return element;
+}
+
+export function createNullElement(document: Document): Element {
+  const element = document.createElement("span");
+  element.appendChild(document.createTextNode("∅"));
+  element.classList.add("value-null");
+  return element;
+}

--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -404,8 +404,12 @@ export function isDataContainer(a: unknown): a is DataContainer {
 export class HTMLVegaSpecRenderer extends HTMLChartRenderer {
   spec: lite.TopLevelSpec;
 
-  constructor(styleDefaults: StyleDefaults, spec: lite.TopLevelSpec) {
-    super(styleDefaults);
+  constructor(
+    document: Document,
+    styleDefaults: StyleDefaults,
+    spec: lite.TopLevelSpec
+  ) {
+    super(document, styleDefaults);
     this.spec = spec;
   }
 

--- a/packages/malloy-render/src/renderer.ts
+++ b/packages/malloy-render/src/renderer.ts
@@ -16,11 +16,13 @@ import { DataColumn } from "@malloydata/malloy";
 export type ChildRenderers = { [fieldName: string]: Renderer };
 
 export interface Renderer {
-  render(value: DataColumn): Promise<string>;
+  render(value: DataColumn): Promise<Element>;
 }
 
 export abstract class RenderTree implements Renderer {
+  constructor(protected readonly document: Document) {}
+
   protected abstract get childRenderers(): ChildRenderers;
 
-  abstract render(value: DataColumn): Promise<string>;
+  abstract render(value: DataColumn): Promise<Element>;
 }

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -13,7 +13,7 @@
 
 import { Result } from "@malloydata/malloy";
 import { HTMLView } from "@malloydata/render";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import {
   QueryMessageType,
@@ -38,7 +38,7 @@ enum Status {
 
 export const App: React.FC = () => {
   const [status, setStatus] = useState<Status>(Status.Ready);
-  const [html, setHTML] = useState("");
+  const [html, setHTML] = useState<Element>(document.createElement("span"));
   const [json, setJSON] = useState("");
   const [sql, setSQL] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
@@ -65,7 +65,7 @@ export const App: React.FC = () => {
               setSQL(
                 Prism.highlight(result.sql, Prism.languages["sql"], "sql")
               );
-              const rendered = await new HTMLView().render(
+              const rendered = await new HTMLView(document).render(
                 data,
                 message.styles
               );
@@ -76,7 +76,7 @@ export const App: React.FC = () => {
               }, 0);
             }, 0);
           } else {
-            setHTML("");
+            setHTML(document.createElement("span"));
             setJSON("");
             setSQL("");
             switch (message.status) {
@@ -116,10 +116,9 @@ export const App: React.FC = () => {
       {!error && <ResultKindToggle kind={resultKind} setKind={setResultKind} />}
       {!error && resultKind === ResultKind.HTML && (
         <Scroll>
-          <div
-            dangerouslySetInnerHTML={{ __html: html }}
-            style={{ margin: "10px" }}
-          />
+          <div style={{ margin: "10px" }}>
+            <DOMElement element={html} />
+          </div>
         </Scroll>
       )}
       {!error && resultKind === ResultKind.JSON && (
@@ -210,3 +209,17 @@ const PrismContainer = styled.pre`
     color: #b98f13;
   }
 `;
+
+const DOMElement: React.FC<{ element: Element }> = ({ element }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const parent = ref.current;
+    if (parent) {
+      parent.innerHTML = "";
+      parent.appendChild(element);
+    }
+  }, [element]);
+
+  return <div ref={ref}></div>;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,11 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
+acorn@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -2170,6 +2175,11 @@ cssom@^0.4.4:
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
 cssom@~0.3.6:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
@@ -2455,6 +2465,15 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+data-urls@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.1.tgz#597fc2ae30f8bc4dbcf731fcd1b1954353afc6f8"
+  integrity sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==
+  dependencies:
+    abab "^2.0.3"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^10.0.0"
+
 date-fns@^2.16.1:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
@@ -2491,7 +2510,7 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decimal.js@^10.2.1:
+decimal.js@^10.2.1, decimal.js@^10.3.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
@@ -2636,6 +2655,13 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
 
 domhandler@^4.0.0, domhandler@^4.2.0:
   version "4.2.0"
@@ -3308,6 +3334,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -3650,6 +3685,13 @@ html-encoding-sniffer@^2.0.1:
   dependencies:
     whatwg-encoding "^1.0.5"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -3702,6 +3744,13 @@ iconv-lite@0.4, iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -4640,6 +4689,39 @@ jsdom@^16.4.0:
     whatwg-url "^8.5.0"
     ws "^7.4.6"
     xml-name-validator "^3.0.0"
+
+jsdom@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-19.0.0.tgz#93e67c149fe26816d38a849ea30ac93677e16b6a"
+  integrity sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==
+  dependencies:
+    abab "^2.0.5"
+    acorn "^8.5.0"
+    acorn-globals "^6.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.1"
+    decimal.js "^10.3.1"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.0"
+    parse5 "6.0.1"
+    saxes "^5.0.1"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.0.0"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^3.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^10.0.0"
+    ws "^8.2.3"
+    xml-name-validator "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -6152,7 +6234,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6781,6 +6863,13 @@ tr46@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
+  dependencies:
+    punycode "^2.1.1"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
 
@@ -7574,6 +7663,13 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+w3c-xmlserializer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz#06cdc3eefb7e4d0b20a560a5a3aeb0d2d9a65923"
+  integrity sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 wait-on@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
@@ -7602,6 +7698,11 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
 whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
@@ -7609,10 +7710,30 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-10.0.0.tgz#37264f720b575b4a311bd4094ed8c760caaa05da"
+  integrity sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"
@@ -7727,10 +7848,20 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
+ws@^8.2.3:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
+  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
 
 xml2js@^0.4.23:
   version "0.4.23"


### PR DESCRIPTION
Benefits:
* Easier to add event listeners to DOM elements than to render the string HTML into a DOM and then add event listeners afterwards
* Comparable rendering speed (in my tests, this was 1% slower on average, but I didn't do enough tests to determine whether that's actually a significant 1% or just normal variance)
* Near instantaneous display speeds
* Allows for safer rendering, using `document.createTextNode` instead of unsanitized HTML strings

The only noticeable effect of this PR should be that the "Displaying" spinner should be much faster (nearly instantaneous).