### PR TITLE
Use constructor safe type checks

### DIFF
--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -226,7 +226,7 @@ export class PostgresConnection implements Connection, StreamingConnection {
     await client.connect();
 
     let result = await client.query(sqlCommand);
-    if (result instanceof Array) {
+    if (Array.isArray(result)) {
       result = result.pop();
     }
     if (deJSON) {
@@ -420,7 +420,7 @@ export class PooledPostgresConnection
   ): Promise<MalloyQueryData> {
     let result = await this.pool.query(sqlCommand);
 
-    if (result instanceof Array) {
+    if (Array.isArray(result)) {
       result = result.pop();
     }
     if (deJSON) {

--- a/packages/malloy-render/src/html/vega_spec.ts
+++ b/packages/malloy-render/src/html/vega_spec.ts
@@ -410,7 +410,7 @@ export const vegaSpecs: Record<string, lite.TopLevelSpec> = {
 };
 
 export function isDataContainer(a: unknown): a is DataContainer {
-  return a instanceof Array || a instanceof Object;
+  return Array.isArray(a) || typeof a === "object";
 }
 
 export class HTMLVegaSpecRenderer extends HTMLChartRenderer {
@@ -460,17 +460,17 @@ export class HTMLVegaSpecRenderer extends HTMLChartRenderer {
   }
 
   translateFields(node: DataContainer, explore: Explore): void {
-    if (node instanceof Array) {
+    if (Array.isArray(node)) {
       for (const e of node) {
         if (isDataContainer(e)) {
           this.translateFields(e, explore);
         }
       }
-    } else if (node instanceof Object) {
+    } else if (typeof node === "object") {
       for (const [key, value] of Object.entries(node)) {
         if (key === "field" && typeof value === "string") {
           node[key] = this.translateField(explore, value);
-        } else if (key === "repeat" && value instanceof Array) {
+        } else if (key === "repeat" && Array.isArray(value)) {
           for (const k of value.keys()) {
             const fieldName = value[k];
             if (typeof fieldName === "string") {

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -2909,7 +2909,7 @@ export class DataRecord extends Data<{ [fieldName: string]: DataColumn }> {
         return new DataString(value as string, field);
       }
     } else if (field.isExploreField()) {
-      if (value instanceof Array) {
+      if (Array.isArray(value)) {
         return new DataArray(value, field, this);
       } else {
         return new DataRecord(value as QueryDataRow, undefined, field, this);


### PR DESCRIPTION
`instanceof Array` can fail because it checks for constructor identity, but not all arrays are constructed using the same constructor, including arrays returned by the duckdb node api, so use known safe checks instead.