### PR TITLE
Use original spacing for `code` of `FieldDef`s (continuation of #442)

### DIFF
--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -248,7 +248,7 @@ export class FieldDeclaration extends MalloyElement {
         template.aggregate = true;
       }
       if (this.exprSrc) {
-        template.source = this.exprSrc;
+        template.code = this.exprSrc;
       }
       // TODO this should work for dates too
       if (isGranularResult(exprValue) && template.type === "timestamp") {

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -181,15 +181,16 @@ export class MalloyToAST
     return el;
   }
 
-  protected getFilterElement(cx: parse.FieldExprContext): ast.FilterElement {
-    const expr = this.getFieldExpr(cx);
+  protected getSourceCode(cx: ParserRuleContext): string {
     const from = cx.start.startIndex;
     const lastToken = cx.stop || cx.start;
     const sourceRange = new StreamInterval(from, lastToken.stopIndex);
-    const fel = new ast.FilterElement(
-      expr,
-      this.parse.sourceStream.getText(sourceRange)
-    );
+    return this.parse.sourceStream.getText(sourceRange);
+  }
+
+  protected getFilterElement(cx: parse.FieldExprContext): ast.FilterElement {
+    const expr = this.getFieldExpr(cx);
+    const fel = new ast.FilterElement(expr, this.getSourceCode(cx));
     return this.astAt(fel, cx);
   }
 
@@ -409,7 +410,11 @@ export class MalloyToAST
     const defCx = pcx.fieldExpr();
     const fieldName = this.getIdText(pcx.fieldNameDef());
     const valExpr = this.getFieldExpr(defCx);
-    const def = new ast.FieldDeclaration(valExpr, fieldName, defCx.text);
+    const def = new ast.FieldDeclaration(
+      valExpr,
+      fieldName,
+      this.getSourceCode(defCx)
+    );
     return this.astAt(def, pcx);
   }
 

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -633,6 +633,24 @@ describe("qops", () => {
       }
     }
   });
+  test(`field expressions preserve source formatting in code:`, () => {
+    const model = new BetaModel(
+      `source: notb is a + { dimension: d is 1 +   2 }`
+    );
+    expect(model).toTranslate();
+    const t = model.translate();
+    const notb = t.translated?.modelDef.contents.notb;
+    expect(notb).toBeDefined();
+    expect(notb?.type).toBe("struct");
+    if (notb?.type === "struct") {
+      const d = notb.fields.find((f) => f.as || f.name === "d");
+      expect(d).toBeDefined();
+      expect(d?.type).toBe("number");
+      if (d?.type === "number") {
+        expect(d.code).toBe("1 +   2");
+      }
+    }
+  });
   test(
     "nest single",
     modelOK(`

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -212,7 +212,7 @@ export class TestTranslator extends MalloyTranslator {
             numberType: "integer",
             aggregate: true,
             e: ["COUNT()"],
-            source: "count()",
+            code: "count()",
           },
           {
             type: "turtle",

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1668,7 +1668,7 @@ class QueryQuery extends QueryField {
         let filterList;
         const sourceField =
           fi.f.parent.getFullOutputName() + (fieldDef.name || fieldDef.as);
-        const sourceExpression: string | undefined = fieldDef.source;
+        const sourceExpression: string | undefined = fieldDef.code;
         const sourceClasses = [sourceField];
         if (isAggregateField(fi.f)) {
           filterList = fi.f.getFilterList();

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -214,7 +214,7 @@ export type Expr = Fragment[];
 export interface Expression {
   e?: Expr;
   aggregate?: boolean;
-  source?: string;
+  code?: string;
 }
 
 interface JustExpression {


### PR DESCRIPTION
This PR applies the same change as #442 applied to filter expressions, but to field expressions. Now, field expressions' `code` field (renamed from `source`) will match the original spacing of the source code. 