### PR TITLE
Refactor SQL definitions to use SQLBlock interface

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -539,7 +539,7 @@ export class BigQueryConnection extends Connection {
 
     for (const sqlRef of sqlRefs) {
       // TODO feature-sql-block sqlRef key should not be nullable here
-      const key = sqlRef.digest;
+      const key = sqlRef.name;
       let inCache = this.sqlSchemaCache.get(key);
       if (!inCache) {
         const tableFieldSchema = await this.getSQLBlockSchema(sqlRef);

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -32,7 +32,7 @@ import {
   FieldTypeDef,
   NamedStructDefs,
   Connection,
-  SQLReferenceData,
+  SQLBlock,
 } from "@malloydata/malloy";
 import { parseTableURL } from "@malloydata/malloy";
 import { PooledConnection } from "@malloydata/malloy";
@@ -482,16 +482,17 @@ export class BigQueryConnection extends Connection {
   }
 
   private structDefFromSQLSchema(
-    sqlRef: SQLReferenceData,
+    sqlBlock: SQLBlock,
     tableFieldSchema: bigquery.ITableFieldSchema
   ): StructDef {
     const structDef: StructDef = {
       type: "struct",
-      name: sqlRef.sql[0],
+      name: sqlBlock.select,
       dialect: this.dialectName,
       structSource: {
         type: "sql",
         method: "subquery",
+        sqlBlock,
       },
       structRelationship: { type: "basetable", connectionName: this.name },
       fields: [],
@@ -517,10 +518,10 @@ export class BigQueryConnection extends Connection {
     return tableStructDefs;
   }
 
-  private async getSQLBlockSchema(sqlRef: SQLReferenceData) {
+  private async getSQLBlockSchema(sqlRef: SQLBlock) {
     const [job] = await this.bigQuery.createQueryJob({
       location: this.config.location || "US",
-      query: sqlRef.sql.join(""), // TODO feature-sql-block Why is this a list of strings instead of just one?
+      query: sqlRef.select,
       dryRun: true,
     });
 
@@ -532,13 +533,13 @@ export class BigQueryConnection extends Connection {
   }
 
   public async fetchSchemaForSQLBlocks(
-    sqlRefs: SQLReferenceData[]
+    sqlRefs: SQLBlock[]
   ): Promise<NamedStructDefs> {
     const tableStructDefs: NamedStructDefs = {};
 
     for (const sqlRef of sqlRefs) {
       // TODO feature-sql-block sqlRef key should not be nullable here
-      const key = sqlRef.key || "foo";
+      const key = sqlRef.digest;
       let inCache = this.sqlSchemaCache.get(key);
       if (!inCache) {
         const tableFieldSchema = await this.getSQLBlockSchema(sqlRef);

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -487,7 +487,7 @@ export class BigQueryConnection extends Connection {
   ): StructDef {
     const structDef: StructDef = {
       type: "struct",
-      name: sqlBlock.select,
+      name: sqlBlock.name,
       dialect: this.dialectName,
       structSource: {
         type: "sql",

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -180,7 +180,7 @@ export class PostgresConnection extends Connection {
     const structDef: StructDef = {
       type: "struct",
       dialect: "postgres",
-      name: sqlRef.select,
+      name: sqlRef.name,
       structSource: {
         type: "sql",
         method: "subquery",

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -136,7 +136,7 @@ export class PostgresConnection extends Connection {
   ): Promise<NamedStructDefs> {
     const tableStructDefs: NamedStructDefs = {};
     for (const sqlRef of sqlStructs) {
-      const key = sqlRef.digest;
+      const key = sqlRef.name;
       let inCache = this.sqlSchemaCache.get(key);
       if (!inCache) {
         inCache = await this.getSQLBlockSchema(sqlRef);

--- a/packages/malloy/src/connection.ts
+++ b/packages/malloy/src/connection.ts
@@ -21,8 +21,8 @@ import {
   MalloyQueryData,
   NamedStructDefs,
   QueryData,
+  SQLBlock,
 } from "./model/malloy_types";
-import { SQLReferenceData } from "./lang/parse-malloy";
 
 export interface PooledConnection {
   // Most pool implementations require a specific call to release connection handles. If a Connection is a
@@ -62,7 +62,7 @@ export abstract class Connection
   ): Promise<NamedStructDefs>;
 
   public abstract fetchSchemaForSQLBlocks(
-    sqlRefs: SQLReferenceData[]
+    sqlStructs: SQLBlock[]
   ): Promise<NamedStructDefs>;
 
   /*

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -34,7 +34,7 @@ export {
   // Needed for tests only
   MalloyTranslator,
 } from "./lang";
-export type { LogMessage, TranslateResponse, SQLDef } from "./lang";
+export type { LogMessage, TranslateResponse } from "./lang";
 export {
   Malloy,
   Runtime,

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -26,6 +26,7 @@ export type {
   FieldTypeDef,
   // Needed for drills in render
   FilterExpression,
+  SQLBlock,
 } from "./model";
 export {
   // Neede for VSCode extension
@@ -33,7 +34,7 @@ export {
   // Needed for tests only
   MalloyTranslator,
 } from "./lang";
-export type { LogMessage, TranslateResponse, SQLReferenceData } from "./lang";
+export type { LogMessage, TranslateResponse, SQLDef } from "./lang";
 export {
   Malloy,
   Runtime,

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -31,7 +31,7 @@ defineQuery
   ;
 
 defineSQLStatement
-  : SQL (sqlCommandNameDef IS)? sqlText+ (ON connectionName)?
+  : SQL (sqlCommandNameDef IS)? sqlBlock (ON connectionName)?
   ;
 
 importStatement
@@ -419,7 +419,7 @@ jsonArray
    | OBRACK CBRACK
    ;
 
-sqlText: SQL_STRING;
+sqlBlock: SQL_STRING;
 sqlExploreNameRef: id;
 sqlCommandNameDef: id;
 connectionName: JSON_STRING;

--- a/packages/malloy/src/lang/index.ts
+++ b/packages/malloy/src/lang/index.ts
@@ -17,8 +17,8 @@ export type {
   UpdateData,
   SchemaData,
   URLData,
-  SQLSchemaData,
-  SQLReferenceData,
+  SQLStructData,
+  SQLDef,
 } from "./parse-malloy";
 export { exploreQueryWalkerBuilder } from "./parse-tree-walkers/explore-query-walker";
 export type { ExploreClauseRef } from "./parse-tree-walkers/explore-query-walker";

--- a/packages/malloy/src/lang/index.ts
+++ b/packages/malloy/src/lang/index.ts
@@ -18,7 +18,6 @@ export type {
   SchemaData,
   URLData,
   SQLStructData,
-  SQLDef,
 } from "./parse-malloy";
 export { exploreQueryWalkerBuilder } from "./parse-tree-walkers/explore-query-walker";
 export type { ExploreClauseRef } from "./parse-tree-walkers/explore-query-walker";

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -25,6 +25,7 @@ import {
   NamedStructDefs,
   StructDef,
   ModelDef,
+  SQLBlock,
 } from "../model/malloy_types";
 import { MalloyLexer } from "./lib/Malloy/MalloyLexer";
 import { MalloyParser } from "./lib/Malloy/MalloyParser";
@@ -33,7 +34,6 @@ import { MalloyToAST } from "./parse-to-ast";
 import { MessageLogger, LogMessage, MessageLog } from "./parse-log";
 import { findReferences } from "./parse-tree-walkers/find-external-references";
 import { Zone, ZoneData } from "./zone";
-import md5 from "md5";
 import {
   DocumentSymbol,
   walkForDocumentSymbols,
@@ -44,6 +44,7 @@ import {
   passForHighlights,
   sortHighlights,
 } from "./parse-tree-walkers/document-highlight-walker";
+import { Range } from "./source-reference";
 
 class ParseErrorHandler implements ANTLRErrorListener<Token> {
   constructor(readonly sourceURL: string, readonly messages: MessageLogger) {}
@@ -95,35 +96,44 @@ export interface NeedURLData {
   urls: string[];
 }
 
-export interface SQLReferenceData {
-  sql: string[];
-  connection?: string;
-  key?: string;
-}
-
 /**
- * The "key" for one of these is a connection name and an SQL string,
- * so we hash those to make a unique key for the Zone code which
- * really wants keys to be strings ...
+ * An SQL Block contains a unique key inside it, and we use that to
+ * reference and define blocks, since Zone really wants keys to be strings.
+ *
+ * If I had SQLBlocks when Zones were defined, this would not be
+ * a one off class, it would be Zone<keyType,valueType>
  */
 export class SQLExploreZone extends Zone<StructDef> {
-  keyed: Record<string, SQLReferenceData> = {};
-  refKey(ref: SQLReferenceData): string {
-    const key = md5(JSON.stringify(ref));
-    this.keyed[key] = ref;
-    ref.key = key;
-    return key;
+  keyed: Record<string, SQLBlock> = {};
+
+  referenceBlock(from: ast.SQLStatement, at: Range): void {
+    const sql = from.sqlBlock();
+    this.reference(sql.digest, at);
+    this.keyed[sql.digest] = sql;
+  }
+
+  getUndefinedBlocks(): SQLBlock[] | undefined {
+    const blockRefs = this.getUndefined();
+    if (blockRefs) {
+      return blockRefs.map((ref) => this.keyed[ref]);
+    }
+    return undefined;
   }
 }
 
-export interface NeedSQLSchema {
-  sqlRefs: SQLReferenceData[];
+export interface NeedSQLStruct {
+  sqlStructs: SQLBlock[];
 }
 
-interface NeededData extends NeedURLData, NeedSchemaData, NeedSQLSchema {}
+export interface SQLDef extends SQLBlock {
+  type: "sql";
+  name: string;
+}
+
+interface NeededData extends NeedURLData, NeedSchemaData, NeedSQLStruct {}
 export type DataRequestResponse = Partial<NeededData> | null;
 function isNeedResponse(dr: DataRequestResponse): dr is NeededData {
-  return !!dr && (dr.tables || dr.urls || dr.sqlRefs) != undefined;
+  return !!dr && (dr.tables || dr.urls || dr.sqlStructs) != undefined;
 }
 
 interface ASTData extends ErrorResponse, NeededData, FinalResponse {
@@ -137,7 +147,7 @@ interface Metadata extends NeededData, ErrorResponse, FinalResponse {
 }
 type MetadataResponse = Partial<Metadata>;
 
-export interface SQLBlock extends SQLReferenceData {
+export interface SQLDef extends SQLBlock {
   type: "sql";
   name: string;
 }
@@ -149,7 +159,7 @@ interface TranslatedResponseData
   translated: {
     modelDef: ModelDef;
     queryList: Query[];
-    sqlBlockList: SQLBlock[];
+    sqlDefs: SQLDef[];
   };
 }
 
@@ -440,20 +450,17 @@ class ASTStep implements TranslationStep {
     for (const sqlExploreRef in sqlExplores) {
       const sqlExplore = sqlExplores[sqlExploreRef];
       if (sqlExplore.ref && sqlExplore.def) {
-        const sqlRef: SQLReferenceData = {
-          sql: sqlExplore.def.stmts,
-          connection: sqlExplore.def.connectionName,
-        };
-        const refKey = sqlZone.refKey(sqlRef);
-        that.root.sqlQueryZone.reference(refKey, sqlExplore.def.location);
+        that.root.sqlQueryZone.referenceBlock(
+          sqlExplore.def,
+          sqlExplore.def.location
+        );
       }
     }
 
     // TODO report errors from here!
-    const missingSqlSchema = sqlZone.getUndefined();
-    if (missingSqlSchema) {
-      const sqlRefs = missingSqlSchema.map((key) => sqlZone.keyed[key]);
-      return { sqlRefs };
+    const missingSqlStructs = sqlZone.getUndefinedBlocks();
+    if (missingSqlStructs) {
+      return { sqlStructs: missingSqlStructs };
     }
 
     newAst.setTranslator(that);
@@ -535,7 +542,7 @@ class TranslateStep implements TranslationStep {
         const doc = astResponse.ast;
         that.modelDef = doc.getModelDef(extendingModel);
         that.queryList = doc.queryList;
-        that.sqlBlockList = doc.sqlBlockList;
+        that.sqlDefs = doc.sqlDefs;
       } else {
         that.root.logger.log({
           sourceURL: that.sourceURL,
@@ -551,7 +558,7 @@ class TranslateStep implements TranslationStep {
         translated: {
           modelDef: that.modelDef,
           queryList: that.queryList,
-          sqlBlockList: that.sqlBlockList,
+          sqlDefs: that.sqlDefs,
         },
         ...that.errors(),
         final: true,
@@ -566,7 +573,7 @@ export abstract class MalloyTranslation {
   childTranslators: Map<string, MalloyTranslation>;
   urlIsFullPath?: boolean;
   queryList: Query[] = [];
-  sqlBlockList: SQLBlock[] = [];
+  sqlDefs: SQLDef[] = [];
   modelDef: ModelDef;
 
   readonly parseStep: ParseStep;
@@ -722,14 +729,14 @@ export class MalloyTranslator extends MalloyTranslation {
   update(dd: ParseUpdate): void {
     this.schemaZone.updateFrom(dd.tables, dd.errors?.tables);
     this.importZone.updateFrom(dd.urls, dd.errors?.urls);
-    this.sqlQueryZone.updateFrom(dd.sqlRefs, dd.errors?.sqlRefs);
+    this.sqlQueryZone.updateFrom(dd.sqlStructs, dd.errors?.sqlStructs);
   }
 }
 
 interface ErrorData {
   tables: Record<string, string>;
   urls: Record<string, string>;
-  sqlRefs: Record<string, string>;
+  sqlStructs: Record<string, string>;
 }
 
 export interface URLData {
@@ -738,10 +745,10 @@ export interface URLData {
 export interface SchemaData {
   tables: ZoneData<StructDef>;
 }
-export interface SQLSchemaData {
-  sqlRefs: ZoneData<StructDef>;
+export interface SQLStructData {
+  sqlStructs: ZoneData<StructDef>;
 }
-export interface UpdateData extends URLData, SchemaData, SQLSchemaData {
+export interface UpdateData extends URLData, SchemaData, SQLStructData {
   errors: Partial<ErrorData>;
 }
 export type ParseUpdate = Partial<UpdateData>;

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -108,8 +108,8 @@ export class SQLExploreZone extends Zone<StructDef> {
 
   referenceBlock(from: ast.SQLStatement, at: Range): void {
     const sql = from.sqlBlock();
-    this.reference(sql.digest, at);
-    this.keyed[sql.digest] = sql;
+    this.reference(sql.name, at);
+    this.keyed[sql.name] = sql;
   }
 
   getUndefinedBlocks(): SQLBlock[] | undefined {
@@ -123,11 +123,6 @@ export class SQLExploreZone extends Zone<StructDef> {
 
 export interface NeedSQLStruct {
   sqlStructs: SQLBlock[];
-}
-
-export interface SQLDef extends SQLBlock {
-  type: "sql";
-  name: string;
 }
 
 interface NeededData extends NeedURLData, NeedSchemaData, NeedSQLStruct {}
@@ -147,11 +142,6 @@ interface Metadata extends NeededData, ErrorResponse, FinalResponse {
 }
 type MetadataResponse = Partial<Metadata>;
 
-export interface SQLDef extends SQLBlock {
-  type: "sql";
-  name: string;
-}
-
 interface TranslatedResponseData
   extends NeededData,
     ErrorResponse,
@@ -159,7 +149,7 @@ interface TranslatedResponseData
   translated: {
     modelDef: ModelDef;
     queryList: Query[];
-    sqlDefs: SQLDef[];
+    sqlBlocks: SQLBlock[];
   };
 }
 
@@ -542,7 +532,7 @@ class TranslateStep implements TranslationStep {
         const doc = astResponse.ast;
         that.modelDef = doc.getModelDef(extendingModel);
         that.queryList = doc.queryList;
-        that.sqlDefs = doc.sqlDefs;
+        that.sqlBlocks = doc.sqlBlocks;
       } else {
         that.root.logger.log({
           sourceURL: that.sourceURL,
@@ -558,7 +548,7 @@ class TranslateStep implements TranslationStep {
         translated: {
           modelDef: that.modelDef,
           queryList: that.queryList,
-          sqlDefs: that.sqlDefs,
+          sqlBlocks: that.sqlBlocks,
         },
         ...that.errors(),
         final: true,
@@ -573,7 +563,7 @@ export abstract class MalloyTranslation {
   childTranslators: Map<string, MalloyTranslation>;
   urlIsFullPath?: boolean;
   queryList: Query[] = [];
-  sqlDefs: SQLDef[] = [];
+  sqlBlocks: SQLBlock[] = [];
   modelDef: ModelDef;
 
   readonly parseStep: ParseStep;

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -1078,6 +1078,10 @@ export class MalloyToAST
       select: commands.slice(2, commands.length - 2),
       connection: this.optionalText(pcx.connectionName()),
     });
+    const nameCx = pcx.sqlCommandNameDef();
+    if (nameCx) {
+      sqlStmt.is = this.getIdText(nameCx);
+    }
     return this.astAt(sqlStmt, pcx);
   }
 }

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -1073,13 +1073,11 @@ export class MalloyToAST
   visitDefineSQLStatement(
     pcx: parse.DefineSQLStatementContext
   ): ast.SQLStatement {
-    const commands = pcx.sqlText().map((cx) => {
-      const fullMatch = cx.text;
-      return fullMatch.slice(2, fullMatch.length - 2);
+    const commands = pcx.sqlBlock().text;
+    const sqlStmt = new ast.SQLStatement({
+      select: commands.slice(2, commands.length - 2),
+      connection: this.optionalText(pcx.connectionName()),
     });
-    const sqlStmt = new ast.SQLStatement(commands);
-    sqlStmt.is = this.optionalText(pcx.sqlCommandNameDef());
-    sqlStmt.connectionName = this.optionalText(pcx.connectionName());
     return this.astAt(sqlStmt, pcx);
   }
 }

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -606,7 +606,7 @@ describe("sql backdoor", () => {
       expect(needs.length).toBe(1);
       const sql = makeSQLBlock({ select: " SELECT * FROM aTable " });
       expect(needs[0]).toMatchObject(sql);
-      const refKey = needs[0].digest;
+      const refKey = needs[0].name;
       expect(refKey).toBeDefined();
       if (refKey) {
         model.update({

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -607,7 +607,7 @@ describe("sql backdoor", () => {
       explore: malloyUsers is from_sql(users) { primary_key: ai }
     `);
     expect(model).toBeErrorless();
-    const needs = model.translate()?.sqlRefs;
+    const needs = model.translate()?.sqlStructs;
     expect(needs).toBeDefined();
     if (needs) {
       expect(needs.length).toBe(1);
@@ -615,11 +615,11 @@ describe("sql backdoor", () => {
         sql: [" SELECT * FROM aTable "],
         connection: undefined,
       });
-      const refKey = needs[0].key;
+      const refKey = needs[0].digest;
       expect(refKey).toBeDefined();
       if (refKey) {
         model.update({
-          sqlRefs: { [refKey]: aTableDef },
+          sqlStructs: { [refKey]: aTableDef },
         });
         expect(model).toCompile();
       }

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -17,7 +17,6 @@ import {
   DocumentSymbol as DocumentSymbolDefinition,
   LogMessage,
   MalloyTranslator,
-  SQLDef,
 } from "./lang";
 import {
   CompiledQuery,
@@ -167,7 +166,7 @@ export class Malloy {
           return new Model(
             result.translated.modelDef,
             result.translated.queryList,
-            result.translated.sqlDefs
+            result.translated.sqlBlocks
           );
         } else {
           const errors = result.errors || [];
@@ -360,16 +359,16 @@ export class MalloyError extends Error {
 export class Model {
   private modelDef: ModelDef;
   private queryList: InternalQuery[];
-  private sqlDefs: SQLDef[];
+  private sqlBlocks: SQLBlock[];
 
   constructor(
     modelDef: ModelDef,
     queryList: InternalQuery[],
-    sqlDefs: SQLDef[]
+    sqlBlocks: SQLBlock[]
   ) {
     this.modelDef = modelDef;
     this.queryList = queryList;
-    this.sqlDefs = sqlDefs;
+    this.sqlBlocks = sqlBlocks;
   }
 
   /**

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2925,7 +2925,7 @@ class QueryStruct extends QueryNode {
         if (this.fieldDef.structSource.method === "nested") {
           return this.fieldDef.name;
         } else if (this.fieldDef.structSource.method === "subquery") {
-          return `(${this.fieldDef.name})`;
+          return `(${this.fieldDef.structSource.sqlBlock.select})`;
         }
         throw new Error(
           "Internal Error: Unknown structSource type 'sql' method"

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -432,13 +432,28 @@ export type StructRelationship =
   | { type: "inline" }
   | { type: "nested"; field: FieldRef };
 
+export interface SQLBlock {
+  before?: string[];
+  select: string;
+  after?: string[];
+  digest: string; // digest/name is a hash of the connection and the select
+  connection?: string;
+}
+
+interface SubquerySource {
+  type: "sql";
+  method: "subquery";
+  sqlBlock: SQLBlock;
+}
+
 /** where does the struct come from? */
 export type StructSource =
   | { type: "table"; tablePath?: string }
   | { type: "nested" }
   | { type: "inline" }
   | { type: "query"; query: Query }
-  | { type: "sql"; method: "nested" | "subquery" };
+  | { type: "sql"; method: "nested" }
+  | SubquerySource;
 
 // Inline and nested tables, cannot have a StructRelationship
 //  the relationshipo is implied

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -432,11 +432,16 @@ export type StructRelationship =
   | { type: "inline" }
   | { type: "nested"; field: FieldRef };
 
-export interface SQLBlock {
+/**
+ * Use factory makeSQLBlock to create one of these, it will compute the
+ * name: property and fill it in.
+ */
+export interface SQLBlock extends AliasedName {
+  type: "sqlBlock";
+  name: string; //  hash of the connection and the select
   before?: string[];
   select: string;
   after?: string[];
-  digest: string; // digest/name is a hash of the connection and the select
   connection?: string;
 }
 

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -26,7 +26,8 @@ export interface SQLBlockRequest extends Partial<SQLBlock> {
  */
 export function makeSQLBlock(from: SQLBlockRequest): SQLBlock {
   const theBlock: SQLBlock = {
-    digest: `md5:/${from.connection || "$default"}//${md5(from.select)}`,
+    type: "sqlBlock",
+    name: `md5:/${from.connection || "$default"}//${md5(from.select)}`,
     select: from.select,
   };
   if (from.before) {

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import { SQLBlock } from "./malloy_types";
+import md5 from "md5";
+
+/**
+ * SQLBlockRequest does not have a digest in it
+ */
+export interface SQLBlockRequest extends Partial<SQLBlock> {
+  select: string;
+}
+
+/**
+ * The factory for SQLBlocks.
+ */
+export function makeSQLBlock(from: SQLBlockRequest): SQLBlock {
+  const theBlock: SQLBlock = {
+    digest: `md5:/${from.connection || "$default"}//${md5(from.select)}`,
+    select: from.select,
+  };
+  if (from.before) {
+    theBlock.before = from.before;
+  }
+  if (from.after) {
+    theBlock.after = from.after;
+  }
+  return theBlock;
+}

--- a/packages/malloy/src/runtime_types.ts
+++ b/packages/malloy/src/runtime_types.ts
@@ -11,8 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { SQLReferenceData } from "./lang/parse-malloy";
-import { MalloyQueryData, StructDef } from "./model";
+import { MalloyQueryData, SQLBlock, StructDef } from "./model";
 
 /**
  * A URL.
@@ -91,7 +90,7 @@ export interface SchemaReader {
 
   // TODO comment
   fetchSchemaForSQLBlocks(
-    sqlRefs: SQLReferenceData[]
+    sqlStructs: SQLBlock[]
   ): Promise<Record<string, StructDef>>;
 }
 


### PR DESCRIPTION
This is a lot of renames, so it touches a lot of files. Formalizes the use of SQL and refactors a bit to aim at a future where SQL blocks have sections.

An `SQLBLock` is ...

```
/**
 * Use factory makeSQLBlock to create one of these, it will compute the
 * name: property and fill it in.
 */
export interface SQLBlock extends AliasedName {
  type: "sqlBlock";
  name: string; //  hash of the connection and the select
  before?: string[];
  select: string;
  after?: string[];
  connection?: string;
}
```

and the list of all `sql:` statements from a translator run are available in the `sqlBlocks:` property of the translation ...

AND ...

The translator, for defs which are used as explores (structs) ... there is an `sqlStructs:` response which asks for a structdef for the SQLBlocks which are used in explores.

A structDef which comes from SQL looks like

```
{
  type: "struct",
  name: == sqlBlock.name
  structSource: {
    type: "sql";
    method: "subquery"l
    sqlBlock: SQLBlock
}
```
 