### PR TITLE
Add SQL copy button, for #451

### DIFF
--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -132,6 +132,15 @@ export const App: React.FC = () => {
         ""
       )}
       {!error && <ResultKindToggle kind={resultKind} setKind={setResultKind} />}
+      {!error && resultKind === ResultKind.SQL && (
+        <CopyButton
+          onClick={() => {
+            navigator.clipboard.writeText(queryHTMLStringToString(sql));
+          }}
+        >
+          COPY SQL
+        </CopyButton>
+      )}
       {!error && resultKind === ResultKind.HTML && (
         <Scroll>
           <div style={{ margin: "10px" }}>
@@ -254,3 +263,19 @@ const DrillTooltip = styled.div`
   box-shadow: rgb(144 144 144) 0px 1px 5px 0px;
   padding: 5px;
 `;
+
+const CopyButton = styled.button`
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  width: fit-content;
+  color: #b1b1b1;
+  font-weight: 500;
+  font-size: 12px;
+  background-color: white;
+  padding: 5px 10px;
+`;
+
+function queryHTMLStringToString(query: string) {
+  return query.replace(/<[^>]+>/g, "");
+}


### PR DESCRIPTION
An idea for a SQL copy button. It copies the SQL without the HTML tags.

It needs some styling help (please fix if you want—definitely not my strong suit). It could switch to say "COPIED!" when it's clicked and hover to blue like the `SQL`/`HTML`/`JSON` buttons.

<img width="481" alt="Screen Shot 2022-04-19 at 10 31 55 PM" src="https://user-images.githubusercontent.com/28961086/164157323-8d47210f-1cd3-44c7-8534-0358c700ca68.png">

<img width="1070" alt="Screen Shot 2022-04-19 at 10 34 34 PM" src="https://user-images.githubusercontent.com/28961086/164157490-9501c131-86ba-47c0-b4cc-7e0588d9b93b.png">