### PR TITLE
Remove Vega's default sorting

### DIFF
--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -78,7 +78,7 @@ const sizeLarge = {
 const bar_SM: lite.TopLevelSpec = {
   ...DEFAULT_SPEC,
   encoding: {
-    y: { field: "#{1}", type: "nominal", axis: null },
+    y: { field: "#{1}", type: "nominal", axis: null, sort: null },
   },
   layer: [
     {
@@ -87,6 +87,7 @@ const bar_SM: lite.TopLevelSpec = {
         x: {
           field: "#{2}",
           type: "quantitative",
+          sort: null,
         },
         color: { value: "#4285F4" },
       },
@@ -105,8 +106,8 @@ const bar_SM_large: lite.TopLevelSpec = {
   mark: "bar",
   data: [],
   encoding: {
-    x: { field: "#{1}", type: "nominal" },
-    y: { field: "#{2}", type: "quantitative" },
+    x: { field: "#{1}", type: "nominal", sort: null },
+    y: { field: "#{2}", type: "quantitative", sort: null },
     color: { value: "#4285F4" },
   },
 };
@@ -175,8 +176,8 @@ const bar_NM: lite.TopLevelSpec = {
   mark: "bar",
   data: [],
   encoding: {
-    x: { field: "#{1}", type: "nominal" },
-    y: { field: "#{2}", type: "quantitative" },
+    x: { field: "#{1}", type: "nominal", sort: null },
+    y: { field: "#{2}", type: "quantitative", sort: null },
     color: { value: "#4285F4" },
   },
 };
@@ -242,7 +243,7 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
     spec: {
       description: "A simple bar chart with embedded data.",
       encoding: {
-        y: { field: "#{1}", type: "nominal", axis: null },
+        y: { field: "#{1}", type: "nominal", axis: null, sort: null },
       },
       layer: [
         {
@@ -253,6 +254,7 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
             x: {
               field: { repeat: "repeat" },
               type: "quantitative",
+              sort: null,
             },
             color: {
               field: "#{2}",
@@ -279,10 +281,12 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
       y: {
         field: "#{1}",
         type: "ordinal",
+        sort: null,
       },
       x: {
         field: "#{2}",
         type: "ordinal",
+        sort: null,
       },
       size: {
         field: "#{3}",
@@ -300,10 +304,12 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
       y: {
         field: "#{1}",
         type: "ordinal",
+        sort: null,
       },
       x: {
         field: "#{2}",
         type: "ordinal",
+        sort: null,
       },
       color: {
         field: "#{3}",
@@ -321,10 +327,12 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
       y: {
         field: "#{1}",
         type: "nominal",
+        sort: null,
       },
       x: {
         field: "#{2}",
         type: "ordinal",
+        sort: null,
       },
       color: {
         field: "#{3}",
@@ -343,12 +351,14 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
         field: "#{2}",
         type: "temporal",
         axis: { grid: false },
+        sort: null,
       },
       y: {
         field: "#{3}",
         type: "quantitative",
         axis: { grid: false },
         title: null,
+        sort: null,
       },
       color: {
         field: "#{1}",
@@ -372,12 +382,14 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
         field: "#{3}",
         type: "temporal",
         axis: { grid: false },
+        sort: null,
       },
       y: {
         field: "#{4}",
         type: "quantitative",
         axis: { grid: false },
         title: null,
+        sort: null,
       },
       color: {
         field: "#{1}",


### PR DESCRIPTION
Potential fix for https://github.com/looker-open-source/malloy/issues/112. This disables Vega's internal sorting and allows the underlying data to dictate the sort. I think this is in general what we want but @anikaks maybe I'm not thinking of something?

Natural

<img width="223" alt="Screen Shot 2022-05-17 at 4 06 12 PM" src="https://user-images.githubusercontent.com/2958002/168926490-5373469b-bfdb-4e3f-8ba8-b9ac25d441a0.png">

<img width="348" alt="Screen Shot 2022-05-17 at 4 06 17 PM" src="https://user-images.githubusercontent.com/2958002/168926510-98e311f6-0547-47e8-8d01-6692fdd3faa3.png">

total_sales_dollars 

<img width="280" alt="Screen Shot 2022-05-17 at 4 06 29 PM" src="https://user-images.githubusercontent.com/2958002/168926539-a60cd7ac-c6ab-469d-9250-41babd0fc5f4.png">

<img width="370" alt="Screen Shot 2022-05-17 at 4 06 39 PM" src="https://user-images.githubusercontent.com/2958002/168926561-eb2b7061-9298-4d47-8b7e-60b7a94eacda.png">

category_class

<img width="255" alt="Screen Shot 2022-05-17 at 4 06 54 PM" src="https://user-images.githubusercontent.com/2958002/168926573-614f5b55-75bb-498b-b0a5-2a873c37e6c4.png">

<img width="372" alt="Screen Shot 2022-05-17 at 4 06 58 PM" src="https://user-images.githubusercontent.com/2958002/168926585-7f8d5dfb-2d7c-4491-aeb9-18612ec77dc2.png">

