### PR TITLE
Fix infinite loop when source file is empty string

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -234,7 +234,7 @@ class ParseStep implements TranslationStep {
       }
     }
     let source = that.root.importZone.get(that.sourceURL);
-    if (!source) {
+    if (source === undefined) {
       return { urls: [that.sourceURL] };
     }
     if (source == "") {


### PR DESCRIPTION
Fixes an issue where if an empty string is passed to the translator as the source for a URL, then the translator asks for that URL again, due to a bad check (`!thing` vs `thing === undefined`).