### PR TITLE
Exit build-parser.sh Upon Failure

### DIFF
--- a/packages/malloy/src/lang/grammar/build-parser.sh
+++ b/packages/malloy/src/lang/grammar/build-parser.sh
@@ -16,6 +16,9 @@
 # BUG: If you go in $lib and delete a file which isn't MalloyParser.ts
 # this hack will fail. yarn clean will fix things though.
 
+# Exit immediately with a non-zero status code if any lines fail
+set -e
+
 lib="../lib/Malloy"
 digest=$lib/Malloy.md5
 target=$lib/MalloyParser.ts

--- a/packages/malloy/src/lang/grammar/build-parser.sh
+++ b/packages/malloy/src/lang/grammar/build-parser.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,18 +16,18 @@
 # BUG: If you go in $lib and delete a file which isn't MalloyParser.ts
 # this hack will fail. yarn clean will fix things though.
 
-# Exit immediately with a non-zero status code if any lines fail
 set -e
-
 lib="../lib/Malloy"
 digest=$lib/Malloy.md5
 target=$lib/MalloyParser.ts
 
-# Decide which md5 command to use based on OS
-if [[ "$(uname -a)" == Linux*  ]]; then
-  newmd5=`md5sum Malloy.g4`
-else
+if command -v md5sum > /dev/null; then
+  newmd5=`md5_sum Malloy.g4`
+elif command -v md5 > /dev/null; then
   newmd5=`md5 Malloy.g4`
+else
+  echo "build_parser: MD5 checksum program not found, assuming rebuild"
+  newmd5=`date`
 fi
 
 oldmd5="--MISSING-DIGEST--"

--- a/packages/malloy/src/lang/grammar/build-parser.sh
+++ b/packages/malloy/src/lang/grammar/build-parser.sh
@@ -38,7 +38,6 @@ if [ ! -r $target ]; then
   oldmd5="--MISSING-PARSER--"
 fi
 
-
 if [ "$oldmd5" != "$newmd5" ]; then
   antlr4ts -visitor -o $lib Malloy.g4 && echo $newmd5 > $digest
 else

--- a/packages/malloy/src/lang/grammar/build-parser.sh
+++ b/packages/malloy/src/lang/grammar/build-parser.sh
@@ -22,7 +22,7 @@ digest=$lib/Malloy.md5
 target=$lib/MalloyParser.ts
 
 if command -v md5sum > /dev/null; then
-  newmd5=`md5_sum Malloy.g4`
+  newmd5=`md5sum Malloy.g4 | cut -d" " -f1`
 elif command -v md5 > /dev/null; then
   newmd5=`md5 Malloy.g4`
 else
@@ -37,6 +37,7 @@ fi
 if [ ! -r $target ]; then
   oldmd5="--MISSING-PARSER--"
 fi
+
 
 if [ "$oldmd5" != "$newmd5" ]; then
   antlr4ts -visitor -o $lib Malloy.g4 && echo $newmd5 > $digest


### PR DESCRIPTION
Before this patch, as long as the last command in the file succeeded, build-parser.sh would exit with a zero status code. With this change, the script will exit immediately with a non-zero status code if any constituent line fails.

---

Before fix:

```
[nix-shell:~/Development/malloy]$ yarn build
yarn run v1.22.17
$ yarn workspace @malloydata/malloy build-parser && yarn tsc --build
$ (cd src/lang/grammar ; sh build-parser.sh)
build-parser.sh: line 23: md5: command not found
ANTLR parser ../lib/Malloy/MalloyParser.ts is up to date
$ /usr/local/google/home/aryehh/Development/malloy/node_modules/.bin/tsc --build
Done in 0.88s.

[nix-shell:~/Development/malloy]$ echo $?
0
```

After fix:

```
 % sh ./packages/malloy/src/lang/grammar/build-parser.sh 
./packages/malloy/src/lang/grammar/build-parser.sh: line 26: md5: command not found
aryehh@aryeh ~/Development/malloy
 % echo $?
127
```