### PR TITLE
md5 or md5sum based on OS

### DIFF
--- a/packages/malloy/src/lang/grammar/build-parser.sh
+++ b/packages/malloy/src/lang/grammar/build-parser.sh
@@ -20,7 +20,13 @@ lib="../lib/Malloy"
 digest=$lib/Malloy.md5
 target=$lib/MalloyParser.ts
 
-newmd5=`md5 Malloy.g4`
+# Decide which md5 command to use based on OS
+if [[ "$(uname -a)" == Linux*  ]]; then
+  newmd5=`md5sum Malloy.g4`
+else
+  newmd5=`md5 Malloy.g4`
+fi
+
 oldmd5="--MISSING-DIGEST--"
 if [  -e $digest ]; then
   oldmd5=`cat $digest`


### PR DESCRIPTION
Fixes the following issue on Linux systems, which use `md5sum` instead of `md5`:

```
[nix-shell:~/Development/malloy]$ yarn build
yarn run v1.22.17
$ yarn workspace @malloydata/malloy build-parser && yarn tsc --build
$ (cd src/lang/grammar ; sh build-parser.sh)
build-parser.sh: line 23: md5: command not found
```