### PR TITLE
Preserve "on" connection in sql blocks

### DIFF
--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -965,6 +965,38 @@ describe("sql backdoor", () => {
     "single sql statement",
     modelOK("sql: users is || SELECT * FROM USERS;;")
   );
+  test("connection shows up in model", () => {
+    const model = new BetaModel(`
+      sql: users IS || SELECT * FROM aTable ;; on "someConnection";
+      source: malloyUsers is from_sql(users) { primary_key: ai }
+    `);
+    const needReq = model.translate();
+    expect(model).toBeErrorless();
+    const needs = needReq?.sqlStructs;
+    expect(needs).toBeDefined();
+    if (needs) {
+      expect(needs.length).toBe(1);
+      const sql = makeSQLBlock({
+        select: " SELECT * FROM aTable ",
+        connection: "someConnection",
+      });
+      expect(needs[0]).toMatchObject(sql);
+      const refKey = needs[0].name;
+      expect(refKey).toBeDefined();
+      if (refKey) {
+        model.update({ sqlStructs: { [refKey]: makeSchemaResponse(sql) } });
+        expect(model).toTranslate();
+      }
+      const modelDef = model.translate().translated?.modelDef;
+      expect(modelDef).toBeDefined();
+      const users = modelDef?.contents.malloyUsers;
+      expect(users).toBeDefined();
+      expect(users).toHaveProperty(
+        "structSource.sqlBlock.connection",
+        "someConnection"
+      );
+    }
+  });
   test("explore from sql", () => {
     const model = new BetaModel(`
       sql: users IS || SELECT * FROM aTable ;;

--- a/packages/malloy/src/model/sql_block.ts
+++ b/packages/malloy/src/model/sql_block.ts
@@ -36,5 +36,8 @@ export function makeSQLBlock(from: SQLBlockRequest): SQLBlock {
   if (from.after) {
     theBlock.after = from.after;
   }
+  if (from.connection) {
+    theBlock.connection = from.connection;
+  }
   return theBlock;
 }


### PR DESCRIPTION
The connection name was being dropped for SQL blocks not on the default connection.