### PR TITLE
Allow `unsafe-eval` for now, because vega uses it

### DIFF
--- a/packages/malloy-vscode/src/extension/webviews/webview_html.ts
+++ b/packages/malloy-vscode/src/extension/webviews/webview_html.ts
@@ -25,7 +25,7 @@ export function getWebviewHtml(
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; default-src 'none'; style-src 'unsafe-inline'; img-src ${cspSrc} https:; script-src 'nonce-${nonce}';">
+    <meta http-equiv="Content-Security-Policy" content="base-uri 'none'; default-src 'none'; style-src 'unsafe-inline'; img-src ${cspSrc} https:; script-src 'nonce-${nonce}' 'unsafe-eval';">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Malloy Query Results</title>
   </head>


### PR DESCRIPTION
Vega uses `eval`: https://github.com/vega/vega/issues/1106