### PR TITLE
Add dependancies for indexed fields

### DIFF
--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -2575,18 +2575,19 @@ class QueryQueryIndex extends QueryQuery {
         resultIndex,
         type: "result",
       });
+      if (field instanceof QueryAtomicField) {
+        this.addDependancies(resultStruct, field);
+      }
       resultIndex++;
     }
     const measure = (this.firstSegment as IndexSegment).weightMeasure;
     if (measure !== undefined) {
-      resultStruct.addField(
-        measure,
-        this.parent.getFieldByName(measure) as QueryField,
-        {
-          resultIndex,
-          type: "result",
-        }
-      );
+      const f = this.parent.getFieldByName(measure) as QueryField;
+      resultStruct.addField(measure, f, {
+        resultIndex,
+        type: "result",
+      });
+      this.addDependancies(resultStruct, f);
     }
     this.expandFilters(resultStruct);
   }

--- a/samples/imdb/imdb.malloy
+++ b/samples/imdb/imdb.malloy
@@ -3,11 +3,9 @@ source: people is table('imdb.name_basics') {
 }
 
 source: movies is table('imdb.movies') + {
-  
+
   join_one: people is people on principals.nconst = people.nconst
 
-
-  // join_one: cast_crew with tconst
   declare:
     title_count is count(distinct tconst)
     total_ratings is sum(ratings.numVotes)
@@ -23,9 +21,9 @@ source: movies is table('imdb.movies') + {
   }
 
   query: by_name is {
-    group_by: 
+    group_by:
       people.primaryName, principals.nconst
-    aggregate: 
+    aggregate:
       total_ratings
       title_count
   }
@@ -42,5 +40,10 @@ source: movies is table('imdb.movies') + {
   query: by_character is {
     group_by: principals.characters.value
     aggregate: title_count
+  }
+
+  query: search_index is {
+    index: * by total_ratings
+    where: ratings.numVotes > 10000
   }
 }


### PR DESCRIPTION
IMDB and data_access_logs were failing to index because we weren't added dependancies to the indexes.