### PR TITLE
Add a strict CSP to webviews

### DIFF
--- a/packages/malloy-vscode/src/extension/commands/edit_connections.ts
+++ b/packages/malloy-vscode/src/extension/commands/edit_connections.ts
@@ -41,7 +41,7 @@ export function editConnectionsCommand(): void {
 
   const entrySrc = panel.webview.asWebviewUri(onDiskPath);
 
-  panel.webview.html = getWebviewHtml(entrySrc.toString());
+  panel.webview.html = getWebviewHtml(entrySrc.toString(), panel.webview);
 
   const messageManager = new WebviewMessageManager<ConnectionPanelMessage>(
     panel

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -180,7 +180,10 @@ export function runMalloyQuery(
 
       const entrySrc = current.panel.webview.asWebviewUri(onDiskPath);
 
-      current.panel.webview.html = getWebviewHtml(entrySrc.toString());
+      current.panel.webview.html = getWebviewHtml(
+        entrySrc.toString(),
+        current.panel.webview
+      );
 
       current.panel.onDidDispose(() => {
         current.cancel();

--- a/packages/malloy-vscode/src/extension/webview_views/help_view.ts
+++ b/packages/malloy-vscode/src/extension/webview_views/help_view.ts
@@ -42,7 +42,10 @@ export class HelpViewProvider implements vscode.WebviewViewProvider {
 
     const entrySrc = webviewView.webview.asWebviewUri(onDiskPath);
 
-    webviewView.webview.html = getWebviewHtml(entrySrc.toString());
+    webviewView.webview.html = getWebviewHtml(
+      entrySrc.toString(),
+      webviewView.webview
+    );
 
     const messageManager = new WebviewMessageManager<HelpPanelMessage>(
       webviewView

--- a/packages/malloy-vscode/src/extension/webviews/webview_html.ts
+++ b/packages/malloy-vscode/src/extension/webviews/webview_html.ts
@@ -25,7 +25,7 @@ export function getWebviewHtml(
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src ${cspSrc} https:; script-src 'nonce-${nonce}';">
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; default-src 'none'; style-src 'unsafe-inline'; img-src ${cspSrc} https:; script-src 'nonce-${nonce}';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Malloy Query Results</title>
   </head>

--- a/packages/malloy-vscode/src/extension/webviews/webview_html.ts
+++ b/packages/malloy-vscode/src/extension/webviews/webview_html.ts
@@ -11,11 +11,21 @@
  * GNU General Public License for more details.
  */
 
-export function getWebviewHtml(entrySrc: string): string {
+import * as vscode from "vscode";
+import { randomInt } from "crypto";
+
+export function getWebviewHtml(
+  entrySrc: string,
+  webview: vscode.Webview
+): string {
+  const cspSrc = webview.cspSource;
+
+  const nonce = getNonce();
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src ${cspSrc} https:; script-src 'nonce-${nonce}';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Malloy Query Results</title>
   </head>
@@ -86,6 +96,19 @@ export function getWebviewHtml(entrySrc: string): string {
       </div>
     </div>
   </body>
-  <script src="${entrySrc}"></script>
+  <script nonce="${nonce}" src="${entrySrc}"></script>
 </html>`;
+}
+
+const NONCE_CHARACTERS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomNonceCharacter() {
+  return NONCE_CHARACTERS.charAt(
+    Math.floor(randomInt(0, NONCE_CHARACTERS.length))
+  );
+}
+
+function getNonce() {
+  return Array.from({ length: 32 }, randomNonceCharacter).join("");
 }


### PR DESCRIPTION
Adds the following CSP directives to all webviews in the VSCode extension:
* `default-src 'none'`

  Makes all of [child-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src), [connect-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src), [font-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src), [frame-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src), [img-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src), [manifest-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src), [media-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/media-src), [object-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src), [prefetch-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src), [script-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src), [script-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem), [script-src-attr](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr), [style-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src), [style-src-elem](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem), [style-src-attr](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr), [worker-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src) default to `'none'`.

  This makes `object-src 'none'` unnecessary.

  `style-src`, `img-src`, and `script-src` are overridden below.
* `style-src 'unsafe-inline'` 

  Allow inline styles.

* `img-src https://*.vscode-webview.net https:` 

  Allow images provided from the extension and loaded via HTTPS.

* `script-src 'nonce-{random}'`

  Allow scripts that have the correct nonce, which is generated at random (using a [secure random](https://nodejs.org/api/crypto.html#cryptorandomintmin-max-callback)) whenever a webview is created.

* `base-uri 'none'`

  Disables `<base>` URIs, which prevents attackers from changing the locations of scripts loaded from relative URLs.