### PR TITLE
Fix/improve error locations

### DIFF
--- a/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
+++ b/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
@@ -77,7 +77,7 @@ export async function getMalloyDiagnostics(
 
     diagnostics.push({
       severity: sev,
-      range: err.range || DEFAULT_RANGE,
+      range: err.at?.range || DEFAULT_RANGE,
       message: err.message,
       source: "malloy",
     });

--- a/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
+++ b/packages/malloy-vscode/src/server/diagnostics/diagnostics.ts
@@ -34,6 +34,11 @@ async function magicGetTheFile(
   }
 }
 
+const DEFAULT_RANGE = {
+  start: { line: 0, character: 0 },
+  end: { line: 0, character: Number.MAX_VALUE },
+};
+
 export async function getMalloyDiagnostics(
   documents: TextDocuments<TextDocument>,
   document: TextDocument
@@ -55,10 +60,7 @@ export async function getMalloyDiagnostics(
       // TODO this kind of error should cease to exist. All errors should have source info.
       diagnostics.push({
         severity: DiagnosticSeverity.Error,
-        range: {
-          start: { line: 0, character: 0 },
-          end: { line: 0, character: Number.MAX_VALUE },
-        },
+        range: DEFAULT_RANGE,
         message: error.message,
         source: "malloy",
       });
@@ -75,16 +77,7 @@ export async function getMalloyDiagnostics(
 
     diagnostics.push({
       severity: sev,
-      range: {
-        start: {
-          line: (err.begin?.line || 1) - 1,
-          character: err.begin?.char || 0,
-        },
-        end: {
-          line: (err.end?.line || err.begin?.line || 1) - 1,
-          character: err.end?.char || Number.MAX_VALUE,
-        },
-      },
+      range: err.range || DEFAULT_RANGE,
       message: err.message,
       source: "malloy",
     });

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -23,7 +23,7 @@ import {
   QueryFieldSpace,
   IndexFieldSpace,
 } from "../field-space";
-import { LogMessage, MessageLogger } from "../parse-log";
+import { MessageLogger } from "../parse-log";
 import { MalloyTranslation } from "../parse-malloy";
 import {
   compressExpr,
@@ -180,13 +180,9 @@ export abstract class MalloyElement {
     return trans?.sourceURL || "(missing)";
   }
 
-  log(logString: string): void {
+  log(message: string): void {
     const trans = this.translator();
-    const msg: LogMessage = {
-      url: this.location.url,
-      range: this.location.range,
-      message: logString,
-    };
+    const msg = { ...this.location, message };
     const logTo = trans?.root.logger;
     if (logTo) {
       logTo.log(msg);

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1140,9 +1140,11 @@ class ReduceExecutor implements QueryExecutor {
   }
 
   execute(qp: QueryProperty): void {
-    if (!this.handle(qp)) {
-      qp.log("Illegal statement in a group_by/aggregate query operation");
-    }
+    this.handle(qp);
+    // Errors should have already been reported computeType()
+    // if (!this.handle(qp)) {
+    //   qp.log("Illegal statement in a group_by/aggregate query operation");
+    // }
   }
 
   refineFrom(from: model.QuerySegment | undefined, to: model.QuerySegment) {

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -183,14 +183,10 @@ export abstract class MalloyElement {
   log(logString: string): void {
     const trans = this.translator();
     const msg: LogMessage = {
-      sourceURL: this.sourceURL,
+      url: this.location.url,
+      range: this.location.range,
       message: logString,
     };
-    const loc = this.location;
-    if (loc) {
-      msg.begin = loc.range.start;
-      msg.end = loc.range.end;
-    }
     const logTo = trans?.root.logger;
     if (logTo) {
       logTo.log(msg);

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -182,7 +182,7 @@ export abstract class MalloyElement {
 
   log(message: string): void {
     const trans = this.translator();
-    const msg = { ...this.location, message };
+    const msg = { at: this.location, message };
     const logTo = trans?.root.logger;
     if (logTo) {
       logTo.log(msg);

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -11,25 +11,16 @@
  * GNU General Public License for more details.
  */
 
-import { DocumentRange } from "../model";
-
-export interface SourcePosition {
-  line: number;
-  char?: number;
-}
+import { DocumentLocation } from "../model/malloy_types";
 
 type LogSeverity = "error" | "warn" | "debug";
 
 /**
- * All errors are guaranteed to have a message, many errors will have a
- * start position, some errors will have an end position.
- *
- * "severity" is not required and defaults to "error"
+ * Default severity is "error"
  */
 export interface LogMessage {
   message: string;
-  url: string;
-  range?: DocumentRange;
+  at?: DocumentLocation;
   severity?: LogSeverity;
 }
 
@@ -50,7 +41,7 @@ export class MessageLog implements MessageLogger {
   }
 
   log(logMsg: LogMessage): void {
-    this.rawLog.push({ ...logMsg });
+    this.rawLog.push(logMsg);
   }
 
   reset(): void {

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -11,6 +11,8 @@
  * GNU General Public License for more details.
  */
 
+import { DocumentRange } from "../model";
+
 export interface SourcePosition {
   line: number;
   char?: number;
@@ -25,10 +27,9 @@ type LogSeverity = "error" | "warn" | "debug";
  * "severity" is not required and defaults to "error"
  */
 export interface LogMessage {
-  sourceURL: string;
   message: string;
-  begin?: SourcePosition;
-  end?: SourcePosition;
+  url: string;
+  range?: DocumentRange;
   severity?: LogSeverity;
 }
 
@@ -49,15 +50,7 @@ export class MessageLog implements MessageLogger {
   }
 
   log(logMsg: LogMessage): void {
-    const xMsg = { ...logMsg };
-    if (
-      xMsg.end &&
-      xMsg.end.line === xMsg.begin?.line &&
-      xMsg.end.char === xMsg.begin?.char
-    ) {
-      delete xMsg.end;
-    }
-    this.rawLog.push(xMsg);
+    this.rawLog.push({ ...logMsg });
   }
 
   reset(): void {

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -669,13 +669,13 @@ export abstract class MalloyTranslation {
             }
           }
           if (lineMap[this.sourceURL]) {
-            const errorLine = lineMap[this.sourceURL][lineNo - 1];
-            cooked = `line ${lineNo}: ${entry.message}\n  | ${errorLine}`;
+            const errorLine = lineMap[this.sourceURL][lineNo];
+            cooked = `line ${lineNo + 1}: ${entry.message}\n  | ${errorLine}`;
             if (charFrom > 0) {
               cooked = cooked + `\n  | ${" ".repeat(charFrom)}^`;
             }
           } else {
-            cooked = `line ${lineNo}: char ${charFrom}: ${entry.message}`;
+            cooked = `line ${lineNo + 1}: char ${charFrom}: ${entry.message}`;
           }
         }
       }

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -52,7 +52,6 @@ export class MalloyToAST
    */
   protected astError(el: ast.MalloyElement, str: string): void {
     this.msgLog.log({
-      sourceURL: this.parse.sourceURL,
       message: str,
       ...el.location,
     });
@@ -63,19 +62,10 @@ export class MalloyToAST
    */
   protected contextError(cx: ParserRuleContext, msg: string): void {
     const error: LogMessage = {
-      sourceURL: this.parse.sourceURL,
+      url: this.parse.sourceURL,
       message: msg,
-      begin: {
-        line: cx.start.line,
-        char: cx.start.charPositionInLine,
-      },
+      range: Source.rangeFromContext(cx),
     };
-    if (cx.stop) {
-      error.end = {
-        line: cx.stop.line,
-        char: cx.stop.charPositionInLine,
-      };
-    }
     this.msgLog.log(error);
   }
 

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -17,7 +17,7 @@ import { AbstractParseTreeVisitor } from "antlr4ts/tree/AbstractParseTreeVisitor
 import { MalloyVisitor } from "./lib/Malloy/MalloyVisitor";
 import * as parse from "./lib/Malloy/MalloyParser";
 import * as ast from "./ast";
-import { LogMessage, MessageLogger } from "./parse-log";
+import { MessageLogger } from "./parse-log";
 import * as Source from "./source-reference";
 import { MalloyParseRoot } from "./parse-malloy";
 
@@ -51,22 +51,17 @@ export class MalloyToAST
    * Log an error message relative to an AST node
    */
   protected astError(el: ast.MalloyElement, str: string): void {
-    this.msgLog.log({
-      message: str,
-      ...el.location,
-    });
+    this.msgLog.log({ message: str, at: el.location });
   }
 
   /**
    * Log an error message relative to a parse node
    */
   protected contextError(cx: ParserRuleContext, msg: string): void {
-    const error: LogMessage = {
-      url: this.parse.sourceURL,
+    this.msgLog.log({
       message: msg,
-      range: Source.rangeFromContext(cx),
-    };
-    this.msgLog.log(error);
+      at: { url: this.parse.sourceURL, range: Source.rangeFromContext(cx) },
+    });
   }
 
   protected onlyExploreProperties(

--- a/packages/malloy/src/lang/source-reference.ts
+++ b/packages/malloy/src/lang/source-reference.ts
@@ -22,19 +22,21 @@ export function rangeFromTokens(
   startToken: Token,
   stopToken: Token
 ): DocumentRange {
-  return {
-    start: {
-      line: startToken.line - 1,
-      character: startToken.charPositionInLine,
-    },
-    end: {
-      line: stopToken.line - 1,
-      character:
-        stopToken.stopIndex -
-        (stopToken.startIndex - stopToken.charPositionInLine) +
-        1,
-    },
+  const start = {
+    line: startToken.line - 1,
+    character: startToken.charPositionInLine,
   };
+  const end =
+    stopToken.stopIndex == -1
+      ? start
+      : {
+          line: stopToken.line - 1,
+          character:
+            stopToken.stopIndex -
+            (stopToken.startIndex - stopToken.charPositionInLine) +
+            1,
+        };
+  return { start, end };
 }
 
 export function rangeFromToken(token: Token): DocumentRange {

--- a/packages/malloy/src/lang/source-reference.ts
+++ b/packages/malloy/src/lang/source-reference.ts
@@ -11,15 +11,21 @@
  * GNU General Public License for more details.
  */
 
-import { ParserRuleContext } from "antlr4ts";
+import { ParserRuleContext, Token } from "antlr4ts";
 import { DocumentRange } from "../model/malloy_types";
 
 export function rangeFromContext(pcx: ParserRuleContext): DocumentRange {
-  const stopToken = pcx.stop || pcx.start;
+  return rangeFromTokens(pcx.start, pcx.stop || pcx.start);
+}
+
+export function rangeFromTokens(
+  startToken: Token,
+  stopToken: Token
+): DocumentRange {
   return {
     start: {
-      line: pcx.start.line - 1,
-      character: pcx.start.charPositionInLine,
+      line: startToken.line - 1,
+      character: startToken.charPositionInLine,
     },
     end: {
       line: stopToken.line - 1,
@@ -29,4 +35,8 @@ export function rangeFromContext(pcx: ParserRuleContext): DocumentRange {
         1,
     },
   };
+}
+
+export function rangeFromToken(token: Token): DocumentRange {
+  return rangeFromTokens(token, token);
 }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -154,7 +154,7 @@ export class TestTranslator extends MalloyTranslator {
       if (whatImports) {
         mysterious = false;
         this.logger.log({
-          url: "test://",
+          at: this.defaultLocation(),
           message: `Missing imports: ${whatImports.join(",")}`,
         });
       }
@@ -162,13 +162,13 @@ export class TestTranslator extends MalloyTranslator {
       if (needThese) {
         mysterious = false;
         this.logger.log({
-          url: "test://",
+          at: this.defaultLocation(),
           message: `Missing schema: ${needThese.join(",")}`,
         });
       }
       if (mysterious) {
         this.logger.log({
-          url: "test://",
+          at: this.defaultLocation(),
           message: "mysterious translation failure",
         });
       }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -154,7 +154,7 @@ export class TestTranslator extends MalloyTranslator {
       if (whatImports) {
         mysterious = false;
         this.logger.log({
-          sourceURL: "test://",
+          url: "test://",
           message: `Missing imports: ${whatImports.join(",")}`,
         });
       }
@@ -162,13 +162,13 @@ export class TestTranslator extends MalloyTranslator {
       if (needThese) {
         mysterious = false;
         this.logger.log({
-          sourceURL: "test://",
+          url: "test://",
           message: `Missing schema: ${needThese.join(",")}`,
         });
       }
       if (mysterious) {
         this.logger.log({
-          sourceURL: "test://",
+          url: "test://",
           message: "mysterious translation failure",
         });
       }

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -225,13 +225,15 @@ export function getJoinField(structDef: StructDef, name: string) {
   return getField(structDef, name) as StructDef;
 }
 
+export interface MarkedSource {
+  code: string;
+  locations: DocumentLocation[];
+}
+
 export function markSource(
   unmarked: TemplateStringsArray,
   ...marked: string[]
-): {
-  code: string;
-  locations: DocumentLocation[];
-} {
+): MarkedSource {
   let code = "";
   const locations: DocumentLocation[] = [];
   for (let index = 0; index < marked.length; index++) {

--- a/packages/malloy/src/lang/zone.ts
+++ b/packages/malloy/src/lang/zone.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { DocumentRange } from "../model/malloy_types";
+import { DocumentLocation } from "../model/malloy_types";
 
 export type ZoneData<TValue> = Record<string, TValue>;
 
@@ -19,7 +19,7 @@ type EntryStatus = "present" | "reference" | "error";
 
 interface AllEntries {
   status: EntryStatus;
-  firstReference?: DocumentRange;
+  firstReference?: DocumentLocation;
 }
 
 interface EntryPresent<T> extends AllEntries {
@@ -29,7 +29,7 @@ interface EntryPresent<T> extends AllEntries {
 
 interface ReferenceEntry {
   status: "reference";
-  firstReference: DocumentRange;
+  firstReference: DocumentLocation;
 }
 
 interface EntryErrored extends AllEntries {
@@ -48,7 +48,7 @@ type ZoneEntry<T> = EntryPresent<T> | ReferenceEntry | EntryErrored;
  */
 export class Zone<TValue> {
   zone: Map<string, ZoneEntry<TValue>>;
-  location: Record<string, DocumentRange> = {};
+  location: Record<string, DocumentLocation> = {};
   constructor() {
     this.zone = new Map<string, ZoneEntry<TValue>>();
   }
@@ -85,7 +85,7 @@ export class Zone<TValue> {
    * @param str The symbol
    * @param loc The location of the reference
    */
-  reference(str: string, loc: DocumentRange): void {
+  reference(str: string, loc: DocumentLocation): void {
     const zst = this.zone.get(str);
     if (zst?.status == undefined) {
       this.zone.set(str, { status: "reference", firstReference: loc });


### PR DESCRIPTION
This PR attaches correct (or at least, more correct) locations to errors. Firstly, it fixes an issue from https://github.com/looker-open-source/malloy/pull/364 where semantic errors appeared on the line before they were supposed to. It also adjusts the location of syntax errors to only include the offending token, and not the offending token plus the rest of that line.