### PR TITLE
Parens around join filters, closes #469

### DIFF
--- a/packages/malloy-db-test/src/nomodel.spec.ts
+++ b/packages/malloy-db-test/src/nomodel.spec.ts
@@ -192,6 +192,7 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       `
       )
       .run();
+    // https://github.com/looker-open-source/malloy/pull/501#discussion_r861022857
     expect(result.data.value).toHaveLength(3);
     expect(result.data.value).toContainEqual({ c: 1845, state: "TX" });
     expect(result.data.value).toContainEqual({ c: 500, state: "LA" });

--- a/packages/malloy-db-test/src/nomodel.spec.ts
+++ b/packages/malloy-db-test/src/nomodel.spec.ts
@@ -138,10 +138,10 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     const result = await runtime
       .loadQuery(
         `
-      explore: a is table('malloy-data.malloytest.airports'){
+      explore: a is table('malloytest.airports'){
         where: state = 'NH' | 'CA'
       }
-      explore: b is table('malloy-data.malloytest.state_facts') {
+      explore: b is table('malloytest.state_facts') {
         join_many: a on state=a.state
       }
       query: b->{

--- a/packages/malloy-db-test/src/nomodel.spec.ts
+++ b/packages/malloy-db-test/src/nomodel.spec.ts
@@ -192,12 +192,10 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       `
       )
       .run();
-    expect(result.data.value[0].c).toBe(1845);
-    expect(result.data.value[0].state).toBe("TX");
-    expect(result.data.value[1].c).toBe(500);
-    expect(result.data.value[1].state).toBe("LA");
-    expect(result.data.value[2].c).toBeNull();
-    expect(result.data.value[2].state).toBeNull();
+    expect(result.data.value).toHaveLength(3);
+    expect(result.data.value).toContainEqual({ c: 1845, state: "TX" });
+    expect(result.data.value).toContainEqual({ c: 500, state: "LA" });
+    expect(result.data.value).toContainEqual({ c: null, state: null });
   });
 
   it(`join_many cross from  - ${databaseName}`, async () => {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1852,7 +1852,7 @@ class QueryQuery extends QueryField {
       }
       if (ji.children.length === 0 || conditions === undefined) {
         if (conditions !== undefined && conditions.length >= 1) {
-          filters = ` AND ${conditions.join(" AND ")}`;
+          filters = ` AND (${conditions.join(" AND ")})`;
         }
         s += `LEFT JOIN ${structSQL} AS ${ji.alias}\n  ON ${onCondition}${filters}\n`;
       } else {


### PR DESCRIPTION
Query [from issue](https://github.com/looker-open-source/malloy/issues/469) becomes

```sql
SELECT 
   users_0.state as state
FROM `malloy-data.ecomm.order_items` as order_items
LEFT JOIN `malloy-data.ecomm.users` AS users_0
  ON users_0.id=order_items.user_id AND ((users_0.state='California')or((users_0.state='New York')or(users_0.state='Oregon')))
GROUP BY 1
ORDER BY 1 asc
```

An alternative would be "add parens only if `conditions` has an 'or'".