### PR TITLE
Third-party licenses available in desktop

### DIFF
--- a/demo/malloy-demo-composer/public/not_packaged.html
+++ b/demo/malloy-demo-composer/public/not_packaged.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%; width: 100%">
+  <head> </head>
+  <body>
+    Not available when app is not packaged
+  </body>
+</html>

--- a/demo/malloy-demo-composer/scripts/package.ts
+++ b/demo/malloy-demo-composer/scripts/package.ts
@@ -29,7 +29,7 @@ async function packageDemo(
 ) {
   doBuild(`${platform}-${architecture}`);
 
-  // include third_party_licenses.txt
+  // third_party_licenses.txt
   const licenseFilePath = path.join(outDir, thirdPartyNotices);
   await new Promise((resolve, reject) => {
     const licenseFile = fs.createWriteStream(licenseFilePath);

--- a/demo/malloy-demo-composer/scripts/package.ts
+++ b/demo/malloy-demo-composer/scripts/package.ts
@@ -25,7 +25,7 @@ const thirdPartyNotices = "third_party_notices.txt";
 async function packageDemo(
   platform: string,
   architecture: string,
-  noCodeSigning = false
+  signAndNotarize = true
 ) {
   doBuild(`${platform}-${architecture}`);
 
@@ -49,7 +49,7 @@ async function packageDemo(
   });
 
   const extraOptions: Partial<packager.Options> = {};
-  if (!noCodeSigning) {
+  if (signAndNotarize) {
     if (platform === "darwin") {
       const appleId = process.env.NOTARIZER_APPLE_ID;
       const appleIdPassword = process.env.NOTARIZER_APPLE_ID_PASSWORD;
@@ -106,12 +106,17 @@ async function packageDemo(
 (async () => {
   const platform = process.argv[2];
   const architecture = process.argv[3];
-  const noCodeSigning = process.argv[4];
+  const signAndNotarize = process.argv[4];
 
   if (platform === undefined || architecture === undefined) {
     throw new Error("Specify platform and architecture.");
   }
-  await packageDemo(platform, architecture, noCodeSigning == "true");
+
+  await packageDemo(
+    platform,
+    architecture,
+    signAndNotarize == "false" ? false : true
+  );
 })()
   .then(() => {
     console.log("Demo application built successfully");

--- a/demo/malloy-demo-composer/scripts/package.ts
+++ b/demo/malloy-demo-composer/scripts/package.ts
@@ -12,47 +12,79 @@
  */
 
 /* eslint-disable no-console */
-
+import fs from "fs";
 import packager from "electron-packager";
 import { exit } from "process";
 import { doBuild } from "./build";
+import * as path from "path";
+import { exec } from "child_process";
 
-async function packageDemo(platform: string, architecture: string) {
+const outDir = "./dist";
+const thirdPartyNotices = "third_party_notices.txt";
+
+async function packageDemo(
+  platform: string,
+  architecture: string,
+  noCodeSigning = false
+) {
   doBuild(`${platform}-${architecture}`);
+
+  // include third_party_licenses.txt
+  const licenseFilePath = path.join(outDir, thirdPartyNotices);
+  await new Promise((resolve, reject) => {
+    const licenseFile = fs.createWriteStream(licenseFilePath);
+    licenseFile.on("open", () => {
+      exec("yarn licenses generate-disclaimer --prod", (error, stdio) => {
+        if (error) {
+          return reject(error);
+        }
+        licenseFile.write(stdio);
+        licenseFile.close();
+        resolve(licenseFile);
+      });
+    });
+    licenseFile.on("error", (err) => {
+      reject(err);
+    });
+  });
+
   const extraOptions: Partial<packager.Options> = {};
-  if (platform === "darwin") {
-    const appleId = process.env.NOTARIZER_APPLE_ID;
-    const appleIdPassword = process.env.NOTARIZER_APPLE_ID_PASSWORD;
-    const signerIdentity = process.env.SIGNER_IDENTITY;
-    const shouldSignAndNotarize = false;
-    if (
-      appleId === undefined ||
-      appleIdPassword === undefined ||
-      signerIdentity == undefined
-    ) {
-      console.log(
-        "Specify NOTARIZER_APPLE_ID, NOTARIZER_APPLE_ID_PASSWORD, and SIGNER_IDENTITY in environment."
-      );
-      exit(1);
+  if (!noCodeSigning) {
+    if (platform === "darwin") {
+      const appleId = process.env.NOTARIZER_APPLE_ID;
+      const appleIdPassword = process.env.NOTARIZER_APPLE_ID_PASSWORD;
+      const signerIdentity = process.env.SIGNER_IDENTITY;
+      const shouldSignAndNotarize = false;
+      if (
+        appleId === undefined ||
+        appleIdPassword === undefined ||
+        signerIdentity == undefined
+      ) {
+        console.log(
+          "Specify NOTARIZER_APPLE_ID, NOTARIZER_APPLE_ID_PASSWORD, and SIGNER_IDENTITY in environment."
+        );
+        exit(1);
+      }
+      extraOptions.osxSign = shouldSignAndNotarize
+        ? {
+            identity: signerIdentity,
+            hardenedRuntime: true,
+            entitlements: "entitlements.plist",
+            "entitlements-inherit": "entitlements.plist",
+          }
+        : undefined;
+      extraOptions.osxNotarize = shouldSignAndNotarize
+        ? {
+            appleId,
+            appleIdPassword,
+          }
+        : undefined;
     }
-    extraOptions.osxSign = shouldSignAndNotarize
-      ? {
-          identity: signerIdentity,
-          hardenedRuntime: true,
-          entitlements: "entitlements.plist",
-          "entitlements-inherit": "entitlements.plist",
-        }
-      : undefined;
-    extraOptions.osxNotarize = shouldSignAndNotarize
-      ? {
-          appleId,
-          appleIdPassword,
-        }
-      : undefined;
   }
+
   const appPaths = await packager({
     dir: ".",
-    out: "./dist",
+    out: outDir,
     overwrite: true,
     icon: "./public/icon.icns",
 
@@ -65,7 +97,7 @@ async function packageDemo(platform: string, architecture: string) {
     ],
     platform,
     arch: architecture,
-    extraResource: ["../../samples/"],
+    extraResource: ["../../samples/", path.join(outDir, thirdPartyNotices)],
     ...extraOptions,
   });
   console.log(`Electron app bundles created:\n${appPaths.join("\n")}`);
@@ -74,10 +106,12 @@ async function packageDemo(platform: string, architecture: string) {
 (async () => {
   const platform = process.argv[2];
   const architecture = process.argv[3];
+  const noCodeSigning = process.argv[4];
+
   if (platform === undefined || architecture === undefined) {
     throw new Error("Specify platform and architecture.");
   }
-  await packageDemo(platform, architecture);
+  await packageDemo(platform, architecture, noCodeSigning == "true");
 })()
   .then(() => {
     console.log("Demo application built successfully");

--- a/demo/malloy-demo-composer/src/electron/main.ts
+++ b/demo/malloy-demo-composer/src/electron/main.ts
@@ -157,6 +157,8 @@ async function registerIPC(): Promise<void> {
                 },
               });
 
+              thirdPartyWindow.setMenu(null);
+
               thirdPartyWindow.loadURL(
                 url.format({
                   pathname: app.isPackaged

--- a/demo/malloy-demo-composer/src/electron/main.ts
+++ b/demo/malloy-demo-composer/src/electron/main.ts
@@ -12,7 +12,7 @@
  */
 
 import { FieldDef } from "@malloydata/malloy";
-import { app, BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain, Menu, shell } from "electron";
 import * as path from "path";
 import url from "url";
 import { getAnalysis, readMalloyDirectory } from "./directory";
@@ -126,4 +126,69 @@ async function registerIPC(): Promise<void> {
   ipcMain.handle("post:open_directory", async (_event) => {
     return await getOpenDirectory();
   });
+
+  // Native application menu
+  const template: (Electron.MenuItem | Electron.MenuItemConstructorOptions)[] =
+    [
+      { role: "appMenu" },
+      { role: "fileMenu" },
+      { role: "editMenu" },
+      {
+        label: "View",
+        submenu: [
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+          { role: "resetZoom" },
+          { role: "zoomIn" },
+          { role: "zoomOut" },
+          { type: "separator" },
+          { role: "togglefullscreen" },
+          { type: "separator" },
+          {
+            label: "View Open Source Licenses",
+            click: async () => {
+              const thirdPartyWindow = new BrowserWindow({
+                width: 400,
+                height: 600,
+                webPreferences: {
+                  javascript: false,
+                },
+              });
+
+              thirdPartyWindow.loadURL(
+                url.format({
+                  pathname: app.isPackaged
+                    ? path.join(
+                        process.resourcesPath,
+                        "third_party_notices.txt"
+                      )
+                    : path.join(__dirname, "app", "not_packaged.html"),
+                  protocol: "file",
+                  slashes: true,
+                })
+              );
+            },
+          },
+        ],
+      },
+      { role: "windowMenu" },
+      {
+        label: "Help",
+        submenu: [
+          {
+            label: "Open Malloy Documentation",
+            click: async () => {
+              await shell.openExternal(
+                "https://looker-open-source.github.io/malloy/documentation/index.html"
+              );
+            },
+          },
+        ],
+      },
+    ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
 }

--- a/scripts/third_party_licenses.ts
+++ b/scripts/third_party_licenses.ts
@@ -50,6 +50,7 @@ const malloyPackages = [
   "@malloydata/db-bigquery",
   "@malloydata/db-postgres",
   "@malloydata/db-duckdb",
+  "malloy-composer-demo",
 ];
 
 // licenses that we would need to mirror source for, if we included (we don't today)
@@ -177,7 +178,7 @@ const getLicenses = async () => {
 
               try {
                 // stop GH/etc from limiting us
-                await new Promise((resolve) => setTimeout(resolve, 400));
+                await new Promise((resolve) => setTimeout(resolve, 700));
 
                 const license = await axios.head(licenseLink);
                 if (license) {


### PR DESCRIPTION
Enable a popup from the application menu to see licenses for software used in the app. Accessed via View -> View Open Source Licenses. Additionally:

- Include desktop app in license check script, and increase time between calls to github
- Add menu item in Help to access Malloy docs
- Dummy html page for when trying to view licenses when not packaged
- Flag to enable packaging of electron binary without notarization