### PR TITLE
Make extension build succeed even if duckdb is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ gems/
 .tmp/
 logfile
 .s.PGSQL.5432.lock
+demo/malloy-demo-composer/env

--- a/packages/malloy-vscode/scripts/build-extension.ts
+++ b/packages/malloy-vscode/scripts/build-extension.ts
@@ -73,8 +73,10 @@ const keytarReplacerPlugin: Plugin = {
   },
 };
 
-function makeDuckdbNoNodePreGypPlugin(target: string | undefined) {
+function makeDuckdbNoNodePreGypPlugin(target: Target | undefined) {
   const localPath = require.resolve("duckdb/lib/binding/duckdb.node");
+  const isDuckDBAvailable =
+    target === undefined || targetDuckDBMap[target] !== undefined;
   return {
     name: "duckdbNoNodePreGypPlugin",
     setup(build: any) {
@@ -109,6 +111,45 @@ function makeDuckdbNoNodePreGypPlugin(target: string | undefined) {
           };
         }
       );
+      build.onResolve({ filter: /duckdb_availability/ }, (args: any) => {
+        return {
+          path: args.path,
+          namespace: "duckdb-no-node-pre-gyp-plugin",
+        };
+      });
+      build.onLoad(
+        {
+          filter: /duckdb_availability/,
+          namespace: "duckdb-no-node-pre-gyp-plugin",
+        },
+        (args: any) => {
+          return {
+            contents: `
+              export const isDuckDBAvailable = ${isDuckDBAvailable};
+            `,
+            resolveDir: ".",
+          };
+        }
+      );
+      if (!isDuckDBAvailable) {
+        build.onResolve({ filter: /^duckdb$/ }, (args: any) => {
+          return {
+            path: args.path,
+            namespace: "duckdb-no-node-pre-gyp-plugin",
+          };
+        });
+        build.onLoad(
+          { filter: /^duckdb$/, namespace: "duckdb-no-node-pre-gyp-plugin" },
+          (args: any) => {
+            return {
+              contents: `
+              module.exports = {};
+            `,
+              resolveDir: ".",
+            };
+          }
+        );
+      }
     },
   };
 }
@@ -165,28 +206,27 @@ export async function doBuild(target?: Target): Promise<void> {
       path.join(outDir, "keytar-native.node")
     );
     const duckDBBinaryName = targetDuckDBMap[target];
-    if (duckDBBinaryName === undefined) {
-      throw new Error(`No DuckDB binary for ${target} is available`);
+    const isDuckDBAvailable = duckDBBinaryName !== undefined;
+    if (isDuckDBAvailable) {
+      fs.copyFileSync(
+        path.join(
+          "..",
+          "..",
+          "third_party",
+          "github.com",
+          "duckdb",
+          "duckdb",
+          duckDBBinaryName
+        ),
+        path.join(outDir, "duckdb-native.node")
+      );
     }
-    fs.copyFileSync(
-      path.join(
-        "..",
-        "..",
-        "third_party",
-        "github.com",
-        "duckdb",
-        "duckdb",
-        duckDBBinaryName
-      ),
-      path.join(outDir, "duckdb-native.node")
-    );
   }
-
+  const duckDBPlugin = makeDuckdbNoNodePreGypPlugin(target);
+  const extensionPlugins = [duckDBPlugin];
   // if we're building with a target, replace keytar imports using plugin that imports
   // binary builds of keytar. if we're building for dev, use a .node plugin to
   // ensure ketyar's node_modules .node file is in the build
-  // NOTE: adding any additional npm packages that create native libs will require a different strategy
-  const extensionPlugins = [makeDuckdbNoNodePreGypPlugin(target)];
   if (target) {
     extensionPlugins.push(keytarReplacerPlugin);
   } else {
@@ -225,6 +265,7 @@ export async function doBuild(target?: Target): Promise<void> {
     svgrPlugin({
       typescript: true,
     }),
+    duckDBPlugin,
   ];
 
   if (development) {

--- a/packages/malloy-vscode/src/common/duckdb_availability.ts
+++ b/packages/malloy-vscode/src/common/duckdb_availability.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+/**
+ * Whether or not DuckDB is available for the current build/architecture.
+ * This is set to true here, but may be overridden during the actual build.
+ * See the build script for details.
+ */
+export const isDuckDBAvailable = true;

--- a/packages/malloy-vscode/src/extension/connection_manager.ts
+++ b/packages/malloy-vscode/src/extension/connection_manager.ts
@@ -22,9 +22,11 @@ export class VSCodeConnectionManager extends ConnectionManager {
   }
 
   static getConnectionsConfig(): ConnectionConfig[] {
-    return vscode.workspace
-      .getConfiguration("malloy")
-      .get("connections") as ConnectionConfig[];
+    return this.filterUnavailableConnectionBackends(
+      vscode.workspace
+        .getConfiguration("malloy")
+        .get("connections") as ConnectionConfig[]
+    );
   }
 
   onConfigurationUpdated(): Promise<void> {

--- a/packages/malloy-vscode/src/extension/webviews/connections_page/ConnectionEditor/ ConnectionEditor.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/connections_page/ConnectionEditor/ ConnectionEditor.tsx
@@ -30,6 +30,7 @@ import { Label } from "./Label";
 import { LabelCell } from "./LabelCell";
 import { PostgresConnectionEditor } from "./PostgresConnectionEditor";
 import { DuckDBConnectionEditor } from "./DuckDBConnectionEditor";
+import { isDuckDBAvailable } from "../../../../common/duckdb_availability";
 
 interface ConnectionEditorProps {
   config: ConnectionConfig;
@@ -52,6 +53,15 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
   isDefault,
   makeDefault,
 }) => {
+  const backendOptions: { value: ConnectionBackend; label: string }[] = [
+    { value: ConnectionBackend.BigQuery, label: "BigQuery" },
+    { value: ConnectionBackend.Postgres, label: "Postgres" },
+  ];
+
+  if (isDuckDBAvailable) {
+    backendOptions.push({ value: ConnectionBackend.DuckDB, label: "DuckDB" });
+  }
+
   return (
     <ConnectionEditorBox>
       <div
@@ -79,7 +89,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
             <td>
               <Dropdown
                 value={config.backend}
-                setValue={(backend) =>
+                setValue={(backend: string) =>
                   setConfig({
                     name: config.name,
                     backend: backend as ConnectionBackend,
@@ -87,11 +97,7 @@ export const ConnectionEditor: React.FC<ConnectionEditorProps> = ({
                     isDefault: config.isDefault,
                   })
                 }
-                options={[
-                  { value: ConnectionBackend.BigQuery, label: "BigQuery" },
-                  { value: ConnectionBackend.Postgres, label: "Postgres" },
-                  { value: ConnectionBackend.DuckDB, label: "DuckDB" },
-                ]}
+                options={backendOptions}
               />
             </td>
           </tr>


### PR DESCRIPTION
We don't have node binaries for DuckDB for every machine/architecture we want to support. This change makes it possible to build the extension even if the DuckDB binary doesn't exist, by making the extension check whether it is available (through a constant which is defined during the build).