### PR TITLE
Better typing of results of function calls in expressions

### DIFF
--- a/docs/_src/examples/ga_sessions.md
+++ b/docs/_src/examples/ga_sessions.md
@@ -6,7 +6,7 @@ Start by defining a source based on a query.
 
 ```malloy
 source: ga_sesions is table('bigquery-public-data.google_analytics_sample.ga_sessions_20170801') {
-  dimension: start_time is timestamp_seconds(visitStartTime)::timestamp
+  dimension: start_time is timestamp_seconds(visitStartTime)
   measure: [
     user_count is count(distinct fullVisitorId)
     session_count is count()

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -67,6 +67,7 @@ export abstract class Dialect {
   abstract hasFinalStage: boolean;
   abstract stringTypeName: string;
   abstract divisionIsInteger: boolean;
+  protected abstract functionInfo: Record<string, FunctionInfo>;
 
   // return a quoted string for use as a table name.
   abstract quoteTableName(tableName: string): string;
@@ -181,5 +182,7 @@ export abstract class Dialect {
     timezone: string
   ): string;
 
-  abstract getFunctionInfo(functionName: string): FunctionInfo | undefined;
+  getFunctionInfo(functionName: string): FunctionInfo | undefined {
+    return this.functionInfo[functionName.toLowerCase()];
+  }
 }

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -11,10 +11,21 @@
  * GNU General Public License for more details.
  */
 
+import { AtomicFieldType } from "..";
+
 interface DialectField {
   type: string;
   sqlExpression: string;
   sqlOutputName: string;
+}
+
+/**
+ * Someday this might be used to control how a function call in malloy is
+ * translated into a function call in SQL. Today this is just so that
+ * the expression compiler can know the output type of a function.
+ */
+export interface FunctionInfo {
+  returnType: AtomicFieldType;
 }
 
 export type DialectFieldList = DialectField[];
@@ -169,4 +180,6 @@ export abstract class Dialect {
     type: "date" | "timestamp",
     timezone: string
   ): string;
+
+  abstract getFunctionInfo(functionName: string): FunctionInfo | undefined;
 }

--- a/packages/malloy/src/dialect/postgres.ts
+++ b/packages/malloy/src/dialect/postgres.ts
@@ -35,6 +35,7 @@ export class PostgresDialect extends Dialect {
   hasFinalStage = true;
   stringTypeName = "VARCHAR";
   divisionIsInteger = true;
+  functionInfo: Record<string, FunctionInfo> = {};
 
   quoteTableName(tableName: string): string {
     return `${tableName}`;

--- a/packages/malloy/src/dialect/postgres.ts
+++ b/packages/malloy/src/dialect/postgres.ts
@@ -18,6 +18,7 @@ import {
   DialectExpr,
   DialectFieldList,
   ExtractDateTimeframe,
+  FunctionInfo,
   isDateTimeframe,
   TimestampTimeframe,
 } from "./dialect";
@@ -275,5 +276,9 @@ export class PostgresDialect extends Dialect {
     } else {
       throw new Error(`Unknown Liternal time format ${type}`);
     }
+  }
+
+  getFunctionInfo(_functionName: string): FunctionInfo | undefined {
+    return undefined;
   }
 }

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -18,6 +18,7 @@ import {
   DialectExpr,
   DialectFieldList,
   ExtractDateTimeframe,
+  FunctionInfo,
   TimestampTimeframe,
 } from "./dialect";
 
@@ -371,5 +372,9 @@ ${indent(sql)}
     } else {
       throw new Error(`Unknown Liternal time format ${type}`);
     }
+  }
+
+  getFunctionInfo(_functionName: string): FunctionInfo | undefined {
+    return undefined;
   }
 }

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -37,6 +37,9 @@ export class StandardSQLDialect extends Dialect {
   hasFinalStage = false;
   stringTypeName = "STRING";
   divisionIsInteger = false;
+  functionInfo: Record<string, FunctionInfo> = {
+    timestamp_seconds: { returnType: "timestamp" },
+  };
 
   quoteTableName(tableName: string): string {
     return `\`${tableName}\``;
@@ -372,9 +375,5 @@ ${indent(sql)}
     } else {
       throw new Error(`Unknown Liternal time format ${type}`);
     }
-  }
-
-  getFunctionInfo(_functionName: string): FunctionInfo | undefined {
-    return undefined;
   }
 }

--- a/packages/malloy/src/lang/ast/ast-time-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-time-expr.ts
@@ -623,10 +623,10 @@ export class ExprFunc extends ExpressionDef {
     }
     funcCall.push(")");
 
-    // TODO hack alert, type of function computation is just temporary
-    // https://github.com/looker/malloy/issues/195
+    const funcInfo = fs.getDialect().getFunctionInfo(this.name);
+    const dataType = funcInfo?.returnType ?? collectType ?? "number";
     return {
-      dataType: collectType ?? "number",
+      dataType,
       aggregate: anyAggregate,
       value: compressExpr(funcCall),
     };

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -147,7 +147,7 @@ expect.extend({
   toBeErrorless: function (trans: Testable) {
     return checkForErrors(trans);
   },
-  toReturnType: function(functionCall: string, returnType: string) {
+  toReturnType: function (functionCall: string, returnType: string) {
     const exprModel = new BetaModel(
       `explore: x is a { dimension: d is ${functionCall} }`
     );
@@ -164,9 +164,9 @@ expect.extend({
     }
     return {
       pass: true,
-      message: () => '',
+      message: () => "",
     };
-  }
+  },
 });
 
 class BetaExpression extends Testable {

--- a/samples/ga_sessions/ga_sessions.malloy
+++ b/samples/ga_sessions/ga_sessions.malloy
@@ -1,7 +1,7 @@
 --! styles ga_sessions.styles.json
 
 source:ga_sessions is table('bigquery-public-data.google_analytics_sample.ga_sessions_20170801'){
-  dimension: start_time is timestamp_seconds(visitStartTime)::timestamp
+  dimension: start_time is timestamp_seconds(visitStartTime)
 
   measure: [
     user_count is count(distinct fullVisitorId)

--- a/samples/hackernews/hackernews.malloy
+++ b/samples/hackernews/hackernews.malloy
@@ -18,7 +18,7 @@ source: stories is table('bigquery-public-data.hacker_news.full') {
   ]
 
   dimension: [
-    post_time is timestamp_seconds(`time`)::timestamp
+    post_time is timestamp_seconds(`time`)
     site is regexp_extract(
       regexp_extract(url, '^http://([^\\/]*)\\/'),
       '([^\\.]+\\.[^\\.]+(?:\\.[A-Za-z][A-Za-z])?)$'


### PR DESCRIPTION
Fixes #106 

Only it will never really fix it. It will only be fixed when do do not allow any pass through function calls, and there is a set of Malloy functions which are documented, and each one generates SQL.