### PR TITLE
Fix reference to unknown source in query

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -44,8 +44,8 @@ export class ErrorFactory {
   static get structDef(): model.StructDef {
     const ret: model.StructDef = {
       type: "struct",
-      name: "//undefined_error_structdef",
-      dialect: "//undefined_errror_dialect",
+      name: "~malformed~",
+      dialect: "~malformed~",
       structSource: { type: "table" },
       structRelationship: {
         type: "basetable",
@@ -57,7 +57,8 @@ export class ErrorFactory {
   }
 
   static isErrorStructdef(s: model.StructDef): boolean {
-    return s.name === this.structDef.name;
+    const sd = this.structDef;
+    return s.name.includes(sd.name);
   }
 
   static get query(): model.Query {
@@ -717,12 +718,11 @@ export class NamedSource extends Mallobj {
 
     const ret = this.modelStruct();
     if (!ret) {
-      const noSql = {
-        ...ErrorFactory.structDef,
-        name: "_reference_undefined_" + this.refName,
-        dialect: "MISSING_reference_undefined_" + this.refName,
-      };
-      return noSql;
+      const notFound = ErrorFactory.structDef;
+      const err = `${this.refName}-undefined`;
+      notFound.name = notFound.name + err;
+      notFound.dialect = notFound.dialect + err;
+      return notFound;
     }
     const declared = { ...ret.parameters } || {};
 
@@ -1894,6 +1894,15 @@ export class FullQuery extends TurtleHeadedPipe {
       : this.explore.structDef();
     let pipeFs = new DynamicSpace(structDef);
 
+    if (ErrorFactory.isErrorStructdef(structDef)) {
+      return {
+        outputStruct: structDef,
+        query: {
+          structRef: structRef,
+          pipeline: [],
+        },
+      };
+    }
     if (this.turtleName) {
       const { error } = this.turtleName.getField(pipeFs);
       if (error) this.log(error);

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -954,14 +954,16 @@ describe("sql backdoor", () => {
 });
 
 describe("error handling", () => {
-  test("query reference to undefined explore", () => {
-    expect(markSource`query: ${"x"}->{ group_by: y }`).compileToFailWith(
+  test("query from undefined source", () => {
+    expect(markSource`query: ${"x"}->{ project: y }`).compileToFailWith(
       "Undefined source 'x'"
     );
   });
-  test("query with expression reference to undefined explore", () => {
+  test("query with expression from undefined source", () => {
+    // Regression check: Once upon a time this died with an exception even
+    // when "query: x->{ group_by: y}" (above) generated the correct error.
     expect(
-      markSource`query: x is ${"x"}->{ project: xv is join.val / table_val }`
+      markSource`query: ${"x"}->{ project: y is z / 2 }`
     ).compileToFailWith("Undefined source 'x'");
   });
   test("join reference before definition", () => {

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -959,6 +959,11 @@ describe("error handling", () => {
       "Undefined source 'x'"
     );
   });
+  test("query with expression reference to undefined explore", () => {
+    expect(
+      markSource`query: x is ${"x"}->{ project: xv is join.val / table_val }`
+    ).compileToFailWith("Undefined source 'x'");
+  });
   test("join reference before definition", () => {
     expect(
       markSource`


### PR DESCRIPTION
This died with an exception on unknown dialect ...

```
query: x->{ project: x is y / 2 }
```

This pr prevents the exception and allows the "Unknown source 'x'" error to be reported.