### PR TITLE
Make `rowLimit` a standard connection option, and use it if a query has a limit

### DIFF
--- a/docs/_scripts/build_docs/run_code.ts
+++ b/docs/_scripts/build_docs/run_code.ts
@@ -125,7 +125,7 @@ class DocsURLReader implements URLReader {
 }
 
 const BIGQUERY_CONNECTION = new BigQueryConnection("bigquery", {
-  pageSize: 5,
+  rowLimit: 5,
 });
 
 function resolveSourcePath(sourcePath: string) {
@@ -199,7 +199,7 @@ export async function runCode(
     sqlRunner: {
       runSQL: (sql: string) =>
         BIGQUERY_CONNECTION.runSQL(sql, {
-          pageSize: options.pageSize || 5,
+          rowLimit: options.pageSize || 5,
         }),
     },
     preparedResult,

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -172,7 +172,9 @@ export class BigQueryConnection extends Connection {
     sqlCommand: string,
     options: Partial<BigQueryQueryOptions> = {}
   ): Promise<MalloyQueryData> {
-    const { pageSize, rowIndex } = { ...this.readQueryOptions(), ...options };
+    const defaultOptions = this.readQueryOptions();
+    const pageSize = options.pageSize ?? defaultOptions.pageSize;
+    const rowIndex = options.rowIndex ?? defaultOptions.rowIndex;
     const hash = crypto
       .createHash("md5")
       .update(sqlCommand)

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -47,8 +47,7 @@ export interface BigQueryManagerOptions {
 }
 
 export interface BigQueryQueryOptions {
-  pageSize: number;
-  rowIndex: number;
+  rowLimit: number;
 }
 
 interface BigQueryConnectionConfiguration {
@@ -92,8 +91,7 @@ const maybeRewriteError = (e: Error | unknown): Error => {
 // manage access to BQ, control costs, enforce global data/API limits
 export class BigQueryConnection extends Connection {
   static DEFAULT_QUERY_OPTIONS: BigQueryQueryOptions = {
-    pageSize: 10,
-    rowIndex: 0,
+    rowLimit: 10,
   };
 
   private bigQuery: BigQuerySDK;
@@ -170,11 +168,11 @@ export class BigQueryConnection extends Connection {
 
   public async runSQL(
     sqlCommand: string,
-    options: Partial<BigQueryQueryOptions> = {}
+    options: Partial<BigQueryQueryOptions> = {},
+    rowIndex = 0
   ): Promise<MalloyQueryData> {
     const defaultOptions = this.readQueryOptions();
-    const pageSize = options.pageSize ?? defaultOptions.pageSize;
-    const rowIndex = options.rowIndex ?? defaultOptions.rowIndex;
+    const pageSize = options.rowLimit ?? defaultOptions.rowLimit;
     const hash = crypto
       .createHash("md5")
       .update(sqlCommand)

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -218,7 +218,7 @@ export class PostgresConnection extends Connection {
 
   public async runSQL(
     sqlCommand: string,
-    pageSize?: number,
+    { pageSize }: { pageSize?: number } = {},
     rowIndex = 0
   ): Promise<MalloyQueryData> {
     const config = await this.readQueryConfig();
@@ -234,7 +234,7 @@ export class PostgresConnection extends Connection {
     }
     result = await this.runPostgresQuery(
       sqlCommand,
-      pageSize || config.pageSize || DEFAULT_PAGE_SIZE,
+      pageSize ?? config.pageSize ?? DEFAULT_PAGE_SIZE,
       rowIndex,
       true
     );

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -51,7 +51,7 @@ const postgresToMalloyTypes: { [key: string]: AtomicFieldType } = {
 };
 
 interface PostgresQueryConfiguration {
-  pageSize?: number;
+  rowLimit?: number;
 }
 
 type PostgresQueryConfigurationReader =
@@ -205,7 +205,7 @@ export class PostgresConnection extends Connection {
     const config = await this.readQueryConfig();
     const queryData = await this.runPostgresQuery(
       query,
-      config.pageSize || DEFAULT_PAGE_SIZE,
+      config.rowLimit || DEFAULT_PAGE_SIZE,
       0,
       false
     );
@@ -218,14 +218,14 @@ export class PostgresConnection extends Connection {
 
   public async runSQL(
     sqlCommand: string,
-    { pageSize }: { pageSize?: number } = {},
+    { rowLimit }: { rowLimit?: number } = {},
     rowIndex = 0
   ): Promise<MalloyQueryData> {
     const config = await this.readQueryConfig();
     const hash = crypto
       .createHash("md5")
       .update(sqlCommand)
-      .update(String(pageSize))
+      .update(String(rowLimit))
       .update(String(rowIndex))
       .digest("hex");
     let result;
@@ -234,7 +234,7 @@ export class PostgresConnection extends Connection {
     }
     result = await this.runPostgresQuery(
       sqlCommand,
-      pageSize ?? config.pageSize ?? DEFAULT_PAGE_SIZE,
+      rowLimit ?? config.rowLimit ?? DEFAULT_PAGE_SIZE,
       rowIndex,
       true
     );

--- a/packages/malloy-vscode/src/common/connection_manager.ts
+++ b/packages/malloy-vscode/src/common/connection_manager.ts
@@ -48,7 +48,7 @@ export class ConnectionManager {
       map.set(
         "bigquery",
         new BigQueryConnection("bigquery", () => ({
-          pageSize: this.getCurrentRowLimit(),
+          rowLimit: this.getCurrentRowLimit(),
         }))
       );
       defaultName = "bigquery";
@@ -81,7 +81,7 @@ export class ConnectionManager {
       case ConnectionBackend.BigQuery:
         return new BigQueryConnection(
           connectionConfig.name,
-          () => ({ pageSize: this.getCurrentRowLimit() }),
+          () => ({ rowLimit: this.getCurrentRowLimit() }),
           {
             defaultProject: connectionConfig.projectName,
             serviceAccountKeyPath: connectionConfig.serviceAccountKeyPath,
@@ -109,7 +109,7 @@ export class ConnectionManager {
         };
         return new PostgresConnection(
           connectionConfig.name,
-          () => ({ pageSize: this.getCurrentRowLimit() }),
+          () => ({ rowLimit: this.getCurrentRowLimit() }),
           configReader
         );
       }

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -232,8 +232,10 @@ export function runMalloyQuery(
             );
           }
 
+          let preparedResult;
           try {
-            const sql = await queryMaterializer.getSQL();
+            preparedResult = await queryMaterializer.getPreparedResult();
+            const sql = preparedResult.sql;
             styles = { ...styles, ...files.getHackyAccumulatedDataStyles() };
 
             if (canceled) return;
@@ -257,7 +259,10 @@ export function runMalloyQuery(
             status: QueryRunStatus.Running,
           });
           progress.report({ increment: 40, message: "Running" });
-          const queryResult = await queryMaterializer.run();
+          const queryResult = await queryMaterializer.run({
+            // Set the page size to the limit provided in the final stage of the query, if present
+            pageSize: preparedResult.resultExplore.limit,
+          });
           if (canceled) return;
 
           const runEnd = performance.now();

--- a/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
+++ b/packages/malloy-vscode/src/extension/commands/run_query_utils.ts
@@ -260,8 +260,8 @@ export function runMalloyQuery(
           });
           progress.report({ increment: 40, message: "Running" });
           const queryResult = await queryMaterializer.run({
-            // Set the page size to the limit provided in the final stage of the query, if present
-            pageSize: preparedResult.resultExplore.limit,
+            // Set the row limit to the limit provided in the final stage of the query, if present
+            rowLimit: preparedResult.resultExplore.limit,
           });
           if (canceled) return;
 

--- a/packages/malloy/src/connection.ts
+++ b/packages/malloy/src/connection.ts
@@ -54,7 +54,7 @@ export abstract class Connection
 
   abstract runSQL(
     sqlCommand: string,
-    options?: { pageSize?: number }
+    options?: { rowLimit?: number }
   ): Promise<MalloyQueryData>;
 
   abstract test(): Promise<void>;

--- a/packages/malloy/src/connection.ts
+++ b/packages/malloy/src/connection.ts
@@ -52,7 +52,10 @@ export abstract class Connection
 
   abstract executeSQLRaw(sqlCommand: string): Promise<QueryData>;
 
-  abstract runSQL(sqlCommand: string): Promise<MalloyQueryData>;
+  abstract runSQL(
+    sqlCommand: string,
+    options?: { pageSize?: number }
+  ): Promise<MalloyQueryData>;
 
   abstract test(): Promise<void>;
 

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -234,7 +234,7 @@ export class Malloy {
   }: {
     lookupSQLRunner: LookupSQLRunner;
     preparedResult: PreparedResult;
-    options?: { pageSize?: number };
+    options?: { rowLimit?: number };
   }): Promise<Result>;
   public static async run({
     sqlRunner,
@@ -243,7 +243,7 @@ export class Malloy {
   }: {
     sqlRunner: SQLRunner;
     preparedResult: PreparedResult;
-    options?: { pageSize?: number };
+    options?: { rowLimit?: number };
   }): Promise<Result>;
   public static async run({
     sqlRunner,
@@ -254,7 +254,7 @@ export class Malloy {
     sqlRunner?: SQLRunner;
     lookupSQLRunner?: LookupSQLRunner;
     preparedResult: PreparedResult;
-    options?: { pageSize?: number };
+    options?: { rowLimit?: number };
   }): Promise<Result> {
     if (sqlRunner === undefined) {
       if (lookupSQLRunner === undefined) {
@@ -1851,7 +1851,7 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    *
    * @returns The query results from running this loaded query.
    */
-  async run(options?: { pageSize?: number }): Promise<Result> {
+  async run(options?: { rowLimit?: number }): Promise<Result> {
     const lookupSQLRunner = this.runtime.lookupSQLRunner;
     const preparedResult = await this.getPreparedResult();
     return Malloy.run({ lookupSQLRunner, preparedResult, options });

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -230,25 +230,31 @@ export class Malloy {
   public static async run({
     lookupSQLRunner,
     preparedResult,
+    options,
   }: {
     lookupSQLRunner: LookupSQLRunner;
     preparedResult: PreparedResult;
+    options?: { pageSize?: number };
   }): Promise<Result>;
   public static async run({
     sqlRunner,
     preparedResult,
+    options,
   }: {
     sqlRunner: SQLRunner;
     preparedResult: PreparedResult;
+    options?: { pageSize?: number };
   }): Promise<Result>;
   public static async run({
     sqlRunner,
     lookupSQLRunner,
     preparedResult,
+    options,
   }: {
     sqlRunner?: SQLRunner;
     lookupSQLRunner?: LookupSQLRunner;
     preparedResult: PreparedResult;
+    options?: { pageSize?: number };
   }): Promise<Result> {
     if (sqlRunner === undefined) {
       if (lookupSQLRunner === undefined) {
@@ -260,7 +266,7 @@ export class Malloy {
         preparedResult.connectionName
       );
     }
-    const result = await sqlRunner.runSQL(preparedResult.sql);
+    const result = await sqlRunner.runSQL(preparedResult.sql, options);
     return new Result(
       {
         ...preparedResult._rawQuery,
@@ -1845,10 +1851,10 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
    *
    * @returns The query results from running this loaded query.
    */
-  async run(): Promise<Result> {
+  async run(options?: { pageSize?: number }): Promise<Result> {
     const lookupSQLRunner = this.runtime.lookupSQLRunner;
     const preparedResult = await this.getPreparedResult();
-    return Malloy.run({ lookupSQLRunner, preparedResult });
+    return Malloy.run({ lookupSQLRunner, preparedResult, options });
   }
 
   /**

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -108,10 +108,14 @@ export interface SQLRunner {
    * Run some SQL and yield results.
    *
    * @param sql The SQL to run.
+   * @param options.pageSize Maximum number of results to return at once.
    * @returns The rows of data resulting from running the given SQL query
    * and the total number of rows available.
    */
-  runSQL(sql: string): Promise<MalloyQueryData>;
+  runSQL(
+    sql: string,
+    options?: { pageSize?: number }
+  ): Promise<MalloyQueryData>;
 }
 
 /**

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -114,7 +114,7 @@ export interface SQLRunner {
    */
   runSQL(
     sql: string,
-    options?: { pageSize?: number }
+    options?: { rowLimit?: number }
   ): Promise<MalloyQueryData>;
 }
 


### PR DESCRIPTION
This makes the `Connection` interface require that `runSQL` can take an optional second parameter of type `{ rowLimit?: number }`. The implication here is that all Malloy connections must allow for `rowLimit` to be provided.

This also makes the VSCode extension respect any limit on the last stage of a pipeline when running queries. E.g. `query: flights -> { project: * }` will still use whatever `rowLimit` is set in the user/workspace configuration, but `query: flights -> { project: *; limit: 1000 }` will use a page size of 100. The thinking here is that it's less surprising to users, so when they run a query with a high limit, they actually get what they asked for. 

Fixes https://github.com/looker-open-source/malloy/issues/290

