### PR TITLE
Fix issue on publish step extension on win32-x64.

### DIFF
--- a/packages/malloy-vscode/scripts/build-extension.ts
+++ b/packages/malloy-vscode/scripts/build-extension.ts
@@ -50,7 +50,7 @@ export const targetDuckDBMap: Partial<BinaryTargetMap> = {
   "darwin-arm64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
   "darwin-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
   "linux-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
-  "win32-x64": "duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node",
+  "win32-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node`,
 };
 
 export const outDir = "dist/";


### PR DESCRIPTION
Issue arose from merge conflict resolution (` vs ") to allow string interpolation of the duckdb versioning.