### PR TITLE
better heuristic for query type

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 import { URL } from "url";
-import { cloneDeep, ThrottleSettings } from "lodash";
+import { cloneDeep } from "lodash";
 import * as model from "../../model/malloy_types";
 import { Segment as ModelQuerySegment } from "../../model/malloy_query";
 import {
@@ -1317,6 +1317,7 @@ export class QOPDesc extends ListOf<QueryProperty> {
       } else if (
         el instanceof Nests ||
         el instanceof NestDefinition ||
+        el instanceof NestReference ||
         el instanceof GroupBy
       ) {
         firstGuess ||= "grouping";
@@ -1340,7 +1341,9 @@ export class QOPDesc extends ListOf<QueryProperty> {
       firstGuess = "grouping";
     }
     if (!firstGuess) {
-      this.log("Query must contain group_by:, aggregate:, or project:");
+      this.log(
+        "Can't determine query type (group_by/aggregate/nest,project,index)"
+      );
     }
     const guessType = firstGuess || "grouping";
     this.opType = guessType;

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1314,7 +1314,11 @@ export class QOPDesc extends ListOf<QueryProperty> {
         if (firstGuess !== "index") {
           el.log(`index: not legal in ${firstGuess} query`);
         }
-      } else if (el instanceof GroupBy) {
+      } else if (
+        el instanceof Nests ||
+        el instanceof NestDefinition ||
+        el instanceof GroupBy
+      ) {
         firstGuess ||= "grouping";
         anyGrouping = true;
         if (firstGuess === "project" || firstGuess === "index") {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -674,7 +674,7 @@ describe("error handling", () => {
     const errList = m.errors().errors;
     const firstError = errList[0];
     expect(firstError.message).toBe(
-      "Query must contain group_by:, aggregate:, or project:"
+      "Can't determine query type (group_by/aggregate/nest,project,index)"
     );
   });
   test("refine can't change query type", () => {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -71,7 +71,7 @@ function checkForErrors(trans: Testable) {
     };
   }
   return {
-    message: () => "Translation resulted in no errors",
+    message: () => "Unexpected error free translation",
     pass: true,
   };
 }
@@ -659,6 +659,17 @@ describe("error handling", () => {
     );
   });
   test("empty document", modelOK("\n"));
+  test("query without fields", () => {
+    const m = new BetaModel(`
+      query: a -> { top: 5 }
+    `);
+    expect(m).not.toCompile();
+    const errList = m.errors().errors;
+    const firstError = errList[0];
+    expect(firstError.message).toBe(
+      "Query must contain group_by:, aggregate:, or project:"
+    );
+  });
   // test("queries with anonymous expressions", () => {
   //   const m = new BetaModel("query: a->{\n group_by: a+1\n}");
   //   expect(m).not.toCompile();

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -218,6 +218,13 @@ describe("model statements", () => {
         query: a -> { aggregate: f is count() } -> { project: f2 is f + 1 }
       `)
     );
+    test(
+      "refine and extend query",
+      modelOK(`
+        query: a_by_str is a -> { group_by: astr }
+        query: -> a_by_str { aggregate: str_count is count() }
+      `)
+    );
   });
   describe("import:", () => {
     test("simple import", () => {
@@ -669,6 +676,15 @@ describe("error handling", () => {
     expect(firstError.message).toBe(
       "Query must contain group_by:, aggregate:, or project:"
     );
+  });
+  test("refine can't change query type", () => {
+    const m = new BetaModel(`
+      query: ab -> aturtle { project: astr }
+    `);
+    expect(m).not.toCompile();
+    const errList = m.errors().errors;
+    const firstError = errList[0];
+    expect(firstError.message).toBe("project: not legal in grouping query");
   });
   // test("queries with anonymous expressions", () => {
   //   const m = new BetaModel("query: a->{\n group_by: a+1\n}");


### PR DESCRIPTION
Fixes #358

... and many other errors which were waiting for us once we started writing more complex models.

* Error on a query which has no fields (and so can't deduce the type)
* Deduction uses item being refined as the starting guess instead of undefined
* Errors if a refinement attempts to change the query type
* Deduction smarter and more correct.