### PR TITLE
add field list to ungrouped()

### DIFF
--- a/packages/malloy-db-test/src/handexpr.spec.ts
+++ b/packages/malloy-db-test/src/handexpr.spec.ts
@@ -375,7 +375,7 @@ it(`hand total - ${databaseName}`, async () => {
             aggregate: true,
             e: [
               {
-                type: "total",
+                type: "ungrouped",
                 e: [{ type: "field", path: "aircraft_count" }],
               },
             ],
@@ -428,7 +428,7 @@ it(`hand turtle total - ${databaseName}`, async () => {
                     aggregate: true,
                     e: [
                       {
-                        type: "total",
+                        type: "ungrouped",
                         e: [{ type: "field", path: "aircraft_count" }],
                       },
                     ],

--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -740,7 +740,7 @@ export class ExprSum extends ExprAsymmetric {
 }
 
 export class ExprUngrouped extends ExpressionDef {
-  legalChildTypes = [FT.numberT, FT.stringT, FT.dateT, FT.timestampT];
+  legalChildTypes = FT.anyAtomicT;
   elementType = "ungrouped";
   constructor(readonly expr: ExpressionDef, readonly fields: FieldName[]) {
     super({ expr, fields });
@@ -751,7 +751,11 @@ export class ExprUngrouped extends ExpressionDef {
   }
 
   getExpression(fs: FieldSpace): ExprValue {
-    const exprVal = this.expr?.getExpression(fs);
+    const exprVal = this.expr.getExpression(fs);
+    if (!exprVal.aggregate) {
+      this.expr.log("ungrouped expression must be an aggregate");
+      return errorFor("ungrouped scalar");
+    }
     if (this.typeCheck(this.expr, { ...exprVal, aggregate: false })) {
       const f: UngroupedFragment = {
         type: "ungrouped",
@@ -768,7 +772,7 @@ export class ExprUngrouped extends ExpressionDef {
         value: [f],
       };
     }
-    return errorFor("aggregate type check");
+    return errorFor("ungrouped type check");
   }
 }
 
@@ -846,7 +850,7 @@ export class ExprCase extends ExpressionDef {
 
 export class ExprFilter extends ExpressionDef {
   elementType = "filtered expression";
-  legalChildTypes = [FT.stringT, FT.numberT, FT.dateT, FT.timestampT];
+  legalChildTypes = FT.anyAtomicT;
   constructor(readonly expr: ExpressionDef, readonly filter: Filter) {
     super({ expr, filter });
   }

--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -378,7 +378,7 @@ fieldExpr
   | OPAREN partialAllowedFieldExpr CPAREN                  # exprExpr
   | (id | timeframe) OPAREN ( argumentList? ) CPAREN       # exprFunc
   | pickStatement                                          # exprPick
-  | UNGROUPED OPAREN fieldExpr CPAREN                      # exprUngrouped
+  | UNGROUPED OPAREN fieldExpr (COMMA fieldName)* CPAREN   # exprUngrouped
   ;
 
 partialAllowedFieldExpr

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -21,6 +21,7 @@ import { MessageLogger } from "./parse-log";
 import { MalloyParseRoot } from "./parse-malloy";
 import { Interval as StreamInterval } from "antlr4ts/misc/Interval";
 import { LogSeverity } from "./parse-log";
+import _ from "lodash";
 
 /**
  * ANTLR visitor pattern parse tree traversal. Generates a Malloy
@@ -904,8 +905,9 @@ export class MalloyToAST
   }
 
   visitExprUngrouped(pcx: parse.ExprUngroupedContext): ast.ExprUngrouped {
+    const flist = pcx.fieldName().map((fcx) => this.getFieldName(fcx));
     return this.astAt(
-      new ast.ExprUngrouped(this.getFieldExpr(pcx.fieldExpr())),
+      new ast.ExprUngrouped(this.getFieldExpr(pcx.fieldExpr()), flist),
       pcx
     );
   }

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -21,7 +21,6 @@ import { MessageLogger } from "./parse-log";
 import { MalloyParseRoot } from "./parse-malloy";
 import { Interval as StreamInterval } from "antlr4ts/misc/Interval";
 import { LogSeverity } from "./parse-log";
-import _ from "lodash";
 
 /**
  * ANTLR visitor pattern parse tree traversal. Generates a Malloy

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1236,6 +1236,13 @@ describe("error handling", () => {
       `
     ).compileToFailWith("'meaning_of_life' is not defined");
   });
+  test("detect output collision on join references", () => {
+    expect(`
+      query: ab -> {
+        group_by: astr, b.astr
+      }
+    `).compileToFailWith("Output already has a field named 'astr'");
+  });
 });
 
 function getSelectOneStruct(sqlBlock: SQLBlock): StructDef {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -58,7 +58,7 @@ import {
   isDialectFragment,
   getPhysicalFields,
   isIndexSegment,
-  TotalFragment,
+  UngroupedFragment,
   isTotalFragment,
 } from "./malloy_types";
 
@@ -395,7 +395,7 @@ class QueryField extends QueryNode {
   generateTotalFragment(
     resultSet: FieldInstanceResult,
     context: QueryStruct,
-    expr: TotalFragment,
+    expr: UngroupedFragment,
     state: GenerateState
   ): string {
     if (state.inTotal) {

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -173,13 +173,14 @@ export function isAsymmetricFragment(f: Fragment): f is AggregateFragment {
   return isAggregateFragment(f) && ["sum", "avg", "count"].includes(f.function);
 }
 
-export interface TotalFragment {
-  type: "total";
+export interface UngroupedFragment {
+  type: "ungrouped";
   e: Expr;
+  fields?: string[];
 }
 
-export function isTotalFragment(f: Fragment): f is TotalFragment {
-  return (f as TotalFragment)?.type === "total";
+export function isTotalFragment(f: Fragment): f is UngroupedFragment {
+  return (f as UngroupedFragment)?.type === "ungrouped";
 }
 
 export interface FieldFragment {
@@ -276,7 +277,7 @@ export type Fragment =
   | ParameterFragment
   | FilterFragment
   | AggregateFragment
-  | TotalFragment
+  | UngroupedFragment
   | DialectFragment;
 
 export type Expr = Fragment[];


### PR DESCRIPTION
OK ... experiment ... half implemented

The parser does NOT check the field name list against the output field name list, because it doesn't have that available at the moment it is generating the list.

Will need to fix that eventually, for now the SQL writer will throw and it will be a bad user experience to have errors there.
