### PR TITLE
Allow sourcemaps from packages

### DIFF
--- a/demo/malloy-demo-composer/scripts/serve.ts
+++ b/demo/malloy-demo-composer/scripts/serve.ts
@@ -50,7 +50,7 @@ async function doServe() {
             const url = new URL(req.url, `http://${req.headers.host}`);
             if (url.pathname.startsWith("/packages")) {
               res.writeHead(200, { "Content-Type": "text/html" });
-              res.end(fs.readFileSync(path.join('../..', url.pathname)));
+              res.end(fs.readFileSync(path.join("../..", url.pathname)));
               return;
             }
           }

--- a/demo/malloy-demo-composer/scripts/serve.ts
+++ b/demo/malloy-demo-composer/scripts/serve.ts
@@ -16,18 +16,55 @@
 import { serve } from "esbuild";
 import { appDirectory, buildDirectory, commonAppConfig } from "./build";
 import * as path from "path";
+import * as http from "http";
+import * as fs from "fs";
 
 async function doServe() {
-  await serve(
+  const { host, port } = await serve(
     {
       servedir: path.join(buildDirectory, appDirectory),
-      port: 3000,
     },
     commonAppConfig(true)
   ).catch((e: unknown) => {
     console.log(e);
     process.exit(1);
   });
+
+  // Hack to handle the fact that our packages directory is outside of the
+  // paths understood by esbuild's serve(), so we need to load the sourcemaps
+  // ourselves.
+  http
+    .createServer((req, res) => {
+      const options = {
+        hostname: host,
+        port: port,
+        path: req.url,
+        method: req.method,
+        headers: req.headers,
+      };
+
+      const proxyReq = http.request(options, (proxyRes) => {
+        // If esbuild returns "not found", chec k
+        if (proxyRes.statusCode === 404) {
+          if (req.url) {
+            const url = new URL(req.url, `http://${req.headers.host}`);
+            if (url.pathname.startsWith("/packages")) {
+              res.writeHead(200, { "Content-Type": "text/html" });
+              res.end(fs.readFileSync(path.join('../..', url.pathname)));
+              return;
+            }
+          }
+        }
+
+        // Otherwise, forward the response from esbuild to the client
+        res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
+        proxyRes.pipe(res, { end: true });
+      });
+
+      // Forward the body of the request to esbuild
+      req.pipe(proxyReq, { end: true });
+    })
+    .listen(3000);
 }
 
 doServe();


### PR DESCRIPTION
Using Electron's developer tools works for `node_modules` and `src` files, but malloy packages are resolved to local paths outside of the electron app's directory. This sort of solution is [recommended](https://esbuild.github.io/api/#customizing-server-behavior) by esbuild when slightly more complex server behavior is needed.

I needed this to track down #599