### PR TITLE
allow join elements in index lists

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1164,20 +1164,20 @@ export class FieldReference extends ListOf<FieldName> {
   }
 }
 
-export type FieldListReference = FieldReference | WildcardFieldReference;
+export type FieldReferenceElement = FieldReference | WildcardFieldReference;
 
-export class FieldReferences extends ListOf<FieldListReference> {
-  constructor(members: FieldListReference[]) {
+export class FieldReferences extends ListOf<FieldReferenceElement> {
+  constructor(members: FieldReferenceElement[]) {
     super("fieldReferenceList", members);
   }
 }
-export function isFieldListReference(
+export function isFieldReferenceElement(
   me: MalloyElement
-): me is FieldListReference {
+): me is FieldReferenceElement {
   return me instanceof FieldReference || me instanceof WildcardFieldReference;
 }
 
-export type FieldCollectionMember = FieldListReference | FieldDeclaration;
+export type FieldCollectionMember = FieldReferenceElement | FieldDeclaration;
 export function isFieldCollectionMember(
   el: MalloyElement
 ): el is FieldCollectionMember {

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1171,12 +1171,6 @@ export class FieldReferences extends ListOf<FieldReferenceElement> {
     super("fieldReferenceList", members);
   }
 }
-export function isFieldReferenceElement(
-  me: MalloyElement
-): me is FieldReferenceElement {
-  return me instanceof FieldReference || me instanceof WildcardFieldReference;
-}
-
 export type FieldCollectionMember = FieldReferenceElement | FieldDeclaration;
 export function isFieldCollectionMember(
   el: MalloyElement

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -292,8 +292,17 @@ topStatement
   : TOP INTEGER_LITERAL bySpec?
   ;
 
+indexElement
+  : fieldPath (DOT STAR)?
+  | STAR
+  ;
+
+indexFields
+  : indexElement ( COMMA? indexElement )*
+  ;
+
 indexStatement
-  : INDEX fieldNameList (BY fieldName)?
+  : INDEX indexFields (BY fieldName)?
   ;
 
 aggregate: SUM | COUNT | AVG | MIN | MAX;
@@ -377,12 +386,7 @@ argumentList
   ;
 
 fieldNameList
-  : fieldOrStar (COMMA? fieldOrStar)* COMMA?
-  ;
-
-fieldOrStar
-  : STAR
-  | fieldName
+  : fieldName (COMMA? fieldName)*
   ;
 
 fieldCollection

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -493,19 +493,10 @@ export class MalloyToAST
     return this.astAt(node, pcx);
   }
 
-  visitFieldOrStar(pcx: parse.FieldOrStarContext): ast.FieldListReference {
-    if (pcx.STAR()) {
-      return this.astAt(new ast.WildcardFieldReference(undefined, "*"), pcx);
-    }
-    const fcx = pcx.fieldName();
-    if (fcx) {
-      return this.astAt(new ast.FieldReference([this.getFieldName(fcx)]), fcx);
-    }
-    throw this.internalError(pcx, "mis-parsed field name reference");
-  }
-
   visitFieldNameList(pcx: parse.FieldNameListContext): ast.FieldReferences {
-    const members = pcx.fieldOrStar().map((cx) => this.visitFieldOrStar(cx));
+    const members = pcx
+      .fieldName()
+      .map((cx) => new ast.FieldReference([this.getFieldName(cx)]));
     return new ast.FieldReferences(members);
   }
 
@@ -592,15 +583,31 @@ export class MalloyToAST
     return this.astAt(new ast.ProjectStatement(fields), pcx);
   }
 
-  visitWildMember(pcx: parse.WildMemberContext): ast.FieldListReference {
+  visitWildMember(pcx: parse.WildMemberContext): ast.FieldReferenceElement {
     const nameCx = pcx.fieldPath();
     const stars = pcx.STAR() ? "*" : "**";
     const join = nameCx ? this.visitFieldPath(nameCx) : undefined;
     return new ast.WildcardFieldReference(join, stars);
   }
 
+  visitIndexFields(pcx: parse.IndexFieldsContext): ast.FieldReferences {
+    const refList = pcx.indexElement().map((el) => {
+      const hasStar = el.STAR() != undefined;
+      const pathCx = el.fieldPath();
+      if (!pathCx) {
+        return new ast.WildcardFieldReference(undefined, "*");
+      }
+      const path = this.visitFieldPath(pathCx);
+      if (!hasStar) {
+        return this.astAt(path, pcx);
+      }
+      return this.astAt(new ast.WildcardFieldReference(path, "*"), pcx);
+    });
+    return new ast.FieldReferences(refList);
+  }
+
   visitIndexStatement(pcx: parse.IndexStatementContext): ast.Index {
-    const fields = this.visitFieldNameList(pcx.fieldNameList());
+    const fields = this.visitIndexFields(pcx.indexFields());
     const indexStmt = new ast.Index(fields);
     const weightCx = pcx.fieldName();
     if (weightCx) {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -579,6 +579,8 @@ describe("qops", () => {
     `)
   );
   test("index single", modelOK("query:a->{index: astr}"));
+  test("index path", modelOK("query:ab->{index: ab.astr}"));
+  test("index join.*", modelOK("query:ab->{index: ab.*}"));
   test("index multiple", modelOK("query:a->{index: astr,af}"));
   test("index star", modelOK("query:a->{index: *}"));
   test("index by", modelOK("query:a->{index: * by ai}"));


### PR DESCRIPTION
Somehow indexes never supported dotted names. With this index index syntax is now

`index:` _fieldPath_ ( `,` _fieldPath_ )* (`by` _fieldName_)?
