### PR TITLE
Allow expressions in join: ... with 

### DIFF
--- a/docs/_src/language/join.md
+++ b/docs/_src/language/join.md
@@ -11,7 +11,7 @@ In Malloy, syntaxes for join are:
 
 ```malloy
 join_one: <source-name> [is <source-exp>] on <boolean expression>
-join_one: <source-name> [is <source-exp>] with <foreign_key>        -- slightly more concise; works with primary to foreign key joins
+join_one: <source-name> [is <source-exp>] with <foreign key expression>
 join_many: <source-name> [is <source-exp>] on <boolean expression>
 join_cross: <source-name> [is <source-exp>] [on <boolean expression>]
 ```
@@ -44,7 +44,7 @@ The easiest, most error-proof way to perform a join is using the following synta
 
 `join_one: <source> with <foreign_key>`
 
-To join a foreign key in the source to the `primary_key` of a joined source, reference the foreign key by name in the `with` clause.
+To join based on a foreign key through the `primary_key` of a joined source, use `with` to specify an expression, which could be as simple as a field name in the source. This expression is matched against the decalred `primary_key` of the joined source. Sources without a `primary_key` cannot use `with` joins.
 
 ```malloy
 source: users is table('malloy-data.ecomm.users'){
@@ -56,7 +56,8 @@ source: order_items is table('malloy-data.ecomm.order_items'){
 }
 ```
 
-This syntax for the join expresses exactly the same thing a bit more explicitly:
+This is simply a shortcut, when joining based on the primary key of a joined source. It is exactly equivalent to the `on` join written like this.
+
 ```
 source: order_items is table('malloy-data.ecomm.order_items'){
   join_one: users on order_items.user_id = users.id

--- a/packages/malloy-db-test/src/handexpr.spec.ts
+++ b/packages/malloy-db-test/src/handexpr.spec.ts
@@ -17,12 +17,24 @@ import { fStringEq, fStringLike } from "./test_utils";
 
 import * as malloy from "@malloydata/malloy";
 import { RuntimeList } from "./runtimes";
+import { StructRelationship } from "@malloydata/malloy/src/model";
 
 const runtimes = new RuntimeList(["bigquery"]);
 
 afterAll(async () => {
   await runtimes.closeAll();
 });
+
+function withJoin(leftKey: string, rightKey: string): StructRelationship {
+  return {
+    type: "one",
+    onExpression: [
+      { type: "field", path: `${leftKey}` },
+      "=",
+      { type: "field", path: `${rightKey}` },
+    ],
+  };
+}
 
 async function validateCompilation(
   databaseName: string,
@@ -210,10 +222,10 @@ export const aircraftHandStructDef: StructDef = {
     ...aircraftHandBase.fields,
     {
       ...modelHandBase,
-      structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "aircraft_model_code" }],
-      },
+      structRelationship: withJoin(
+        "aircraft_model_code",
+        "aircraft_models.aircraft_model_code"
+      ),
     },
   ],
 };

--- a/packages/malloy-db-test/src/handexpr.spec.ts
+++ b/packages/malloy-db-test/src/handexpr.spec.ts
@@ -212,7 +212,7 @@ export const aircraftHandStructDef: StructDef = {
       ...modelHandBase,
       structRelationship: {
         type: "foreignKey",
-        foreignKey: "aircraft_model_code",
+        keyExpression: [{ type: "field", path: "aircraft_model_code" }],
       },
     },
   ],

--- a/packages/malloy-db-test/src/models/faa_model.ts
+++ b/packages/malloy-db-test/src/models/faa_model.ts
@@ -67,7 +67,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "carriers",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: { type: "foreignKey", foreignKey: "carrier" },
+      structRelationship: {
+        type: "foreignKey",
+        keyExpression: [{ type: "field", path: "carrier" }],
+      },
       primaryKey: "code",
       fields: [
         { type: "string", name: "code" },
@@ -83,7 +86,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "aircraft",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: { type: "foreignKey", foreignKey: "tail_num" },
+      structRelationship: {
+        type: "foreignKey",
+        keyExpression: [{ type: "field", path: "tail_num" }],
+      },
       primaryKey: "tail_num",
       fields: [
         { type: "string", name: "tail_num" },
@@ -140,7 +146,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
           structSource: { type: "table" },
           structRelationship: {
             type: "foreignKey",
-            foreignKey: "aircraft_model_code",
+            keyExpression: [{ type: "field", path: "aircraft_model_code" }],
           },
           fields: [
             { type: "string", name: "aircraft_model_code" },
@@ -186,7 +192,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "origin",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: { type: "foreignKey", foreignKey: "origin_code" },
+      structRelationship: {
+        type: "foreignKey",
+        keyExpression: [{ type: "field", path: "origin_code" }],
+      },
       primaryKey: "code",
       fields: [
         { type: "number", name: "id", numberType: "integer" },
@@ -234,7 +243,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
       structSource: { type: "table" },
       structRelationship: {
         type: "foreignKey",
-        foreignKey: "destination_code",
+        keyExpression: [{ type: "field", path: "destination_code" }],
       },
       primaryKey: "code",
       fields: [
@@ -288,7 +297,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
           pipeline: [],
         },
       },
-      structRelationship: { type: "foreignKey", foreignKey: "tail_num" },
+      structRelationship: {
+        type: "foreignKey",
+        keyExpression: [{ type: "field", path: "tail_num" }],
+      },
       primaryKey: "tail_num",
       fields: [
         { type: "string", name: "tail_num" },
@@ -310,7 +322,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
     //         ]
     //       }
     //   },
-    //   structRelationship: {type: 'foreignKey', foreignKey: 'tail_num'},
+    //   structRelationship: {type: 'foreignKey', keyExpression: [{ type: "field", path:  'tail_num'},
     //   fields: [
     //   ]
     // },

--- a/packages/malloy-db-test/src/models/faa_model.ts
+++ b/packages/malloy-db-test/src/models/faa_model.ts
@@ -14,6 +14,18 @@
 import { ModelDef, StructDef } from "@malloydata/malloy";
 import { medicareModel, medicareStateFacts } from "./medicare_model";
 import { fStringEq, fYearEq } from "../test_utils";
+import { StructRelationship } from "@malloydata/malloy/src/model";
+
+function withJoin(leftKey: string, rightKey: string): StructRelationship {
+  return {
+    type: "one",
+    onExpression: [
+      { type: "field", path: `${leftKey}` },
+      "=",
+      { type: "field", path: `${rightKey}` },
+    ],
+  };
+}
 
 /** Flight Model */
 export const FLIGHTS_EXPLORE: StructDef = {
@@ -68,8 +80,12 @@ export const FLIGHTS_EXPLORE: StructDef = {
       dialect: "standardsql",
       structSource: { type: "table" },
       structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "carrier" }],
+        type: "one",
+        onExpression: [
+          { type: "field", path: "carrier" },
+          "=",
+          { type: "field", path: "carriers.code" },
+        ],
       },
       primaryKey: "code",
       fields: [
@@ -86,10 +102,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "aircraft",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "tail_num" }],
-      },
+      structRelationship: withJoin("tail_num", "aircraft.tail_num"),
       primaryKey: "tail_num",
       fields: [
         { type: "string", name: "tail_num" },
@@ -144,10 +157,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
           dialect: "standardsql",
           primaryKey: "aircraft_model_code",
           structSource: { type: "table" },
-          structRelationship: {
-            type: "foreignKey",
-            keyExpression: [{ type: "field", path: "aircraft_model_code" }],
-          },
+          structRelationship: withJoin(
+            "aircraft_model_code",
+            "aircraft_models.aircraft_model_code"
+          ),
           fields: [
             { type: "string", name: "aircraft_model_code" },
             { type: "string", name: "manufacturer" },
@@ -192,10 +205,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "origin",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "origin_code" }],
-      },
+      structRelationship: withJoin("origin_code", "origin.code"),
       primaryKey: "code",
       fields: [
         { type: "number", name: "id", numberType: "integer" },
@@ -241,10 +251,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
       as: "destination",
       dialect: "standardsql",
       structSource: { type: "table" },
-      structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "destination_code" }],
-      },
+      structRelationship: withJoin("destination_code", "destination.code"),
       primaryKey: "code",
       fields: [
         { type: "number", name: "id", numberType: "integer" },
@@ -297,10 +304,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
           pipeline: [],
         },
       },
-      structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "tail_num" }],
-      },
+      structRelationship: withJoin("tail_num", "aircraft_facts.tail_num"),
       primaryKey: "tail_num",
       fields: [
         { type: "string", name: "tail_num" },

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -830,17 +830,16 @@ export class KeyJoin extends Join {
 
   fixupJoinOn(outer: FieldSpace, inStruct: model.StructDef): void {
     const exprX = this.keyExpr.getExpression(outer);
-    const into = outer.structDef();
-    if (into.primaryKey) {
-      const pkey = into.fields.find(
-        (f) => (f.as || f.name) === into.primaryKey
+    if (inStruct.primaryKey) {
+      const pkey = inStruct.fields.find(
+        (f) => (f.as || f.name) === inStruct.primaryKey
       );
       if (pkey) {
         if (pkey.type === exprX.dataType) {
           inStruct.structRelationship = {
             type: "one",
             onExpression: [
-              { type: "field", path: into.primaryKey },
+              { type: "field", path: `${this.name}.${inStruct.primaryKey}` },
               "=",
               ...exprX.value,
             ],

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -812,7 +812,7 @@ export class KeyJoin extends Join {
   constructor(
     readonly name: ModelEntryReference,
     readonly source: Mallobj,
-    readonly key: FieldName
+    readonly key: FieldReference
   ) {
     super({ name, source, key });
   }

--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -322,7 +322,7 @@ export class NewFieldSpace extends StructSpace {
       }
       const reorderFields = [...fields, ...joins, ...turtles];
       for (const [fieldName, field] of reorderFields) {
-        if (field instanceof JoinSpaceField && field.join.needsFixup()) {
+        if (field instanceof JoinSpaceField) {
           const joinStruct = field.join.structDef();
           if (!ErrorFactory.isErrorStructdef(joinStruct)) {
             this.final.fields.push(joinStruct);

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -173,7 +173,7 @@ joinList
   ;
 
 joinDef
-  : joinNameDef (IS explore)? WITH fieldName        # joinWith
+  : joinNameDef (IS explore)? WITH fieldPath        # joinWith
   | joinNameDef (IS explore)? (ON joinExpression)?  # joinOn
   ;
 

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -173,7 +173,7 @@ joinList
   ;
 
 joinDef
-  : joinNameDef (IS explore)? WITH fieldPath        # joinWith
+  : joinNameDef (IS explore)? WITH fieldExpr        # joinWith
   | joinNameDef (IS explore)? (ON joinExpression)?  # joinOn
   ;
 

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -396,7 +396,7 @@ export class MalloyToAST
   visitJoinWith(pcx: parse.JoinWithContext): ast.Join {
     const joinAs = this.getModelEntryName(pcx.joinNameDef());
     const joinFrom = this.getJoinSource(joinAs, pcx.explore());
-    const joinOn = this.visitFieldPath(pcx.fieldPath());
+    const joinOn = this.getFieldExpr(pcx.fieldExpr());
     const join = new ast.KeyJoin(joinAs, joinFrom, joinOn);
     return this.astAt(join, pcx);
   }

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -396,7 +396,7 @@ export class MalloyToAST
   visitJoinWith(pcx: parse.JoinWithContext): ast.Join {
     const joinAs = this.getModelEntryName(pcx.joinNameDef());
     const joinFrom = this.getJoinSource(joinAs, pcx.explore());
-    const joinOn = this.getFieldName(pcx.fieldName());
+    const joinOn = this.visitFieldPath(pcx.fieldPath());
     const join = new ast.KeyJoin(joinAs, joinFrom, joinOn);
     return this.astAt(join, pcx);
   }
@@ -528,9 +528,7 @@ export class MalloyToAST
   }
 
   visitFieldPath(pcx: parse.FieldPathContext): ast.FieldReference {
-    const names = pcx.fieldName().map((nameCx) => {
-      return this.getFieldName(nameCx);
-    });
+    const names = pcx.fieldName().map((nameCx) => this.getFieldName(nameCx));
     return this.astAt(new ast.FieldReference(names), pcx);
   }
 
@@ -541,8 +539,7 @@ export class MalloyToAST
   }
 
   visitQueryFieldRef(pcx: parse.QueryFieldRefContext): ast.QueryItem {
-    const refCx = pcx.fieldPath();
-    return this.astAt(this.visitFieldPath(refCx), refCx);
+    return this.visitFieldPath(pcx.fieldPath());
   }
 
   // visitQueryFieldNameless(

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -37,8 +37,8 @@ describe("structdef comprehension", () => {
     };
   }
 
-  function fieldRef(...names: string[]) {
-    return names.map((name) => new FieldName(name));
+  function fieldRef(fieldPath: string): FieldName[] {
+    return fieldPath.split(".").map((name) => new FieldName(name));
   }
 
   test(`import string field`, () => {
@@ -102,7 +102,7 @@ describe("structdef comprehension", () => {
     };
     const struct = mkStructDef(field);
     const space = new StructSpace(struct);
-    expect(space.lookup(fieldRef("t", "b")).found).toBeInstanceOf(
+    expect(space.lookup(fieldRef("t.b")).found).toBeInstanceOf(
       ColumnSpaceField
     );
     const oField = space.structDef().fields[0];
@@ -120,7 +120,7 @@ describe("structdef comprehension", () => {
     };
     const struct = mkStructDef(field);
     const space = new StructSpace(struct);
-    expect(space.lookup(fieldRef("t", "a")).found).toBeInstanceOf(
+    expect(space.lookup(fieldRef("t.a")).found).toBeInstanceOf(
       ColumnSpaceField
     );
     const oField = space.structDef().fields[0];
@@ -135,17 +135,17 @@ describe("structdef comprehension", () => {
       structRelationship: {
         type: "one",
         onExpression: [
-          { type: "field", path: "tKey" },
+          { type: "field", path: "aKey" },
           "=",
           { type: "field", path: "t.a" },
         ],
       },
       structSource: { type: "table" },
-      fields: [{ type: "string", name: "t1" }],
+      fields: [{ type: "string", name: "a" }],
     };
     const struct = mkStructDef(field);
     const space = new StructSpace(struct);
-    expect(space.lookup(fieldRef("t", "a")).found).toBeInstanceOf(
+    expect(space.lookup(fieldRef("t.a")).found).toBeInstanceOf(
       ColumnSpaceField
     );
     const oField = space.structDef().fields[0];

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -132,7 +132,10 @@ describe("structdef comprehension", () => {
       name: "t",
       type: "struct",
       dialect: "standardsql",
-      structRelationship: { type: "foreignKey", foreignKey: "b" },
+      structRelationship: {
+        type: "foreignKey",
+        keyExpression: [{ type: "field", path: "b" }],
+      },
       structSource: { type: "table" },
       fields: [{ type: "string", name: "a" }],
     };

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -133,11 +133,15 @@ describe("structdef comprehension", () => {
       type: "struct",
       dialect: "standardsql",
       structRelationship: {
-        type: "foreignKey",
-        keyExpression: [{ type: "field", path: "b" }],
+        type: "one",
+        onExpression: [
+          { type: "field", path: "tKey" },
+          "=",
+          { type: "field", path: "t.a" },
+        ],
       },
       structSource: { type: "table" },
-      fields: [{ type: "string", name: "a" }],
+      fields: [{ type: "string", name: "t1" }],
     };
     const struct = mkStructDef(field);
     const space = new StructSpace(struct);

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -386,6 +386,10 @@ describe("explore properties", () => {
   describe("joins", () => {
     test("with", modelOK("explore: x is a { join_one: b with astr }"));
     test("with", modelOK("explore: x is a { join_one: y is b with astr }"));
+    test(
+      "with dotted ref",
+      modelOK("explore: x is ab { join_one: xz is a with b.astr }")
+    );
     test("one on", modelOK("explore: x is a { join_one: b on astr = b.astr }"));
     test(
       "one is on",

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -978,7 +978,7 @@ describe("source locations", () => {
   test("location of join with", () => {
     const source = markSource`
       explore: na is a {
-        join_one: ${"x is a { primary_key: abool } with astr"}
+        join_one: ${"x is a { primary_key: astr } with astr"}
       }
     `;
     const m = new BetaModel(source.code);

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -110,8 +110,12 @@ export class TestTranslator extends MalloyTranslator {
             ...aTableDef,
             as: "b",
             structRelationship: {
-              type: "foreignKey",
-              keyExpression: [{ type: "field", path: "astr" }],
+              type: "one",
+              onExpression: [
+                { type: "field", path: "astr" },
+                "=",
+                { type: "field", path: "b.astr" },
+              ],
             },
           },
           {

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -109,7 +109,10 @@ export class TestTranslator extends MalloyTranslator {
           {
             ...aTableDef,
             as: "b",
-            structRelationship: { type: "foreignKey", foreignKey: "astr" },
+            structRelationship: {
+              type: "foreignKey",
+              keyExpression: [{ type: "field", path: "astr" }],
+            },
           },
           {
             type: "number",

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1011,7 +1011,6 @@ export enum SourceRelationship {
   /**
    * The `Explore` is joined to its source
    */
-  ForeignKey = "foreign_key",
   Cross = "cross",
   One = "one",
   Many = "many",
@@ -1199,8 +1198,6 @@ export class Explore extends Entity {
         return SourceRelationship.One;
       case "cross":
         return SourceRelationship.Cross;
-      case "foreignKey":
-        return SourceRelationship.ForeignKey;
       case "inline":
         return SourceRelationship.Inline;
       case "nested":
@@ -1542,7 +1539,6 @@ export class ExploreField extends Explore {
   public get joinRelationship(): JoinRelationship {
     switch (this.structDef.structRelationship.type) {
       case "one":
-      case "foreignKey":
         return JoinRelationship.OneToMany;
       case "many":
       case "cross":

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -560,7 +560,12 @@ class QueryFieldStruct extends QueryAtomicField {
       structRelationship: {
         type: "one",
         onExpression: [
-          PRIMARY_KEY_GOES_HERE,
+          {
+            type: "field",
+            path: `${this.getIdentifier()}.${
+              (this.fieldDef as StructDef).primaryKey
+            }`,
+          },
           "=",
           { type: "field", path: foreignKeyName },
         ],

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -550,6 +550,13 @@ class QueryFieldBoolean extends QueryAtomicField {}
 //  will include the StructDef as a foreign key join in the output
 //  StructDef.
 class QueryFieldStruct extends QueryAtomicField {
+  primaryKey: string;
+
+  constructor(fieldDef: FieldDef, parent: QueryStruct, primaryKey: string) {
+    super(fieldDef, parent);
+    this.primaryKey = primaryKey;
+  }
+
   getName() {
     return getIdentifier(this.fieldDef);
   }
@@ -562,9 +569,7 @@ class QueryFieldStruct extends QueryAtomicField {
         onExpression: [
           {
             type: "field",
-            path: `${this.getIdentifier()}.${
-              (this.fieldDef as StructDef).primaryKey
-            }`,
+            path: this.primaryKey,
           },
           "=",
           { type: "field", path: foreignKeyName },
@@ -2737,9 +2742,11 @@ class QueryStruct extends QueryNode {
     if (pkType !== "string" && pkType !== "number") {
       throw new Error(`Unknown Primary key data type for ${name}`);
     }
+    const aliasName = getIdentifier(this.fieldDef);
+    const pkName = this.fieldDef.primaryKey;
     const fieldDef: FieldDef = {
       type: pkType,
-      name: `${getIdentifier(this.fieldDef)}_id`,
+      name: `${aliasName}_id`,
       e: [
         {
           type: "field",
@@ -2748,7 +2755,7 @@ class QueryStruct extends QueryNode {
         },
       ],
     };
-    return new QueryFieldStruct(fieldDef, this);
+    return new QueryFieldStruct(fieldDef, this, `${aliasName}.${pkName}`);
   }
 
   // return the name of the field in SQL

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -457,11 +457,6 @@ export type JoinRelationship =
   | "many_to_one"
   | "many_to_many";
 
-export interface JoinForeignKey {
-  type: "foreignKey";
-  keyExpression: Expr;
-}
-
 export interface JoinOn {
   type: "one" | "many" | "cross";
   onExpression?: Expr;
@@ -470,16 +465,9 @@ export interface JoinOn {
 export function isJoinOn(sr: StructRelationship): sr is JoinOn {
   return ["one", "many", "cross"].includes(sr.type);
 }
-export function isAnyJoin(
-  sr: StructRelationship
-): sr is JoinOn | JoinForeignKey {
-  return isJoinOn(sr) || sr.type == "foreignKey";
-}
-
 /** types of joins. */
 export type StructRelationship =
   | { type: "basetable"; connectionName: string }
-  | JoinForeignKey
   | JoinOn
   | { type: "inline" }
   | { type: "nested"; field: FieldRef };

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -459,7 +459,7 @@ export type JoinRelationship =
 
 export interface JoinForeignKey {
   type: "foreignKey";
-  foreignKey: FieldRef;
+  keyExpression: Expr;
 }
 
 export interface JoinOn {


### PR DESCRIPTION
Fixes #347

Once upon a time we had plans to allow reversed foreign key join with something like

```
source: users {
  join_many: orders with orders.user_id
```

And automatically generate a join into the primary key of users.

Only we never implemented that, and in the grammar a `with` clause could ONLY be a field name with no dots.

---

With this PR the `with` clause takes any expression, and always joins based on the primary key of the source being join in. This will allow any expression based on the outer source to be used as a foreign key for joining the new source, including, as mentioned in #347 _exisitingJoinName.fieldName_