### PR TITLE
Move to a custom matcher for SQL result checking

### DIFF
--- a/packages/malloy-db-test/src/datetimes.spec.ts
+++ b/packages/malloy-db-test/src/datetimes.spec.ts
@@ -330,7 +330,10 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         expect(result).isSqlEq();
       });
       test(`timestamp delta hours - ${databaseName}`, async () => {
-        const eq = await sqlEq("t_timestamp + 10 hours", "@2021-02-24 13:05:06");
+        const eq = await sqlEq(
+          "t_timestamp + 10 hours",
+          "@2021-02-24 13:05:06"
+        );
         expect(eq).isSqlEq();
       });
       test(`timestamp delta week - ${databaseName}`, async () => {

--- a/packages/malloy-db-test/src/datetimes.spec.ts
+++ b/packages/malloy-db-test/src/datetimes.spec.ts
@@ -50,284 +50,257 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
   const sqlEq = mkSqlEqWith(runtime, { sql: basicTypes[databaseName] });
 
   test(`date in sql_block no explore- ${databaseName}`, async () => {
-    const result = await sqlEq("t_date", "@2021-02-24");
-    expect(result).isSqlEq();
+    const eq = sqlEq("t_date", "@2021-02-24");
+    expect(await eq).isSqlEq();
   });
 
   test(`timestamp in sql_block no explore- ${databaseName}`, async () => {
-    const result = await sqlEq("t_timestamp", "@2021-02-24 03:05:06");
-    expect(result).isSqlEq();
+    const eq = sqlEq("t_timestamp", "@2021-02-24 03:05:06");
+    expect(await eq).isSqlEq();
   });
 
   test(`valid timestamp without seconds - ${databaseName}`, async () => {
     // discovered this writing tests ...
-    const result = await sqlEq("year(@2000-01-01 00:00)", "2000");
-    expect(result).isSqlEq();
+    const eq = sqlEq("year(@2000-01-01 00:00)", "2000");
+    expect(await eq).isSqlEq();
   });
 
   describe(`time operations - ${databaseName}`, () => {
     describe(`time difference - ${databaseName}`, () => {
       test("forwards is positive", async () => {
-        const result = await sqlEq("day(@2000-01-01 to @2000-01-02)", "1");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day(@2000-01-01 to @2000-01-02)", "1");
+        expect(await eq).isSqlEq();
       });
       test("reverse is negative", async () => {
-        const result = await sqlEq("day(@2000-01-02 to @2000-01-01)", "-1");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day(@2000-01-02 to @2000-01-01)", "-1");
+        expect(await eq).isSqlEq();
       });
       test("DATE to TIMESTAMP", async () => {
-        const result = await sqlEq(
-          "day((@1999)::date to @2000-01-01 00:00:00)",
-          "365"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("day((@1999)::date to @2000-01-01 00:00:00)", "365");
+        expect(await eq).isSqlEq();
       });
       test("TIMESTAMP to DATE", async () => {
-        const result = await sqlEq(
-          "month(@2000-01-01 to (@1999)::date)",
-          "-12"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("month(@2000-01-01 to (@1999)::date)", "-12");
+        expect(await eq).isSqlEq();
       });
       test("seconds", async () => {
-        const result = await sqlEq(
+        const eq = sqlEq(
           "seconds(@2001-01-01 00:00:00 to @2001-01-01 00:00:42)",
           "42"
         );
-        expect(result).isSqlEq();
+        expect(await eq).isSqlEq();
       });
       test("many seconds", async () => {
-        const result = await sqlEq(
+        const eq = sqlEq(
           "seconds(@2001-01-01 00:00:00 to @2001-01-02 00:00:42)",
           "86442"
         );
-        expect(result).isSqlEq();
+        expect(await eq).isSqlEq();
       });
       test("minutes", async () => {
-        const result = await sqlEq(
+        const eq = sqlEq(
           "minutes(@2001-01-01 00:00:00 to @2001-01-01 00:42:00)",
           "42"
         );
-        expect(result).isSqlEq();
+        expect(await eq).isSqlEq();
       });
       test("many minutes", async () => {
-        const result = await sqlEq(
+        const eq = sqlEq(
           "minutes(@2001-01-01 00:00:00 to @2001-01-02 00:42:00)",
           "1482"
         );
-        expect(result).isSqlEq();
+        expect(await eq).isSqlEq();
       });
 
       test("hours", async () => {
-        const result = await sqlEq(
+        const eq = sqlEq(
           "hours(@2001-01-01 00:00:00 to @2001-01-02 18:00:00)",
           "42"
         );
-        expect(result).isSqlEq();
+        expect(await eq).isSqlEq();
       });
       test("days", async () => {
-        const result = await sqlEq("days(@2001-01-01 to @2001-02-12)", "42");
-        expect(result).isSqlEq();
+        const eq = sqlEq("days(@2001-01-01 to @2001-02-12)", "42");
+        expect(await eq).isSqlEq();
       });
       test("weeks", async () => {
-        const result = await sqlEq("weeks(@2001-01-01 to @2001-10-27)", "42");
-        expect(result).isSqlEq();
+        const eq = sqlEq("weeks(@2001-01-01 to @2001-10-27)", "42");
+        expect(await eq).isSqlEq();
       });
       test("quarters", async () => {
-        const result = await sqlEq(
-          "quarters(@2001-01-01 to @2011-09-30)",
-          "42"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("quarters(@2001-01-01 to @2011-09-30)", "42");
+        expect(await eq).isSqlEq();
       });
       test("months", async () => {
-        const result = await sqlEq("months(@2000-01-01 to @2003-07-01)", "42");
-        expect(result).isSqlEq();
+        const eq = sqlEq("months(@2000-01-01 to @2003-07-01)", "42");
+        expect(await eq).isSqlEq();
       });
       test("years", async () => {
-        const result = await sqlEq("year(@2000 to @2042)", "42");
-        expect(result).isSqlEq();
+        const eq = sqlEq("year(@2000 to @2042)", "42");
+        expect(await eq).isSqlEq();
       });
     });
 
     describe(`timestamp truncation - ${databaseName}`, () => {
       // 2021-02-24 03:05:06
       test(`trunc second - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp.second",
-          "@2021-02-24 03:05:06"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.second", "@2021-02-24 03:05:06");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc minute - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp.minute",
-          "@2021-02-24 03:05:00"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.minute", "@2021-02-24 03:05:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc hour - ${databaseName}`, async () => {
-        const result = await sqlEq("t_timestamp.hour", "@2021-02-24 03:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.hour", "@2021-02-24 03:00:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc day - ${databaseName}`, async () => {
-        const result = await sqlEq("t_timestamp.day", "@2021-02-24 00:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.day", "@2021-02-24 00:00:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc week - ${databaseName}`, async () => {
-        const result = await sqlEq("t_timestamp.week", "@2021-02-21 00:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.week", "@2021-02-21 00:00:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc month - ${databaseName}`, async () => {
-        const result = await sqlEq("t_timestamp.month", "@2021-02-01 00:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.month", "@2021-02-01 00:00:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc quarter - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp.quarter",
-          "@2021-01-01 00:00:00"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.quarter", "@2021-01-01 00:00:00");
+        expect(await eq).isSqlEq();
       });
 
       test(`trunc year - ${databaseName}`, async () => {
-        const result = await sqlEq("t_timestamp.year", "@2021-01-01 00:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp.year", "@2021-01-01 00:00:00");
+        expect(await eq).isSqlEq();
       });
     });
 
     describe(`timestamp extraction - ${databaseName}`, () => {
       // 2021-02-24 03:05:06
       test(`extract second - ${databaseName}`, async () => {
-        const result = await sqlEq("second(t_timestamp)", "6");
-        expect(result).isSqlEq();
+        const eq = sqlEq("second(t_timestamp)", "6");
+        expect(await eq).isSqlEq();
       });
       test(`extract minute - ${databaseName}`, async () => {
-        const result = await sqlEq("minute(t_timestamp)", "5");
-        expect(result).isSqlEq();
+        const eq = sqlEq("minute(t_timestamp)", "5");
+        expect(await eq).isSqlEq();
       });
       test(`extract hour - ${databaseName}`, async () => {
-        const result = await sqlEq("hour(t_timestamp)", "3");
-        expect(result).isSqlEq();
+        const eq = sqlEq("hour(t_timestamp)", "3");
+        expect(await eq).isSqlEq();
       });
       test(`extract day - ${databaseName}`, async () => {
-        const result = await sqlEq("day(t_timestamp)", "24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day(t_timestamp)", "24");
+        expect(await eq).isSqlEq();
       });
       test(`extract day_of_week - ${databaseName}`, async () => {
-        const result = await sqlEq("day_of_week(t_timestamp)", "4");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day_of_week(t_timestamp)", "4");
+        expect(await eq).isSqlEq();
       });
       test(`first week day is one  - ${databaseName}`, async () => {
-        const result = await sqlEq("day_of_week(t_timestamp.week)", "1");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day_of_week(t_timestamp.week)", "1");
+        expect(await eq).isSqlEq();
       });
       test(`extract day_of_year - ${databaseName}`, async () => {
-        const result = await sqlEq("day_of_year(t_timestamp)", "55");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day_of_year(t_timestamp)", "55");
+        expect(await eq).isSqlEq();
       });
       test(`extract week - ${databaseName}`, async () => {
-        const result = await sqlEq("week(t_timestamp)", "8");
-        expect(result).isSqlEq();
+        const eq = sqlEq("week(t_timestamp)", "8");
+        expect(await eq).isSqlEq();
       });
       test(`extract month - ${databaseName}`, async () => {
-        const result = await sqlEq("month(t_timestamp)", "2");
-        expect(result).isSqlEq();
+        const eq = sqlEq("month(t_timestamp)", "2");
+        expect(await eq).isSqlEq();
       });
       test(`extract quarter - ${databaseName}`, async () => {
-        const result = await sqlEq("quarter(t_timestamp)", "1");
-        expect(result).isSqlEq();
+        const eq = sqlEq("quarter(t_timestamp)", "1");
+        expect(await eq).isSqlEq();
       });
       test(`extract year - ${databaseName}`, async () => {
-        const result = await sqlEq("year(t_timestamp)", "2021");
-        expect(result).isSqlEq();
+        const eq = sqlEq("year(t_timestamp)", "2021");
+        expect(await eq).isSqlEq();
       });
     });
 
     describe(`date truncation - ${databaseName}`, () => {
       test(`date trunc day - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date.day", "@2021-02-24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date.day", "@2021-02-24");
+        expect(await eq).isSqlEq();
       });
 
       test(`date trunc week - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date.week", "@2021-02-21");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date.week", "@2021-02-21");
+        expect(await eq).isSqlEq();
       });
 
       test(`date trunc month - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date.month", "@2021-02-01");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date.month", "@2021-02-01");
+        expect(await eq).isSqlEq();
       });
 
       test(`date trunc quarter - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date.quarter", "@2021-01-01");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date.quarter", "@2021-01-01");
+        expect(await eq).isSqlEq();
       });
 
       test(`date trunc year - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date.year", "@2021");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date.year", "@2021");
+        expect(await eq).isSqlEq();
       });
     });
 
     describe(`date extraction - ${databaseName}`, () => {
       test(`date extract day - ${databaseName}`, async () => {
-        const result = await sqlEq("day(t_date)", "24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day(t_date)", "24");
+        expect(await eq).isSqlEq();
       });
       test(`date extract day_of_week - ${databaseName}`, async () => {
-        const result = await sqlEq("day_of_week(t_date)", "4");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day_of_week(t_date)", "4");
+        expect(await eq).isSqlEq();
       });
       test(`date extract day_of_year - ${databaseName}`, async () => {
-        const result = await sqlEq("day_of_year(t_date)", "55");
-        expect(result).isSqlEq();
+        const eq = sqlEq("day_of_year(t_date)", "55");
+        expect(await eq).isSqlEq();
       });
       test(`date extract week - ${databaseName}`, async () => {
-        const result = await sqlEq("week(t_date)", "8");
-        expect(result).isSqlEq();
+        const eq = sqlEq("week(t_date)", "8");
+        expect(await eq).isSqlEq();
       });
       test(`date extract month - ${databaseName}`, async () => {
-        const result = await sqlEq("month(t_date)", "2");
-        expect(result).isSqlEq();
+        const eq = sqlEq("month(t_date)", "2");
+        expect(await eq).isSqlEq();
       });
       test(`date extract quarter - ${databaseName}`, async () => {
-        const result = await sqlEq("quarter(t_date)", "1");
-        expect(result).isSqlEq();
+        const eq = sqlEq("quarter(t_date)", "1");
+        expect(await eq).isSqlEq();
       });
       test(`date extract year - ${databaseName}`, async () => {
-        const result = await sqlEq("year(t_date)", "2021");
-        expect(result).isSqlEq();
+        const eq = sqlEq("year(t_date)", "2021");
+        expect(await eq).isSqlEq();
       });
     });
     describe(`delta - ${databaseName}`, () => {
       test(`timestamp delta second - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp + 10 seconds",
-          "@2021-02-24 03:05:16"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp + 10 seconds", "@2021-02-24 03:05:16");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta negative second - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp - 6 seconds",
-          "@2021-02-24 03:05:00"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp - 6 seconds", "@2021-02-24 03:05:00");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta minute - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp + 10 minutes",
-          "@2021-02-24 03:15:06"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_timestamp + 10 minutes", "@2021-02-24 03:15:06");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta hours - ${databaseName}`, async () => {
         const eq = await sqlEq(
@@ -337,113 +310,86 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         expect(eq).isSqlEq();
       });
       test(`timestamp delta week - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "(t_timestamp - 2 weeks)::date",
-          "@2021-02-10"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("(t_timestamp - 2 weeks)::date", "@2021-02-10");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta month - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "(t_timestamp + 9 months)::date",
-          "@2021-11-24"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("(t_timestamp + 9 months)::date", "@2021-11-24");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta quarter - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "(t_timestamp + 2 quarters)::date",
-          "@2021-08-24"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("(t_timestamp + 2 quarters)::date", "@2021-08-24");
+        expect(await eq).isSqlEq();
       });
       test(`timestamp delta year - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "(t_timestamp + 10 years)::date",
-          "@2031-02-24"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("(t_timestamp + 10 years)::date", "@2031-02-24");
+        expect(await eq).isSqlEq();
       });
       test(`date delta second - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_date + 10 seconds",
-          "@2021-02-24 00:00:10"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 10 seconds", "@2021-02-24 00:00:10");
+        expect(await eq).isSqlEq();
       });
       test(`date delta minute - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_date + 10 minutes",
-          "@2021-02-24 00:10:00"
-        );
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 10 minutes", "@2021-02-24 00:10:00");
+        expect(await eq).isSqlEq();
       });
       test(`date delta hours - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date + 10 hours", "@2021-02-24 10:00:00");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 10 hours", "@2021-02-24 10:00:00");
+        expect(await eq).isSqlEq();
       });
       test(`date delta week - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date - 2 weeks", "@2021-02-10");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date - 2 weeks", "@2021-02-10");
+        expect(await eq).isSqlEq();
       });
       test(`date delta month - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date + 9 months", "@2021-11-24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 9 months", "@2021-11-24");
+        expect(await eq).isSqlEq();
       });
       test(`date delta quarter - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date + 2 quarters", "@2021-08-24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 2 quarters", "@2021-08-24");
+        expect(await eq).isSqlEq();
       });
       test(`date delta year - ${databaseName}`, async () => {
-        const result = await sqlEq("t_date + 10 years", "@2031-02-24");
-        expect(result).isSqlEq();
+        const eq = sqlEq("t_date + 10 years", "@2031-02-24");
+        expect(await eq).isSqlEq();
       });
     });
     describe(`to range edge tests - ${databaseName}`, () => {
       describe(`${databaseName} date`, () => {
         test(`before to is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
-            "t_date ? @2021-02-25 to @2021-03-01",
-            false
-          );
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-25 to @2021-03-01", false);
+          expect(await eq).isSqlEq();
         });
         test(`first to is inside - ${databaseName}`, async () => {
-          const result = await sqlEq(
-            "t_date ? @2021-02-24 to @2021-03-01",
-            true
-          );
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-24 to @2021-03-01", true);
+          expect(await eq).isSqlEq();
         });
         test(`last to is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
-            "t_date ? @2021-02-01 to @2021-02-24",
-            false
-          );
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-01 to @2021-02-24", false);
+          expect(await eq).isSqlEq();
         });
       });
       describe(`${databaseName} timestamp`, () => {
         test(`before to is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-25 00:00:00 to @2021-02-26 00:00:00",
             false
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
         test(`first to is inside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-24 03:04:05 to @2021-02-26 00:00:00",
             true
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
         test(`last to is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-24 00:00:00 to @2021-02-24 03:05:06",
             false
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
       });
     });
@@ -451,61 +397,61 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
     describe(`for range edge tests - ${databaseName}`, () => {
       describe(`${databaseName} date`, () => {
         test(`before for-range is outside - ${databaseName}`, async () => {
-          const result = await sqlEq("t_date ? @2021-02-25 for 1 day", false);
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-25 for 1 day", false);
+          expect(await eq).isSqlEq();
         });
         test(`first for-range is inside - ${databaseName}`, async () => {
-          const result = await sqlEq("t_date ? @2021-02-24 for 1 day", true);
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-24 for 1 day", true);
+          expect(await eq).isSqlEq();
         });
         test(`last for-range is outside - ${databaseName}`, async () => {
-          const result = await sqlEq("t_date ? @2021-02-23 for 1 day", false);
-          expect(result).isSqlEq();
+          const eq = sqlEq("t_date ? @2021-02-23 for 1 day", false);
+          expect(await eq).isSqlEq();
         });
       });
       describe(`${databaseName} timestamp`, () => {
         test(`before for-range is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-25 00:00:00 for 1 day",
             false
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
         test(`first for-range is inside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-24 03:04:05 for 1 day",
             true
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
         test(`last for-range is outside - ${databaseName}`, async () => {
-          const result = await sqlEq(
+          const eq = sqlEq(
             "t_timestamp ? @2021-02-23 03:05:06 for 1 day",
             false
           );
-          expect(result).isSqlEq();
+          expect(await eq).isSqlEq();
         });
       });
     });
 
     describe(`granular time range checks - ${databaseName}`, () => {
       test("date = timestamp.ymd", async () => {
-        const result = await sqlEq(`t_date ? t_timestamp.month`, true);
-        expect(result).isSqlEq();
+        const eq = sqlEq(`t_date ? t_timestamp.month`, true);
+        expect(await eq).isSqlEq();
       });
       test("date = timestamp.hms", async () => {
-        const result = await sqlEq(`t_date ? t_timestamp.hour`, false);
-        expect(result).isSqlEq();
+        const eq = sqlEq(`t_date ? t_timestamp.hour`, false);
+        expect(await eq).isSqlEq();
       });
 
       test("date = literal.ymd", async () => {
-        const result = await sqlEq(`t_date ? @2021-02-24.week`, true);
-        expect(result).isSqlEq();
+        const eq = sqlEq(`t_date ? @2021-02-24.week`, true);
+        expect(await eq).isSqlEq();
       });
 
       test("date = literal.hms", async () => {
-        const result = await sqlEq(`t_date ? @2021-02-24.hour`, false);
-        expect(result).isSqlEq();
+        const eq = sqlEq(`t_date ? @2021-02-24.hour`, false);
+        expect(await eq).isSqlEq();
       });
       /*
        * Here is the matrix of all possible tests, I don't know that we need

--- a/packages/malloy-db-test/src/datetimes.spec.ts
+++ b/packages/malloy-db-test/src/datetimes.spec.ts
@@ -16,7 +16,7 @@
 
 import { RuntimeList } from "./runtimes";
 import "./is-sql-eq";
-import { mkSqlEq } from "./sql-eq";
+import { mkSqlEqWith } from "./sql-eq";
 
 // No prebuilt shared model, each test is complete.  Makes debugging easier.
 
@@ -47,7 +47,7 @@ const basicTypes: Record<DialectNames, string> = {
 };
 
 runtimes.runtimeMap.forEach((runtime, databaseName) => {
-  const sqlEq = mkSqlEq(runtime, { sql: basicTypes[databaseName] });
+  const sqlEq = mkSqlEqWith(runtime, { sql: basicTypes[databaseName] });
 
   test(`date in sql_block no explore- ${databaseName}`, async () => {
     const result = await sqlEq("t_date", "@2021-02-24");
@@ -330,11 +330,8 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
         expect(result).isSqlEq();
       });
       test(`timestamp delta hours - ${databaseName}`, async () => {
-        const result = await sqlEq(
-          "t_timestamp + 10 hours",
-          "@2021-02-24 13:05:06"
-        );
-        expect(result).isSqlEq();
+        const eq = await sqlEq("t_timestamp + 10 hours", "@2021-02-24 13:05:06");
+        expect(eq).isSqlEq();
       });
       test(`timestamp delta week - ${databaseName}`, async () => {
         const result = await sqlEq(

--- a/packages/malloy-db-test/src/datetimes.spec.ts
+++ b/packages/malloy-db-test/src/datetimes.spec.ts
@@ -15,7 +15,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 import { RuntimeList } from "./runtimes";
-import "./sql-eq";
+import "./is-sql-eq";
 import { mkSqlEq } from "./sql-eq";
 
 // No prebuilt shared model, each test is complete.  Makes debugging easier.

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -16,7 +16,7 @@
 
 import * as malloy from "@malloydata/malloy";
 import { RuntimeList } from "./runtimes";
-import "./sql-eq";
+import "./is-sql-eq";
 import { mkSqlEqWith } from "./sql-eq";
 
 const runtimes = new RuntimeList([

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -16,8 +16,8 @@
 
 import * as malloy from "@malloydata/malloy";
 import { RuntimeList } from "./runtimes";
-import "./is-sql-eq";
-import { mkSqlEq } from "./sql-eq";
+import "./sql-eq";
+import { mkSqlEqWith } from "./sql-eq";
 
 const runtimes = new RuntimeList([
   "bigquery", //
@@ -571,7 +571,7 @@ expressionModels.forEach((expressionModel, databaseName) => {
 });
 
 runtimes.runtimeMap.forEach((runtime, databaseName) => {
-  const sqlEq = mkSqlEq(runtime, {
+  const sqlEq = mkSqlEqWith(runtime, {
     malloy: `+ {
       dimension: friName is 'friday'
       dimension: friDay is 5

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -15,33 +15,9 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 import * as malloy from "@malloydata/malloy";
-import { Result } from "@malloydata/malloy";
 import { RuntimeList } from "./runtimes";
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      isSqlEq(): R;
-    }
-  }
-}
-
-expect.extend({
-  isSqlEq: (result: Result) => {
-    const wantEq = result.data.path(0, "calc").value;
-    if (wantEq != "=") {
-      return {
-        pass: false,
-        message: () => `${wantEq}\nSQL:\n${result.sql}`,
-      };
-    }
-    return {
-      pass: true,
-      message: () => "SQL expression matched",
-    };
-  },
-});
+import "./sql-eq";
+import { mkSqlEq } from "./sql-eq";
 
 const runtimes = new RuntimeList([
   "bigquery", //
@@ -595,43 +571,14 @@ expressionModels.forEach((expressionModel, databaseName) => {
 });
 
 runtimes.runtimeMap.forEach((runtime, databaseName) => {
-  async function sqlEq(expr: string, result: string | boolean) {
-    const qExpr = expr.replace(/'/g, "`");
-    const sourceDef = `
-      sql: nothing is || SELECT 1 as one ;;
-      source: basicTypes is from_sql(nothing) + {
-        dimension: friName is 'friday'
-        dimension: friDay is 5
-        dimension: satName is 'saturday'
-        dimension: satDay is 6
-        dimension: dayTime is @2001-01-01 00:00:00
-      }\n`;
-    let query: string;
-    if (typeof result == "boolean") {
-      const notEq = `concat('${qExpr} was ${!result} expected ${result}')`;
-      const whenPick = result ? "'=' when exprTrue" : `${notEq} when exprTrue`;
-      const elsePick = result ? notEq : "'='";
-      query = `${sourceDef}
-        query: basicTypes
-        -> { project: exprTrue is ${expr} }
-        -> {
-          project: calc is pick ${whenPick} else ${elsePick}
-        }`;
-    } else {
-      const qResult = result.replace(/'/g, "`");
-      query = `${sourceDef}
-        query: basicTypes
-        -> {
-          project: expect is ${result}
-          project: got is ${expr}
-        } -> {
-          project: calc is
-            pick '=' when expect = got
-            else concat('${qExpr} != ${qResult}. Got: ', got::string)
-        }`;
-    }
-    return await runtime.loadQuery(query).run();
-  }
+  const sqlEq = mkSqlEq(runtime, {
+    malloy: `+ {
+      dimension: friName is 'friday'
+      dimension: friDay is 5
+      dimension: satName is 'saturday'
+      dimension: satDay is 6
+    }`,
+  });
 
   describe.skip(`alternations with not-eq - ${databaseName}`, () => {
     /*

--- a/packages/malloy-db-test/src/expr.spec.ts
+++ b/packages/malloy-db-test/src/expr.spec.ts
@@ -16,7 +16,7 @@
 
 import * as malloy from "@malloydata/malloy";
 import { RuntimeList } from "./runtimes";
-import "./sql-eq";
+import "./is-sql-eq";
 import { mkSqlEq } from "./sql-eq";
 
 const runtimes = new RuntimeList([

--- a/packages/malloy-db-test/src/is-sql-eq.ts
+++ b/packages/malloy-db-test/src/is-sql-eq.ts
@@ -1,0 +1,30 @@
+import { Result } from "@malloydata/malloy";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      isSqlEq(): R;
+    }
+  }
+}
+
+expect.extend({
+  /**
+   * Check the return of `sqlEQ(expr1,expr2)` and error if the database
+   * does not find those two expressions to be equal.
+   */
+  isSqlEq(result: Result) {
+    const wantEq = result.data.path(0, "calc").value;
+    if (wantEq != "=") {
+      return {
+        pass: false,
+        message: () => `${wantEq}\nSQL:\n${result.sql}`,
+      };
+    }
+    return {
+      pass: true,
+      message: () => "SQL expression matched",
+    };
+  },
+});

--- a/packages/malloy-db-test/src/is-sql-eq.ts
+++ b/packages/malloy-db-test/src/is-sql-eq.ts
@@ -16,10 +16,11 @@ expect.extend({
    */
   isSqlEq(result: Result) {
     const wantEq = result.data.path(0, "calc").value;
+    const sql = result.sql.replace(/\n/g, "\n    ");
     if (wantEq != "=") {
       return {
         pass: false,
-        message: () => `${wantEq}\nSQL:\n${result.sql}`,
+        message: () => `${wantEq}\nSQL:\n    ${sql}`,
       };
     }
     return {

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -1,0 +1,72 @@
+import { Result, Runtime } from "@malloydata/malloy";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      isSqlEq(): R;
+    }
+  }
+}
+
+expect.extend({
+  isSqlEq: (result: Result) => {
+    const wantEq = result.data.path(0, "calc").value;
+    if (wantEq != "=") {
+      return {
+        pass: false,
+        message: () => `${wantEq}\nSQL:\n${result.sql}`,
+      };
+    }
+    return {
+      pass: true,
+      message: () => "SQL expression matched",
+    };
+  },
+});
+
+interface InitValues {
+  sql?: string;
+  malloy?: string;
+}
+
+export function mkSqlEq(runtime: Runtime, initV?: InitValues) {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  return async function (
+    expr: string,
+    result: string | boolean
+  ): Promise<Result> {
+    const qExpr = expr.replace(/'/g, "`");
+    const sqlV = initV?.sql || "SELECT 1 as one";
+    const malloyV = initV?.malloy || "";
+    const sourceDef = `
+      sql: sqlData is || ${sqlV} ;;
+      source: basicTypes is from_sql(sqlData) ${malloyV}
+    `;
+    let query: string;
+    if (typeof result == "boolean") {
+      const notEq = `concat('${qExpr} was ${!result} expected ${result}')`;
+      const whenPick = result ? "'=' when exprTrue" : `${notEq} when exprTrue`;
+      const elsePick = result ? notEq : "'='";
+      query = `${sourceDef}
+          query: basicTypes
+          -> { project: exprTrue is ${expr} }
+          -> {
+            project: calc is pick ${whenPick} else ${elsePick}
+          }`;
+    } else {
+      const qResult = result.replace(/'/g, "`");
+      query = `${sourceDef}
+          query: basicTypes
+          -> {
+            project: expect is ${result}
+            project: got is ${expr}
+          } -> {
+            project: calc is
+              pick '=' when expect = got
+              else concat('${qExpr} != ${qResult}. Got: ', got::string)
+          }`;
+    }
+    return runtime.loadQuery(query).run();
+  };
+}

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -20,7 +20,7 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
     `;
     let query: string;
     if (typeof result == "boolean") {
-      const notEq = `'sqlEq failed\nExpected: ${qExpr} to be ${result}'`;
+      const notEq = `concat('sqlEq failed', CHR(10), ' .   Expected: ${qExpr} to be ${result}')`;
       const varName = result ? "expectTrue" : "expectFalse";
       const whenPick = result
         ? `'=' when ${varName}`
@@ -42,7 +42,7 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
           } -> {
             project: calc is
               pick '=' when expect = got
-              else concat('sqlEq failed\nExpected: ${qExpr} == ${qResult}.\nReceived: ', got::string)
+              else concat('sqlEq failed', CHR(10), '    Expected: ${qExpr} == ${qResult}', CHR(10), '    Received: ', got::string)
           }`;
     }
     return runtime.loadQuery(query).run();

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -21,8 +21,10 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
     let query: string;
     if (typeof result == "boolean") {
       const notEq = `'sqlEq failed\nExpected: ${qExpr} to be ${result}'`;
-      const varName = result ? "exprTrue" : "exprFalse";
-      const whenPick = result ? `'=' when ${varName}` : `${notEq} when ${varName}`;
+      const varName = result ? "expectTrue" : "expectFalse";
+      const whenPick = result
+        ? `'=' when ${varName}`
+        : `${notEq} when ${varName}`;
       const elsePick = result ? notEq : "'='";
       query = `${sourceDef}
           query: basicTypes

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -20,12 +20,13 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
     `;
     let query: string;
     if (typeof result == "boolean") {
-      const notEq = `'sqlEq failed\nExpected: ${qExpr} to be ${result}`;
-      const whenPick = result ? "'=' when exprTrue" : `${notEq} when exprTrue`;
+      const notEq = `'sqlEq failed\nExpected: ${qExpr} to be ${result}'`;
+      const varName = result ? "exprTrue" : "exprFalse";
+      const whenPick = result ? `'=' when ${varName}` : `${notEq} when ${varName}`;
       const elsePick = result ? notEq : "'='";
       query = `${sourceDef}
           query: basicTypes
-          -> { project: exprTrue is ${expr} }
+          -> { project: ${varName} is ${expr} }
           -> {
             project: calc is pick ${whenPick} else ${elsePick}
           }`;

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -1,30 +1,5 @@
 import { Result, Runtime } from "@malloydata/malloy";
 
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace jest {
-    interface Matchers<R> {
-      isSqlEq(): R;
-    }
-  }
-}
-
-expect.extend({
-  isSqlEq: (result: Result) => {
-    const wantEq = result.data.path(0, "calc").value;
-    if (wantEq != "=") {
-      return {
-        pass: false,
-        message: () => `${wantEq}\nSQL:\n${result.sql}`,
-      };
-    }
-    return {
-      pass: true,
-      message: () => "SQL expression matched",
-    };
-  },
-});
-
 interface InitValues {
   sql?: string;
   malloy?: string;

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -20,7 +20,7 @@ export function mkSqlEq(runtime: Runtime, initV?: InitValues) {
     `;
     let query: string;
     if (typeof result == "boolean") {
-      const notEq = `concat('${qExpr} was ${!result} expected ${result}')`;
+      const notEq = `'sqlEq failed\nExpected: ${qExpr} to be ${result}`;
       const whenPick = result ? "'=' when exprTrue" : `${notEq} when exprTrue`;
       const elsePick = result ? notEq : "'='";
       query = `${sourceDef}
@@ -39,7 +39,7 @@ export function mkSqlEq(runtime: Runtime, initV?: InitValues) {
           } -> {
             project: calc is
               pick '=' when expect = got
-              else concat('${qExpr} != ${qResult}. Got: ', got::string)
+              else concat('sqlEq failed\nExpected: ${qExpr} == ${qResult}.\nReceived: ', got::string)
           }`;
     }
     return runtime.loadQuery(query).run();

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -20,7 +20,7 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
     `;
     let query: string;
     if (typeof result == "boolean") {
-      const notEq = `concat('sqlEq failed', CHR(10), ' .   Expected: ${qExpr} to be ${result}')`;
+      const notEq = `concat('sqlEq failed', CHR(10), '    Expected: ${qExpr} to be ${result}')`;
       const varName = result ? "expectTrue" : "expectFalse";
       const whenPick = result
         ? `'=' when ${varName}`

--- a/packages/malloy-db-test/src/sql-eq.ts
+++ b/packages/malloy-db-test/src/sql-eq.ts
@@ -5,7 +5,7 @@ interface InitValues {
   malloy?: string;
 }
 
-export function mkSqlEq(runtime: Runtime, initV?: InitValues) {
+export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   return async function (
     expr: string,

--- a/packages/malloy/src/lang/ast/ast-types.ts
+++ b/packages/malloy/src/lang/ast/ast-types.ts
@@ -135,33 +135,20 @@ export interface ExprResult extends FragType {
   value: Fragment[];
 }
 
-export interface GranularResult extends ExprResult {
+export interface TimeResult extends ExprResult {
   dataType: TimeFieldType;
-  timeframe: TimestampUnit;
   alsoTimestamp?: true;
 }
+
+export interface GranularResult extends TimeResult {
+  timeframe: TimestampUnit;
+}
+
 export function isGranularResult(v: ExprValue): v is GranularResult {
   if (v.dataType !== "date" && v.dataType !== "timestamp") {
     return false;
   }
   return (v as GranularResult).timeframe !== undefined;
-}
-export function granularity(t: TimestampUnit): number {
-  const granularityMap: Record<string, number> = {
-    microsecond: -2,
-    millisecond: -1,
-    second: 1,
-    minute: 2,
-    hour: 3,
-    day: 4,
-    date: 4,
-    week: 5,
-    month: 6,
-    quarter: 7,
-    year: 8,
-  };
-
-  return granularityMap[t] || granularityMap.millisecond;
 }
 
 /**

--- a/packages/malloy/src/lang/ast/time-utils.ts
+++ b/packages/malloy/src/lang/ast/time-utils.ts
@@ -18,6 +18,7 @@ import {
   TypecastFragment,
   AtomicFieldType,
 } from "../../model/malloy_types";
+import { GranularResult, TimeResult } from "./ast-types";
 
 export function timeOffset(
   timeType: TimeFieldType,
@@ -87,4 +88,14 @@ export function resolution(timeframe: string): TimeFieldType {
       return "timestamp";
   }
   return "date";
+}
+
+export function timeResult(
+  t: TimeResult,
+  tt: TimestampUnit | undefined
+): TimeResult | GranularResult {
+  if (tt) {
+    return { ...t, timeframe: tt };
+  }
+  return t;
 }


### PR DESCRIPTION
This is not correct yet. I have some test errors introduced by moving this into a matcher than I don't quite understand, but I am ready for a review of the overall approach.

Not 100% sure this is how we should go, but after working in a couple of different problems, I have managed to abstract out a pattern for a custom matcher which I find useful. If we like this, I'll make more tests use this instead of the way they are testing now, it makes the tests, and test failures, way easier to understand.

It has the following features

1) To use this feature you need three lines of code in your file ..

```Typescript
import "./is-sql-eq";
import { mkSqlEqWith } from "./sql-eq";

// and the inside the loop where you are iterating over the connections generating a runtime ...
// you set up some inital values ... that your expressions can use, and that can come
// from a select statement, or a refinement, or both

  const sqlEq = mkSqlEqWith(runtime, {
    sql: "SELECT statement goes here",
    malloy: " + { dimension: malloy_code_goes_here }",
  });

// for example, here is code which loads different SQL depending on the connection

  const sqlEq = mkSqlEqWith(runtime, { sql: basicTypes[databaseName] });
```

2) The code to test a malloy fragment against an expected value result is pretty short and clear

```Typescript
      test(`timestamp delta hours - ${databaseName}`, async () => {
        const eq = await sqlEq("t_timestamp + 10 hours", "@2021-02-24 13:05:06");
        expect(eq).isSqlEq();
      });
 ```
 
3) Here's some sample output where the test fails. You can see the Malloy expression and the SQL result which didn't match and the SQL which generates that. I found it clearer to debug if I write the computation in it's own stage.
 ```
  ● time operations - postgres › delta - postgres › timestamp delta hours - postgres

    sqlEq failed
        Expected: t_timestamp + 10 hours == @2021-02-24 13:05:06.
        Received: 2021-02-24 13:00:00-10
    SQL:
        WITH __stage0 AS (
          SELECT 
             DATE_TRUNC('second', TIMESTAMP '2021-02-24 13:05:06') as "expect",
             DATE_TRUNC('hour', ((basicTypes."t_timestamp")+make_interval(hours=>10))) as "got"
          FROM ( 
              SELECT
                DATE('2021-02-24') as t_date,
                '2021-02-24 03:05:06'::timestamp with time zone as t_timestamp
             ) as basicTypes
        )
        , __stage1 AS (
          SELECT 
             CASE WHEN DATE_TRUNC('second', base."expect")=DATE_TRUNC('hour', base."got") THEN '=' ELSE concat('sqlEq failed
            Expected: t_timestamp + 10 hours == @2021-02-24 13:05:06.
            Received: ',cast(DATE_TRUNC('hour', base."got") as varchar)) END as "calc"
          FROM "__stage0" as base
        )
        SELECT row_to_json(finalStage) as row FROM __stage1 AS finalStage

      332 |       test(`timestamp delta hours - ${databaseName}`, async () => {
      333 |         const eq = await sqlEq("t_timestamp + 10 hours", "@2021-02-24 13:05:06");
    > 334 |         expect(eq).isSqlEq();
          |                    ^
      335 |       });
      336 |       test(`timestamp delta week - ${databaseName}`, async () => {
      337 |         const result = await sqlEq(

      at Object.<anonymous> (packages/malloy-db-test/src/datetimes.spec.ts:334:20)
```

How I accomplish this is a little wonky and needs review though.