### PR TITLE
Arrays are really nested tables with one column

### DIFF
--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -250,7 +250,11 @@ export class PostgresConnection implements Connection {
       create temp table ${tempTableName} as SELECT * FROM (
         ${sqlRef.select}
       ) as x where false;
-      SELECT column_name, data_type FROM information_schema.columns where table_name='${tempTableName}';
+      SELECT column_name, c.data_type, e.data_type as element_type
+      FROM information_schema.columns c LEFT JOIN information_schema.element_types e
+        ON ((c.table_catalog, c.table_schema, c.table_name, 'TABLE', c.dtd_identifier)
+          = (e.object_catalog, e.object_schema, e.object_name, e.object_type, e.collection_type_identifier))
+      where table_name='${tempTableName}';
     `;
     await this.schemaFromQuery(infoQuery, structDef);
     return structDef;
@@ -268,11 +272,26 @@ export class PostgresConnection implements Connection {
     );
     for (const row of result.rows) {
       const postgresDataType = row["data_type"] as string;
-      const malloyType = postgresToMalloyTypes[postgresDataType];
-      if (malloyType !== undefined) {
-        structDef.fields.push({
-          type: malloyType,
+      let s = structDef;
+      let malloyType = postgresToMalloyTypes[postgresDataType];
+      let name = row["column_name"] as string;
+      if (postgresDataType === "ARRAY") {
+        malloyType = postgresToMalloyTypes[row["element_type"] as string];
+        s = {
+          type: "struct",
           name: row["column_name"] as string,
+          dialect: this.dialectName,
+          structRelationship: { type: "nested", field: name, isArray: true },
+          structSource: { type: "nested" },
+          fields: [],
+        };
+        structDef.fields.push(s);
+        name = "value";
+      }
+      if (malloyType !== undefined) {
+        s.fields.push({
+          type: malloyType,
+          name,
         });
       } else {
         throw new Error(`unknown postgres type ${postgresDataType}`);

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -105,7 +105,8 @@ export abstract class Dialect {
     source: string,
     alias: string,
     fieldList: DialectFieldList,
-    needDistinctKey: boolean
+    needDistinctKey: boolean,
+    isArray: boolean
   ): string;
 
   abstract sqlSumDistinctHashedKey(sqlDistinctKey: string): string;

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -106,9 +106,16 @@ export class StandardSQLDialect extends Dialect {
     source: string,
     alias: string,
     fieldList: DialectFieldList,
-    needDistinctKey: boolean
+    needDistinctKey: boolean,
+    isArray: boolean
   ): string {
-    if (needDistinctKey) {
+    if (isArray) {
+      if (needDistinctKey) {
+        return `LEFT JOIN UNNEST(ARRAY(( SELECT AS STRUCT GENERATE_UUID() as __distinct_key, value FROM UNNEST(${source}) value))) as ${alias}`;
+      } else {
+        return `LEFT JOIN UNNEST(ARRAY((SELECT AS STRUCT value FROM unnest(${source}) value))) as ${alias}`;
+      }
+    } else if (needDistinctKey) {
       return `LEFT JOIN UNNEST(ARRAY(( SELECT AS STRUCT GENERATE_UUID() as __distinct_key, * FROM UNNEST(${source})))) as ${alias}`;
     } else {
       return `LEFT JOIN UNNEST(${source}) as ${alias}`;

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -96,7 +96,7 @@ describe("structdef comprehension", () => {
       name: "t",
       type: "struct",
       dialect: "standardsql",
-      structRelationship: { type: "nested", field: "a" },
+      structRelationship: { type: "nested", field: "a", isArray: false },
       structSource: { type: "nested" },
       fields: [{ type: "string", name: "b" }],
     };

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -488,7 +488,7 @@ export type StructRelationship =
   | { type: "basetable"; connectionName: string }
   | JoinOn
   | { type: "inline" }
-  | { type: "nested"; field: FieldRef };
+  | { type: "nested"; field: FieldRef; isArray: boolean };
 
 /**
  * Use factory makeSQLBlock to create one of these, it will compute the


### PR DESCRIPTION
Malloy treats arrays as nested tables with a single column named 'value'.  This obviates the need for special functions for arrays like ARRAY_AGG and ARRAY.  

There is more work to do here around UNNEST, but this will be the same for both nested results and arrays.

Added array support for postgres and bigquery