### PR TITLE
fix error handling for join errors

### DIFF
--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -31,6 +31,7 @@ import {
   MalloyElement,
   NestReference,
   FieldReference,
+  ErrorFactory,
 } from "./ast";
 import {
   SpaceField,
@@ -323,8 +324,10 @@ export class NewFieldSpace extends StructSpace {
       for (const [fieldName, field] of reorderFields) {
         if (field instanceof JoinSpaceField && field.join.needsFixup()) {
           const joinStruct = field.join.structDef();
-          this.final.fields.push(joinStruct);
-          fixupJoins.push([field.join, joinStruct]);
+          if (!ErrorFactory.isErrorStructdef(joinStruct)) {
+            this.final.fields.push(joinStruct);
+            fixupJoins.push([field.join, joinStruct]);
+          }
         } else {
           const fieldDef = field.fieldDef();
           if (fieldDef) {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -712,7 +712,7 @@ describe("sql backdoor", () => {
 describe("error handling", () => {
   test(
     "query reference to undefined explore",
-    badModel("query: x->{ group_by: y }", "Undefined data source 'x'")
+    badModel("query: x->{ group_by: y }", "Undefined source 'x'")
   );
   test(
     "join reference before definition",
@@ -721,7 +721,7 @@ describe("error handling", () => {
         explore: newAB is a { join_one: newB is bb on astring }
         explore: newB is b
       `,
-      "Undefined data source 'bb'"
+      "Undefined source 'bb'"
     )
   );
   test(
@@ -765,6 +765,16 @@ describe("error handling", () => {
   //   const firstError = errList[0];
   //   expect(firstError.message).toBe("Expressions in queries must have names");
   // });
+  test(
+    "query on source with errors",
+    modelErrors(
+      markSource`
+        explore: na is a { join_one: ${"n"} on astr }
+        // query: na -> { project: * }
+      `,
+      "Undefined source 'n'"
+    )
+  );
 });
 
 function getSelectOneStruct(sqlBlock: SQLBlock): StructDef {


### PR DESCRIPTION
Fixes #387

Don't add error-causing objects to models or explores. This stops the
"ErrorFactory" structdef from being used.

Don't report duplicate errors against same object. Now that a bad join
turns into an undefined join, don't report that undefined join
more than once per reference.