### PR TITLE
Remove extra new line in unnest join, closes #401

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1949,7 +1949,7 @@ class QueryQuery extends QueryField {
         qs.parent.fieldDef.structRelationship.type === "nested"
       );
       // we need to generate primary key.  If parent has a primary key combine
-      s += `\n${this.parent.dialect.sqlUnnestAlias(
+      s += `${this.parent.dialect.sqlUnnestAlias(
         fieldExpression,
         ji.alias,
         ji.getDialectFieldList(),


### PR DESCRIPTION
Query in the linked issue is now:

```sql
SELECT 
   SUM(product_0.productRevenue) as total_productRevenue
FROM `bigquery-public-data.google_analytics_sample.ga_sessions_20170801` as ga_sessions
LEFT JOIN UNNEST(ga_sessions.hits) as hits_0
LEFT JOIN UNNEST(hits_0.product) as product_0
ORDER BY 1 desc
```

Other left join lines like 1923 and 1936 in this same file don't start with `\n`, so makes sense that this one wouldn't either.