### PR TITLE
allow a nest reference to include a refinement

### DIFF
--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -27,11 +27,11 @@ import {
   HasParameter,
   FieldCollectionMember,
   QueryItem,
-  NestDefinition,
   MalloyElement,
   NestReference,
   FieldReference,
   ErrorFactory,
+  isNestedQuery,
 } from "./ast";
 import {
   SpaceField,
@@ -389,7 +389,7 @@ export abstract class QueryFieldSpace extends NewFieldSpace {
         this.addReference(qi);
       } else if (qi instanceof FieldDeclaration) {
         this.addField(qi);
-      } else if (qi instanceof NestDefinition) {
+      } else if (isNestedQuery(qi)) {
         this.setEntry(qi.name, new QueryFieldAST(this.inputSpace, qi, qi.name));
       } else {
         throw new Error("INTERNAL ERROR: QueryFieldSpace unknown element");

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -253,7 +253,7 @@ nestedQueryList
   ;
 
 nestEntry
-  : queryName                       # nestExisting
+  : queryName queryProperties?      # nestExisting
   | queryName IS pipelineFromName   # nestDef
   ;
 

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -733,6 +733,13 @@ export class MalloyToAST
 
   visitNestExisting(pcx: parse.NestExistingContext): ast.NestedQuery {
     const name = this.getFieldName(pcx.queryName());
+    const propsCx = pcx.queryProperties();
+    if (propsCx) {
+      const nestRefine = new ast.NestRefinement(name);
+      const queryDesc = this.visitQueryProperties(propsCx);
+      nestRefine.refineHead(queryDesc);
+      return this.astAt(nestRefine, pcx);
+    }
     return this.astAt(new ast.NestReference(name), pcx);
   }
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1694,6 +1694,15 @@ describe("pipeline comprehension", () => {
     `)
   );
   test(
+    "reference to a query can include a refinement",
+    modelOK(`
+      query: ab -> {
+        group_by: ai
+        nest: aturtle { limit: 1 }
+      }
+    `)
+  );
+  test(
     "Querying an explore based on a query",
     modelOK(`
       query: q is a -> { group_by: astr; aggregate: strsum is ai.sum() }


### PR DESCRIPTION
Fixes #413

Very common pattern, a useful nested query is embedded in another query, with a small refinement ... as in

```
query: dashboard is {
   nest: by_color { limit: 5 }
   nest: by_size { limit: 5 }
}
```