### PR TITLE
Add postgres type "character"

### DIFF
--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -55,6 +55,7 @@ const postgresToMalloyTypes: { [key: string]: AtomicFieldTypeInner } = {
   "timestamp with time zone": "timestamp",
   timestamp: "timestamp",
   '"char"': "string",
+  character: "string",
   smallint: "number",
   xid: "string",
   real: "number",


### PR DESCRIPTION
I was testing malloy with postgres on localhost. I created a table with a "character(50)" column, and malloy doesn't seem to like this postgres type. I traced down to its mapping and added this new/missing mapping.