### PR TITLE
move away from : for apply

### DIFF
--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -355,7 +355,7 @@ fieldExpr
   | startAt=fieldExpr FOR duration=fieldExpr timeframe     # exprForRange
   | fieldExpr (AMPER | BAR) partialAllowedFieldExpr        # exprLogicalTree
   | fieldExpr compareOp fieldExpr                          # exprCompare
-  | fieldExpr COLON partialAllowedFieldExpr                # exprApply
+  | fieldExpr (COLON | QMARK) partialAllowedFieldExpr      # exprApply
   | NOT fieldExpr                                          # exprNot
   | fieldExpr (AND | OR) fieldExpr                         # exprLogical
   | CAST OPAREN fieldExpr AS malloyType CPAREN             # exprCast

--- a/packages/malloy/src/lang/parse-log.ts
+++ b/packages/malloy/src/lang/parse-log.ts
@@ -13,7 +13,7 @@
 
 import { DocumentLocation } from "../model/malloy_types";
 
-type LogSeverity = "error" | "warn" | "debug";
+export type LogSeverity = "error" | "warn" | "debug";
 
 /**
  * Default severity is "error"


### PR DESCRIPTION
it's left-over from old days and it looks bad with `where: field: value`

new hotness: `where: field ? value`