### PR TITLE
Handle Postgres table paths with capitals, closes #495, closes #499

### DIFF
--- a/packages/malloy-db-test/src/postgres.spec.ts
+++ b/packages/malloy-db-test/src/postgres.spec.ts
@@ -126,7 +126,7 @@ describe("postgres tests", () => {
     expect(result.data.value[0].n).toBe(1);
   });
 
-  it(`sql_block`, async () => {
+  it(`quote field name`, async () => {
     const result = await runtime
       .loadQuery(
         `

--- a/packages/malloy/src/dialect/dialect.ts
+++ b/packages/malloy/src/dialect/dialect.ts
@@ -47,8 +47,8 @@ export abstract class Dialect {
   abstract divisionIsInteger: boolean;
   protected abstract functionInfo: Record<string, FunctionInfo>;
 
-  // return a quoted string for use as a table name.
-  abstract quoteTableName(tableName: string): string;
+  // return a quoted string for use as a table path.
+  abstract quoteTablePath(tablePath: string): string;
 
   // returns an table that is a 0 based array of numbers
   abstract sqlGroupSetTable(groupSetCount: number): string;

--- a/packages/malloy/src/dialect/postgres.ts
+++ b/packages/malloy/src/dialect/postgres.ts
@@ -61,8 +61,11 @@ export class PostgresDialect extends Dialect {
   divisionIsInteger = true;
   functionInfo: Record<string, FunctionInfo> = {};
 
-  quoteTableName(tableName: string): string {
-    return `${tableName}`;
+  quoteTablePath(tablePath: string): string {
+    return tablePath
+      .split(".")
+      .map((part) => `"${part}"`)
+      .join(".");
   }
 
   sqlGroupSetTable(groupSetCount: number): string {

--- a/packages/malloy/src/dialect/standardsql.ts
+++ b/packages/malloy/src/dialect/standardsql.ts
@@ -54,8 +54,8 @@ export class StandardSQLDialect extends Dialect {
     timestamp_seconds: { returnType: "timestamp" },
   };
 
-  quoteTableName(tableName: string): string {
-    return `\`${tableName}\``;
+  quoteTablePath(tablePath: string): string {
+    return `\`${tablePath}\``;
   }
 
   sqlGroupSetTable(groupSetCount: number): string {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3023,7 +3023,7 @@ class QueryStruct extends QueryNode {
         const { tablePath } = parseTableURL(
           this.fieldDef.structSource.tablePath || this.fieldDef.name
         );
-        return this.dialect.quoteTableName(tablePath);
+        return this.dialect.quoteTablePath(tablePath);
       }
       case "sql":
         if (this.fieldDef.structSource.method === "nested") {


### PR DESCRIPTION
Closes https://github.com/looker-open-source/malloy/issues/495

`packages/malloy-db-test/src/postgres.spec.ts` isn't quite set up to easily make and drop schemas and tables, but an automated test could be added eventually to mirror the manual test below:

<img width="909" alt="Screen Shot 2022-04-20 at 11 36 26 PM" src="https://user-images.githubusercontent.com/28961086/164390114-49faa8b1-1218-445e-a330-6cd62d91f405.png">
