### PR TITLE
Wrap numeric terms in parens, closes #454

### DIFF
--- a/packages/malloy/src/lang/ast/apply-expr.ts
+++ b/packages/malloy/src/lang/ast/apply-expr.ts
@@ -223,7 +223,8 @@ function numeric(
     return {
       dataType: "number",
       aggregate: anyAggregate,
-      value: compose(lhs.value, op, rhs.value),
+      // set needsParens to true for mathematical order of operations
+      value: compose(lhs.value, op, rhs.value, true),
     };
   }
 

--- a/packages/malloy/src/lang/ast/ast-types.ts
+++ b/packages/malloy/src/lang/ast/ast-types.ts
@@ -186,9 +186,9 @@ export function errorFor(reason: string): ExprValue {
  * If the passed expresion is not a single term, wrap it in parens
  * @param f expression fragment
  */
-function term(f: Fragment[]): Fragment[] {
+function composeTerm(f: Fragment[]): Fragment[] {
   if (f.length > 1) {
-    return ["(", ...f, ")"];
+    return wrapInParens(f);
   }
   if (f.length === 0) {
     // Trying to compose a binary expresion with an entity that has no value
@@ -197,6 +197,10 @@ function term(f: Fragment[]): Fragment[] {
     return ["__MISSING_VALUE__"];
   }
   return f;
+}
+
+function wrapInParens(f: Fragment[]): Fragment[] {
+  return ["(", ...f, ")"];
 }
 
 export function compressExpr(expr: Expr): Expr {
@@ -225,18 +229,21 @@ export function compressExpr(expr: Expr): Expr {
  * @param left
  * @param op
  * @param right
+ * @param needsParens
  * @returns Fragment list of the composed expression
  */
 export function compose(
   left: Fragment[],
   op: string,
-  right: Fragment[]
+  right: Fragment[],
+  needsParens?: true
 ): Fragment[] {
   const opAlpha = op.match(/^[A-Za-z]/);
   const leftSpace = left.length === 1 && opAlpha ? " " : "";
   const rightSpace = right.length === 1 && opAlpha ? " " : "";
   const newOp = leftSpace + op + rightSpace;
-  return [...term(left), newOp, ...term(right)];
+  const composed = [...composeTerm(left), newOp, ...composeTerm(right)];
+  return needsParens ? wrapInParens(composed) : composed;
 }
 
 export function dateOffset(


### PR DESCRIPTION
Basically, wrap any numerical operation in parens. Maybe it's now over–paren-ing in some spots (it's not immediately clear how to safely dedupe), but the bug is fixed and the resulting SQL from [the issue](https://github.com/looker-open-source/malloy/issues/454) becomes:

```sql
SELECT 
   ((((base.product_retail_price-base.cost)))/(nullif(base.product_retail_price,0))) as gross_margin_pct_good,
   ((base.product_retail_price-base.cost)/(nullif(base.product_retail_price,0))) as gross_margin_pct_bad
FROM `malloy-data.ecomm.inventory_items` as base
```

![Screen Shot 2022-04-17 at 10 41 33 PM](https://user-images.githubusercontent.com/28961086/163760663-8da1da77-ca65-4fb8-ab57-905a4c2117d6.png)
