### PR TITLE
Allow query operations to refine the input source

### DIFF
--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -27,7 +27,7 @@ import {
   StructDef,
   Expr,
 } from "../../model/malloy_types";
-import { CircleSpace, FieldSpace, LookupResult } from "../field-space";
+import { DefSpace, FieldSpace, LookupResult } from "../field-space";
 import {
   Filter,
   MalloyElement,
@@ -134,6 +134,7 @@ class DollarReference extends ExpressionDef {
 }
 
 class ConstantFieldSpace implements FieldSpace {
+  readonly type = "fieldSpace";
   structDef(): StructDef {
     return {
       type: "struct",
@@ -227,8 +228,7 @@ export class FieldDeclaration extends MalloyElement {
      * a refactor of QueryFieldSpace might someday be the place where this should
      * happen.
      */
-    const circleFS = new CircleSpace(fs, this);
-    return this.queryFieldDef(circleFS, exprName);
+    return this.queryFieldDef(new DefSpace(fs, this), exprName);
   }
 
   queryFieldDef(exprFS: FieldSpace, exprName: string): FieldTypeDef {
@@ -256,11 +256,10 @@ export class FieldDeclaration extends MalloyElement {
       }
       return template;
     }
-    const complained = exprFS instanceof CircleSpace && exprFS.foundCircle;
-    if (!complained) {
-      this.log(
-        `Cannot define ${exprName}, unexpected type ${FT.inspect(exprValue)}`
-      );
+    const circularDef = exprFS instanceof DefSpace && exprFS.foundCircle;
+    if (!circularDef) {
+      const badType = FT.inspect(exprValue);
+      this.log(`Cannot define '${exprName}', unexpected type ${badType}`);
     }
     return {
       name: `error_defining_${exprName}`,

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -34,6 +34,7 @@ import {
 } from "./index";
 import { QueryField } from "../space-field";
 import { makeSQLBlock, SQLBlockRequest } from "../../model/sql_block";
+import { inspect } from "util";
 
 /*
  ** For times when there is a code generation error but your function needs
@@ -92,7 +93,10 @@ function opOutputStruct(
     try {
       return ModelQuerySegment.nextStructDef(inputStruct, opDesc);
     } catch (e) {
-      logTo.log(`INTERNAL ERROR model/Segment.nextStructDef: ${e.message}`);
+      logTo.log(
+        `INTERNAL ERROR model/Segment.nextStructDef: ${e.message}\n` +
+          `QUERY: ${inspect(opDesc, { breakLength: 72, depth: Infinity })}`
+      );
     }
   }
   return ErrorFactory.structDef;
@@ -846,7 +850,10 @@ export class KeyJoin extends Join {
     const sourceDef = this.source.structDef();
     const joinStruct: model.StructDef = {
       ...sourceDef,
-      structRelationship: { type: "one", onExpression: ["1=0"] },
+      structRelationship: {
+        type: "one",
+        onExpression: ["('join fixup'='not done yet')"],
+      },
       location: this.location,
     };
     if (sourceDef.structSource.type === "query") {

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1136,6 +1136,11 @@ export class FieldReference extends ListOf<FieldName> {
     return this.list.map((n) => n.refString).join(".");
   }
 
+  get outputName(): string {
+    const last = this.list[this.list.length - 1];
+    return last.refString;
+  }
+
   get sourceString(): string | undefined {
     if (this.list.length > 1) {
       return this.list

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1782,7 +1782,7 @@ abstract class PipelineDesc extends MalloyElement {
   } {
     const turtle = getStructFieldDef(fromStruct, turtleName);
     if (!turtle) {
-      this.log(`Reference to undefined explore query '${turtleName}'`);
+      this.log(`Query '${turtleName}' is not defined in source`);
     } else if (turtle.type !== "turtle") {
       this.log(`'${turtleName}' is not a query`);
     } else {

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -889,8 +889,10 @@ export class KeyJoin extends Join {
           );
         }
       } else {
-        this.log(`join_one: with requires primary key`);
+        this.log(`join_one: Primary key '${pkey}' not found in source`);
       }
+    } else {
+      this.log(`join_one: Cannot use with unless source has a primary key`);
     }
   }
 }

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -85,11 +85,10 @@ function opOutputStruct(
   inputStruct: model.StructDef,
   opDesc: model.PipeSegment
 ): model.StructDef {
-  if (ErrorFactory.isErrorStructdef(inputStruct)) {
-    return inputStruct;
-  }
-  // Do not call into model if we have any errors
-  if (!logTo.errorsExist()) {
+  const badModel =
+    logTo.errorsExist() || ErrorFactory.isErrorStructdef(inputStruct);
+  // Don't call into the model code with a broken model
+  if (!badModel) {
     try {
       return ModelQuerySegment.nextStructDef(inputStruct, opDesc);
     } catch (e) {

--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -441,7 +441,12 @@ export abstract class QueryOperationSpace extends DynamicSpace {
   }
 
   addReference(ref: FieldReference): void {
-    this.setEntry(ref.refString, new ReferenceField(ref));
+    const refName = ref.outputName;
+    if (this.entry(refName)) {
+      ref.log(`Output already has a field named '${refName}'`);
+    } else {
+      this.setEntry(refName, new ReferenceField(ref));
+    }
   }
 
   log(s: string): void {

--- a/packages/malloy/src/lang/field-utils.ts
+++ b/packages/malloy/src/lang/field-utils.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import { QueryFieldDef, FieldDef } from "../model/malloy_types";
+
+type Field = QueryFieldDef | FieldDef;
+
+export function nameOf(qfd: Field): string {
+  if (typeof qfd == "string") {
+    return qfd;
+  }
+  return qfd.as || qfd.name;
+}
+
+export function mergeFields<T extends Field>(older: T[], newer: T[]): T[] {
+  const redefined = new Set(newer.map((f) => nameOf(f)));
+  const merged = older.filter((f) => !redefined.has(nameOf(f)));
+  merged.push(...newer);
+  return merged;
+}

--- a/packages/malloy/src/lang/field-utils.ts
+++ b/packages/malloy/src/lang/field-utils.ts
@@ -22,7 +22,13 @@ export function nameOf(qfd: Field): string {
   return qfd.as || qfd.name;
 }
 
-export function mergeFields<T extends Field>(older: T[], newer: T[]): T[] {
+export function mergeFields<T extends Field>(
+  older: T[] | undefined,
+  newer: T[]
+): T[] {
+  if (older == undefined) {
+    return newer;
+  }
   const redefined = new Set(newer.map((f) => nameOf(f)));
   const merged = older.filter((f) => !redefined.has(nameOf(f)));
   merged.push(...newer);

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -130,9 +130,7 @@ exploreStatement
   : DIMENSION dimensionDefList         # defExploreDimension
   | MEASURE measureDefList             # defExploreMeasure
   | declareStatement                   # defDeclare_stub
-  | JOIN_ONE joinList                  # defJoinOne
-  | JOIN_MANY joinList                 # defJoinMany
-  | JOIN_CROSS joinList                # defJoinCross
+  | joinStatement                      # defJoin_stub
   | whereStatement                     # defExploreWhere
   | PRIMARY_KEY fieldName              # defExplorePrimaryKey
   | RENAME renameList                  # defExploreRename
@@ -167,6 +165,12 @@ measureDef: fieldDef;
 
 declareStatement
   : DECLARE fieldDef (COMMA? fieldDef)* COMMA?
+  ;
+
+joinStatement
+  : JOIN_ONE joinList                  # defJoinOne
+  | JOIN_MANY joinList                 # defJoinMany
+  | JOIN_CROSS joinList                # defJoinCross
   ;
 
 joinList
@@ -214,6 +218,8 @@ exploreQueryDef
 
 queryStatement
   : groupByStatement
+  | declareStatement
+  | joinStatement
   | projectStatement
   | indexStatement
   | aggregateStatement

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -766,8 +766,16 @@ export abstract class MalloyTranslation {
     return {};
   }
 
+  private finalAnswer?: TranslateResponse;
   translate(extendingModel?: ModelDef): TranslateResponse {
-    return this.translateStep.step(this, extendingModel);
+    if (this.finalAnswer) {
+      return this.finalAnswer;
+    }
+    const attempt = this.translateStep.step(this, extendingModel);
+    if (attempt.final) {
+      this.finalAnswer = attempt;
+    }
+    return attempt;
   }
 
   metadata(): MetadataResponse {

--- a/packages/malloy/src/lang/space-field.ts
+++ b/packages/malloy/src/lang/space-field.ts
@@ -12,7 +12,7 @@
  */
 
 import * as model from "../model/malloy_types";
-import { FieldSpace, StructSpace, NewFieldSpace } from "./field-space";
+import { FieldSpace, DynamicSpace, StaticSpace } from "./field-space";
 import {
   FieldValueType,
   FieldDeclaration,
@@ -79,7 +79,7 @@ export abstract class SpaceField extends SpaceEntry {
     return ref;
   }
 
-  queryFieldDef(): model.QueryFieldDef | undefined {
+  getQueryFieldDef(_fs: FieldSpace): model.QueryFieldDef | undefined {
     return undefined;
   }
 
@@ -123,7 +123,7 @@ export class WildSpaceField extends SpaceField {
     throw new Error("should never ask a wild field for its type");
   }
 
-  queryFieldDef(): model.QueryFieldDef {
+  getQueryFieldDef(_fs: FieldSpace): model.QueryFieldDef {
     return this.wildText;
   }
 }
@@ -136,7 +136,7 @@ export class StructSpaceField extends SpaceField {
 
   get fieldSpace(): FieldSpace {
     if (!this.space) {
-      this.space = new StructSpace(this.sourceDef);
+      this.space = new StaticSpace(this.sourceDef);
     }
     return this.space;
   }
@@ -175,7 +175,7 @@ export abstract class QueryField extends SpaceField {
     super();
   }
 
-  queryFieldDef(): model.QueryFieldDef | undefined {
+  getQueryFieldDef(_fs: FieldSpace): model.QueryFieldDef | undefined {
     return this.fieldDef();
   }
 
@@ -285,7 +285,7 @@ export class FANSPaceField extends SpaceField {
     return undefined;
   }
 
-  queryFieldDef(): model.QueryFieldDef {
+  getQueryFieldDef(_fs: FieldSpace): model.QueryFieldDef {
     // TODO if this reference is to a field which does not exist
     // it needs to be an error SOMEWHERE
     const n: model.FilteredAliasedName = { name: this.ref.refString };
@@ -306,24 +306,13 @@ export class FANSPaceField extends SpaceField {
 
 export class ExpressionFieldFromAst extends SpaceField {
   fieldName: string;
+  defType?: FieldType;
   constructor(
-    readonly space: NewFieldSpace,
+    readonly space: DynamicSpace,
     readonly exprDef: FieldDeclaration
   ) {
     super();
     this.fieldName = exprDef.defineName;
-    // left over from anonymous expression days
-    // we may not know the type of an expression as we add it to the list,
-    //
-    // TODO smart logic about naming this field based on the expression
-    // const defName = exprDef.defineName;
-    // if (defName) {
-    //   this.fieldName = defName;
-    // }
-    // else {
-    //   const fieldProvided = exprDef.expr.defaultFieldName();
-    //   this.fieldName = fieldProvided || space.nextAnonymousField();
-    // }
   }
 
   get name(): string {
@@ -331,14 +320,21 @@ export class ExpressionFieldFromAst extends SpaceField {
   }
 
   fieldDef(): model.FieldDef {
-    return this.exprDef.fieldDef(this.space, this.name);
+    const def = this.exprDef.fieldDef(this.space, this.name);
+    this.defType = this.fieldTypeFromFieldDef(def);
+    return def;
   }
 
-  queryFieldDef(): model.QueryFieldDef {
-    return this.exprDef.queryFieldDef(this.space, this.name);
+  getQueryFieldDef(queryInputFS: FieldSpace): model.QueryFieldDef {
+    const def = this.exprDef.queryFieldDef(queryInputFS, this.name);
+    this.defType = this.fieldTypeFromFieldDef(def);
+    return def;
   }
 
   type(): FieldType {
+    if (this.defType) {
+      return this.defType;
+    }
     return this.fieldTypeFromFieldDef(this.fieldDef());
   }
 }

--- a/packages/malloy/src/lang/space-field.ts
+++ b/packages/malloy/src/lang/space-field.ts
@@ -304,6 +304,22 @@ export class FANSPaceField extends SpaceField {
   }
 }
 
+export class ReferenceField extends SpaceField {
+  constructor(readonly fieldRef: FieldReference) {
+    super();
+  }
+
+  getQueryFieldDef(fs: FieldSpace): model.QueryFieldDef | undefined {
+    // Lookup string and generate error if it isn't defined.
+    this.fieldRef.getField(fs);
+    return this.fieldRef.refString;
+  }
+
+  type(): FieldType {
+    return { type: "unknown" };
+  }
+}
+
 export class ExpressionFieldFromAst extends SpaceField {
   fieldName: string;
   defType?: FieldType;

--- a/packages/malloy/src/lang/space-field.ts
+++ b/packages/malloy/src/lang/space-field.ts
@@ -311,7 +311,10 @@ export class ReferenceField extends SpaceField {
 
   getQueryFieldDef(fs: FieldSpace): model.QueryFieldDef | undefined {
     // Lookup string and generate error if it isn't defined.
-    this.fieldRef.getField(fs);
+    const check = this.fieldRef.getField(fs);
+    if (check.error) {
+      this.fieldRef.log(check.error);
+    }
     return this.fieldRef.refString;
   }
 

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -17,7 +17,7 @@ import {
   DefinedParameter,
   QueryFieldStruct,
 } from "../space-field";
-import { StructSpace } from "../field-space";
+import { StaticSpace } from "../field-space";
 import { FieldName } from "../ast";
 
 /*
@@ -47,7 +47,7 @@ describe("structdef comprehension", () => {
       type: "string",
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -60,7 +60,7 @@ describe("structdef comprehension", () => {
       numberType: "float",
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -73,7 +73,7 @@ describe("structdef comprehension", () => {
       numberType: "integer",
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -85,7 +85,7 @@ describe("structdef comprehension", () => {
       type: "boolean",
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(ColumnSpaceField);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -101,7 +101,7 @@ describe("structdef comprehension", () => {
       fields: [{ type: "string", name: "b" }],
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t.b")).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -119,7 +119,7 @@ describe("structdef comprehension", () => {
       fields: [{ type: "string", name: "a" }],
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t.a")).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -144,7 +144,7 @@ describe("structdef comprehension", () => {
       fields: [{ type: "string", name: "a" }],
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t.a")).found).toBeInstanceOf(
       ColumnSpaceField
     );
@@ -164,7 +164,7 @@ describe("structdef comprehension", () => {
       ],
     };
     const struct = mkStructDef(field);
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("t")).found).toBeInstanceOf(QueryFieldStruct);
     const oField = space.structDef().fields[0];
     expect(oField).toEqual(field);
@@ -186,7 +186,7 @@ describe("structdef comprehension", () => {
         constant: false,
       },
     };
-    const space = new StructSpace(struct);
+    const space = new StaticSpace(struct);
     expect(space.lookup(fieldRef("cReqStr")).found).toBeInstanceOf(
       DefinedParameter
     );

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -684,18 +684,16 @@ describe("qops", () => {
       }
     }
   });
-  test(
-    "refine query source bad with join",
-    badModel(
-      `
+  test("refine query source errors with illegal join", () => {
+    expect(
+      markSource`
         query: ab -> aturtle + {
           join_one: bb is table('aTable') with astr
           group_by: bb_astr is bb.astr
         }
-      `,
-      "mising primary key"
-    )
-  );
+    `
+    ).compileToFailWith("mising primary key");
+  });
 });
 
 describe("expressions", () => {
@@ -870,20 +868,19 @@ describe("sql backdoor", () => {
 });
 
 describe("error handling", () => {
-  test(
-    "query reference to undefined explore",
-    badModel("query: x->{ group_by: y }", "Undefined source 'x'")
-  );
-  test(
-    "join reference before definition",
-    badModel(
-      `
-        explore: newAB is a { join_one: newB is bb on astring }
+  test("query reference to undefined explore", () => {
+    expect(markSource`query: ${"x"}->{ group_by: y }`).compileToFailWith(
+      "Undefined source 'x'"
+    );
+  });
+  test("join reference before definition", () => {
+    expect(
+      markSource`
+        explore: newAB is a { join_one: newB is ${"bb"} on astring }
         explore: newB is b
-      `,
-      "Undefined source 'bb'"
-    )
-  );
+      `
+    ).compileToFailWith("Undefined source 'bb'");
+  });
   test(
     "non-rename rename",
     badModel(

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -487,6 +487,17 @@ describe("explore properties", () => {
         }
       `)
     );
+    test("with requires primary key", () => {
+      expect(
+        markSource`
+          source: nb is b {
+            join_one: ${"bb is table('aTable') with astr"}
+          }
+        `
+      ).compileToFailWith(
+        "join_one: Cannot use with unless source has a primary key"
+      );
+    });
   });
   test("primary_key", modelOK("explore: c is a { primary_key: ai }"));
   test("rename", modelOK("explore: c is a { rename: nn is ai }"));
@@ -683,16 +694,6 @@ describe("qops", () => {
         fail("Did not generate extendSource");
       }
     }
-  });
-  test("refine query source errors with illegal join", () => {
-    expect(
-      markSource`
-        query: ab -> aturtle + {
-          join_one: bb is table('aTable') with astr
-          group_by: bb_astr is bb.astr
-        }
-    `
-    ).compileToFailWith("mising primary key");
   });
 });
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "../../model";
 import { makeSQLBlock } from "../../model/sql_block";
 import { ExpressionDef } from "../ast";
-import { StructSpace } from "../field-space";
+import { StaticSpace } from "../field-space";
 import { DataRequestResponse } from "../parse-malloy";
 import {
   TestTranslator,
@@ -179,7 +179,7 @@ class BetaExpression extends Testable {
     if (exprAst instanceof ExpressionDef) {
       const aStruct = this.internalModel.contents.ab;
       if (aStruct.type === "struct") {
-        const exprDef = exprAst.getExpression(new StructSpace(aStruct));
+        const exprDef = exprAst.getExpression(new StaticSpace(aStruct));
         if (inspectCompile) {
           console.log("EXPRESSION: ", pretty(exprDef));
         }

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -932,8 +932,13 @@ describe("error handling", () => {
 
   test("detect duplicate output field names", () => {
     expect(
+      markSource`query: ab -> { group_by: astr, ${"astr"} }`
+    ).compileToFailWith("Output already has a field named 'astr'");
+  });
+  test("detect join tail overlap existing ref", () => {
+    expect(
       markSource`query: ab -> { group_by: astr, ${"b.astr"} }`
-    ).compileToFailWith("duplicate field names");
+    ).compileToFailWith("Output already has a field named 'astr'");
   });
 });
 

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -91,7 +91,7 @@ export class TestTranslator extends MalloyTranslator {
    *   explore: ab is a {
    *     join_one: b with astr
    *     measure: acount is count()
-   *     query: aturtle is { group_bY: astr; aggregate: acount }
+   *     query: aturtle is { group_by: astr; aggregate: acount }
    *   }
    */
   internalModel: ModelDef = {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3311,7 +3311,7 @@ export class QueryModel {
     let extendSource;
     let querySegment: QuerySegment | undefined;
     if (
-      pipeline !== undefined &&
+      pipeline?.length > 0 &&
       isQuerySegment(pipeline[0]) &&
       pipeline[0].extendSource !== undefined
     ) {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -442,6 +442,7 @@ export function isIndexSegment(pe: PipeSegment): pe is IndexSegment {
 export interface QuerySegment extends Filtered {
   type: "reduce" | "project";
   fields: QueryFieldDef[];
+  extendSource?: FieldDef[];
   limit?: number;
   by?: By;
   orderBy?: OrderBy[]; // uses output field name or index.


### PR DESCRIPTION
- [x] Provisional over syntax to allow declare: and join: in a query
- [x] Fix `model/`to understand `extendSource:` in a query
- [x] Generate `extendSource` in `lang`
- [x] Tests in `lang/`