### PR TITLE
Fix filter source to include whitespace

### DIFF
--- a/packages/malloy-db-test/src/handexpr.spec.ts
+++ b/packages/malloy-db-test/src/handexpr.spec.ts
@@ -121,7 +121,7 @@ export const modelHandBase: StructDef = {
           filterList: [
             {
               aggregate: false,
-              source: "manufacturer='BOEING'",
+              code: "manufacturer='BOEING'",
               expression: [
                 {
                   type: "field",
@@ -576,7 +576,7 @@ export const modelB: StructDef = {
   filterList: [
     {
       expression: [{ type: "field", path: "manufacturer" }, " LIKE 'B%'"],
-      source: "manufacturer ~ 'B%'",
+      code: "manufacturer ~ 'B%'",
     },
   ],
 };

--- a/packages/malloy-db-test/src/test_utils.ts
+++ b/packages/malloy-db-test/src/test_utils.ts
@@ -16,14 +16,14 @@ import { FilterExpression, Fragment } from "@malloydata/malloy";
 export function fStringEq(field: string, value: string): FilterExpression {
   return {
     expression: [{ type: "field", path: field }, `='${value}'`],
-    source: `${field}='${value}'`,
+    code: `${field}='${value}'`,
   };
 }
 
 export function fStringLike(field: string, value: string): FilterExpression {
   return {
     expression: [{ type: "field", path: field }, ` LIKE '${value}'`],
-    source: `${field}~'${value}'`,
+    code: `${field}~'${value}'`,
   };
 }
 
@@ -33,6 +33,6 @@ export function fYearEq(field: string, year: number): FilterExpression {
   const fx: Fragment = { type: "field", path: field };
   return {
     expression: [fx, `>=${yBegin} and `, fx, `<${yEnd}`],
-    source: `${field}:@${year}`,
+    code: `${field}:@${year}`,
   };
 }

--- a/packages/malloy-render/src/drill.ts
+++ b/packages/malloy-render/src/drill.ts
@@ -44,7 +44,7 @@ function getTableFilters(table: DataArray): FilterItem[] {
   const filters = [];
   for (const f of table.field.filters || []) {
     if (!f.aggregate) {
-      filters.push({ key: f.source, value: undefined });
+      filters.push({ key: f.code, value: undefined });
     }
   }
   return filters;

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1024,12 +1024,12 @@ export class FilterElement extends MalloyElement {
     if (exprVal.dataType !== "boolean") {
       this.expr.log("Filter expression must have boolean value");
       return {
-        source: this.exprSrc,
+        code: this.exprSrc,
         expression: ["_FILTER_MUST_RETURN_BOOLEAN_"],
       };
     }
     const exprCond: model.FilterExpression = {
-      source: this.exprSrc,
+      code: this.exprSrc,
       expression: compressExpr(exprVal.value),
     };
     if (exprVal.aggregate) {
@@ -1331,7 +1331,7 @@ class ReduceExecutor implements QueryExecutor {
   finalize(fromSeg: model.PipeSegment | undefined): model.PipeSegment {
     let from: model.ReduceSegment | undefined;
     if (fromSeg) {
-      if (fromSeg.type == "reduce") {
+      if (model.isReduceSegment(fromSeg)) {
         from = fromSeg;
       } else {
         this.queryFS.log(`Can't refine reduce with ${fromSeg.type}`);
@@ -1367,7 +1367,7 @@ class ProjectExecutor extends ReduceExecutor {
   finalize(fromSeg: model.PipeSegment | undefined): model.PipeSegment {
     let from: model.ProjectSegment | undefined;
     if (fromSeg) {
-      if (fromSeg.type == "project") {
+      if (model.isProjectSegment(fromSeg)) {
         from = fromSeg;
       } else {
         this.queryFS.log(`Can't refine project with ${fromSeg.type}`);
@@ -1765,7 +1765,7 @@ abstract class PipelineDesc extends MalloyElement {
     }
     const pipeline: model.PipeSegment[] = [];
     if (modelPipe.pipeHead) {
-      const { pipeline: turtlePipe } = this.importTurtle(
+      const { pipeline: turtlePipe } = this.expandTurtle(
         modelPipe.pipeHead.name,
         fs.structDef()
       );
@@ -1780,7 +1780,7 @@ abstract class PipelineDesc extends MalloyElement {
     return { pipeline };
   }
 
-  protected importTurtle(
+  protected expandTurtle(
     turtleName: string,
     fromStruct: model.StructDef
   ): {
@@ -1900,7 +1900,7 @@ export class FullQuery extends TurtleHeadedPipe {
       const { error } = this.turtleName.getField(pipeFs);
       if (error) this.log(error);
       const name = this.turtleName.refString;
-      const { pipeline, location } = this.importTurtle(name, structDef);
+      const { pipeline, location } = this.expandTurtle(name, structDef);
       destQuery.location = location;
       const refined = this.refinePipeline(pipeFs, { pipeline }).pipeline;
       if (this.headRefinement) {

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -18,6 +18,7 @@ import {
   CharStreams,
   CommonTokenStream,
   ParserRuleContext,
+  CodePointCharStream,
 } from "antlr4ts";
 import type { ParseTree } from "antlr4ts/tree";
 import {
@@ -189,7 +190,8 @@ interface TranslationStep {
 
 export interface MalloyParseRoot {
   root: ParseTree;
-  tokens: CommonTokenStream;
+  tokenStream: CommonTokenStream;
+  sourceStream: CodePointCharStream;
   subTranslator: MalloyTranslation;
   malloyVersion: string;
 }
@@ -316,7 +318,8 @@ class ParseStep implements TranslationStep {
 
     return {
       root: parseFunc.call(malloyParser) as ParseTree,
-      tokens: tokenStream,
+      tokenStream: tokenStream,
+      sourceStream: inputStream,
       // TODO put the real version here
       malloyVersion: "?.?.?-????",
       subTranslator: that,
@@ -338,7 +341,7 @@ class ImportsAndTablesStep implements TranslationStep {
       this.alreadyLooked = true;
       const parseRefs = findReferences(
         that,
-        parseReq.parse.tokens,
+        parseReq.parse.tokenStream,
         parseReq.parse.root
       );
 
@@ -531,7 +534,7 @@ class MetadataStep implements TranslationStep {
         try {
           symbols = walkForDocumentSymbols(
             that,
-            tryParse.parse.tokens,
+            tryParse.parse.tokenStream,
             tryParse.parse.root
           );
         } catch {
@@ -540,7 +543,7 @@ class MetadataStep implements TranslationStep {
         let walkHighlights: DocumentHighlight[];
         try {
           walkHighlights = walkForDocumentHighlights(
-            tryParse.parse.tokens,
+            tryParse.parse.tokenStream,
             tryParse.parse.root
           );
         } catch {
@@ -549,7 +552,7 @@ class MetadataStep implements TranslationStep {
         this.response = {
           symbols,
           highlights: sortHighlights([
-            ...passForHighlights(tryParse.parse.tokens),
+            ...passForHighlights(tryParse.parse.tokenStream),
             ...walkHighlights,
           ]),
           final: true,
@@ -575,7 +578,7 @@ class CompletionsStep implements TranslationStep {
       if (position !== undefined) {
         try {
           completions = walkForDocumentCompletions(
-            tryParse.parse.tokens,
+            tryParse.parse.tokenStream,
             tryParse.parse.root,
             position
           );

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -19,6 +19,7 @@ import * as parse from "./lib/Malloy/MalloyParser";
 import * as ast from "./ast";
 import { MessageLogger } from "./parse-log";
 import { MalloyParseRoot } from "./parse-malloy";
+import { Interval as StreamInterval } from "antlr4ts/misc";
 
 /**
  * ANTLR visitor pattern parse tree traversal. Generates a Malloy
@@ -182,7 +183,13 @@ export class MalloyToAST
 
   protected getFilterElement(cx: parse.FieldExprContext): ast.FilterElement {
     const expr = this.getFieldExpr(cx);
-    const fel = new ast.FilterElement(expr, cx.text);
+    const from = cx.start.startIndex;
+    const lastToken = cx.stop || cx.start;
+    const sourceRange = new StreamInterval(from, lastToken.stopIndex);
+    const fel = new ast.FilterElement(
+      expr,
+      this.parse.sourceStream.getText(sourceRange)
+    );
     return this.astAt(fel, cx);
   }
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -619,6 +619,20 @@ describe("qops", () => {
     "where multiple",
     modelOK("query:a->{ group_by: astr; where: af > 10,astr~'a%' }")
   );
+  test(`filters preserve source formatting in code:`, () => {
+    const model = new BetaModel(`source: notb is a + { where: astr  !=  'b' }`);
+    expect(model).toTranslate();
+    const t = model.translate();
+    const notb = t.translated?.modelDef.contents.notb;
+    expect(notb).toBeDefined();
+    if (notb) {
+      const f = notb.filterList;
+      expect(f).toBeDefined();
+      if (f) {
+        expect(f[0].code).toBe("astr  !=  'b'");
+      }
+    }
+  });
   test(
     "nest single",
     modelOK(`

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -409,24 +409,24 @@ export interface Query extends Pipeline, Filtered, HasLocation {
 
 export type NamedQuery = Query & NamedObject;
 
-export type PipeSegment = ReduceSegment | ProjectSegment | IndexSegment;
+export type PipeSegment = QuerySegment | IndexSegment;
 
 export interface ReduceSegment extends QuerySegment {
   type: "reduce";
 }
 export function isReduceSegment(pe: PipeSegment): pe is ReduceSegment {
-  return (pe as ReduceSegment).type === "reduce";
+  return pe.type === "reduce";
 }
 
 export interface ProjectSegment extends QuerySegment {
   type: "project";
 }
 export function isProjectSegment(pe: PipeSegment): pe is ProjectSegment {
-  return (pe as ProjectSegment).type === "project";
+  return pe.type === "project";
 }
 
 export function isQuerySegment(pe: PipeSegment): pe is QuerySegment {
-  return pe.type === "project" || pe.type === "reduce";
+  return isProjectSegment(pe) || isReduceSegment(pe);
 }
 
 export interface IndexSegment extends Filtered {
@@ -572,7 +572,7 @@ export type PrimaryKeyRef = string;
 /** filters */
 export interface FilterExpression {
   expression: Expr;
-  source: string;
+  code: string;
   aggregate?: boolean;
 }
 


### PR DESCRIPTION
This isn't quite the right thing. But it will do for now.

The long term right thing is for filter expressions to be trees and not string templates.

Why is it not the right thing? If you edit a filter which has comments in it, life will be bad for you.

Which is fine for now, and the fix is to generate expression trees and not expression templates.