### PR TITLE
Update developing.md

### DIFF
--- a/developing.md
+++ b/developing.md
@@ -8,7 +8,7 @@ The following will install dependencies for the entire set of packages and compi
 
 ```bash
 yarn install
-yarn build-extension
+yarn package-extension
 ```
 
 ### VS Code tips

--- a/developing.md
+++ b/developing.md
@@ -24,7 +24,7 @@ The Malloy VSCode extension's source is in the `malloy-vscode` directory.
 To build and install the current version of the extension, first ensure that you've followed the steps to install the dependencies for the Malloy Repo. **Note: You will need to re-run the below any time you pull in new changes.** Then run:
 
 ```bash
-yarn build-extension
+yarn package-extension
 ```
 
 Next, in VSCode _EITHER_:


### PR DESCRIPTION
Resolves the following error:

```
[nix-shell:~/Development/malloy]$ yarn install
yarn install v1.22.17
[1/5] Validating package.json...
[2/5] Resolving packages...
success Already up-to-date.
Done in 0.42s.

[nix-shell:~/Development/malloy]$ yarn build-extension
yarn run v1.22.17
error Command "build-extension" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```