### PR TITLE
Automate duckdb updates

### DIFF
--- a/demo/malloy-demo-composer/scripts/build.ts
+++ b/demo/malloy-demo-composer/scripts/build.ts
@@ -19,10 +19,13 @@ import svgrPlugin from "esbuild-plugin-svgr";
 import * as path from "path";
 import fs from "fs";
 
+import duckdbPackage from "@malloydata/db-duckdb/package.json";
+const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
+
 export const targetDuckDBMap: Record<string, string> = {
-  "darwin-arm64": "duckdb-v0.4.1-dev454.0-node-v93-darwin-arm64.node",
-  "darwin-x64": "duckdb-v0.4.1-dev454.0-node-v93-darwin-x64.node",
-  "linux-x64": "duckdb-v0.4.1-dev454.0-node-v93-linux-x64.node",
+  "darwin-arm64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
+  "darwin-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
+  "linux-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
 };
 
 export const buildDirectory = "build/";

--- a/packages/malloy-vscode/scripts/build-extension.ts
+++ b/packages/malloy-vscode/scripts/build-extension.ts
@@ -20,6 +20,9 @@ import { exec, execSync } from "child_process";
 import { noNodeModulesSourceMaps } from "../../../third_party/github.com/evanw/esbuild/no-node-modules-sourcemaps";
 import svgrPlugin from "esbuild-plugin-svgr";
 
+import duckdbPackage from "@malloydata/db-duckdb/package.json";
+const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
+
 export type Target =
   | "linux-x64"
   | "linux-arm64"
@@ -43,9 +46,9 @@ export const targetKeytarMap: BinaryTargetMap = {
 };
 
 export const targetDuckDBMap: Partial<BinaryTargetMap> = {
-  "darwin-arm64": "duckdb-v0.4.1-dev454.0-node-v93-darwin-arm64.node",
-  "darwin-x64": "duckdb-v0.4.1-dev454.0-node-v93-darwin-x64.node",
-  "linux-x64": "duckdb-v0.4.1-dev454.0-node-v93-linux-x64.node",
+  "darwin-arm64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
+  "darwin-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
+  "linux-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
 };
 
 export const outDir = "dist/";

--- a/scripts/update_duckdb.ts
+++ b/scripts/update_duckdb.ts
@@ -1,0 +1,77 @@
+/* eslint-disable no-console */
+import * as fs from "fs";
+import * as path from "path";
+import * as zlib from "zlib";
+import fetch from "node-fetch";
+import tar from "tar-stream";
+
+import duckdbPackage from "@malloydata/db-duckdb/package.json";
+
+const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
+
+export const targetDuckDBMap: Record<string, string> = {
+  "darwin-arm64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
+  "darwin-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
+  "linux-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
+  "win32-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node`,
+};
+
+const fetchNode = async (target: string, file: string) => {
+  const url = `https://duckdb-node.s3.amazonaws.com/duckdb-v${DUCKDB_VERSION}-node-v93-${target}.tar.gz`;
+  const filePath = path.resolve(
+    path.join("third_party", "github.com", "duckdb", "duckdb", file)
+  );
+  if (fs.existsSync(filePath)) {
+    console.info(`Already exists: ${file}`);
+    return;
+  }
+  console.info(`Fetching: ${url}`);
+  const extract = tar.extract();
+  const response = await fetch(url);
+  await new Promise((resolve, reject) => {
+    try {
+      extract.on("entry", async (header, stream, next) => {
+        const outFile = fs.openSync(filePath, "w", header.mode);
+
+        for await (const chunk of stream) {
+          fs.writeFileSync(outFile, chunk);
+        }
+
+        stream.on("end", () => {
+          fs.closeSync(outFile);
+          next();
+        });
+      });
+
+      extract.on("finish", function () {
+        resolve(null);
+      });
+      extract.on("error", function (error) {
+        console.error(error);
+        reject(error);
+      });
+    } catch (error) {
+      console.error(error);
+      reject(error);
+    }
+    if (response.ok) {
+      const stream = response.body;
+      if (stream) {
+        console.info(`Reading: ${url}`);
+        stream.pipe(zlib.createGunzip()).pipe(extract);
+      }
+    } else {
+      console.error(`Failed to fetch ${file}: ${response.statusText}`);
+    }
+  });
+};
+
+(async () => {
+  const fetches: Promise<void>[] = [];
+
+  for (const [target, file] of Object.entries(targetDuckDBMap)) {
+    fetches.push(fetchNode(target, file));
+  }
+
+  await Promise.allSettled(fetches);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,14 @@
   dependencies:
     moment "*"
 
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@^16.11.26":
   version "16.11.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.35.tgz#6642bdce5b5cee23314b91a7c069981c6bd68791"
@@ -1145,6 +1153,13 @@
     "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     csstype "^3.0.2"
+
+"@types/tar-stream@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/tar-stream/-/tar-stream-2.2.2.tgz#be9d0be9404166e4b114151f93e8442e6ab6fb1d"
+  integrity sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/tough-cookie@*":
   version "4.0.1"


### PR DESCRIPTION
Allows us to update duckdb version in a single place and fetch and unzip into the correct locations.

Unfortunately right now darwin arm64 versions still need to be built by hand pending an update to duckdb ci.