### PR TITLE
Only throw Error objects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     "prettier/prettier": "error",
     "sort-keys": "off",
     "no-use-before-define": "off",
+    "no-throw-literal": "error",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -80,11 +80,14 @@ export class DuckDBConnection implements Connection, PersistSQLResults {
     return true;
   }
 
-  // @bporterfield need help writing this. it needs to wait if a setup is in process.
   protected async setup(): Promise<void> {
     if (!this.isSetup) {
+      // TODO: This is where we will load extensions once we figure
+      // out how to better support them.
       // await this.runDuckDBQuery("INSTALL 'json'");
       // await this.runDuckDBQuery("LOAD 'json'");
+      // await this.runDuckDBQuery("INSTALL 'httpfs'");
+      // await this.runDuckDBQuery("LOAD 'httpfs'");
       //   await this.runDuckDBQuery("DROP MACRO sum_distinct");
       //   try {
       //     await this.runDuckDBQuery(
@@ -226,7 +229,7 @@ export class DuckDBConnection implements Connection, PersistSQLResults {
       if (columnMatch && columnMatch.groups) {
         ret[columnMatch.groups["name"]] = columnMatch.groups["type"];
       } else {
-        throw `Badly form Structure definition ${s}`;
+        throw new Error(`Badly form Structure definition ${s}`);
       }
     }
     return ret;

--- a/packages/malloy-vscode/src/common/connection_manager.ts
+++ b/packages/malloy-vscode/src/common/connection_manager.ts
@@ -136,7 +136,7 @@ export class DynamicConnectionLookup implements LookupConnection<Connection> {
           { useCache: true, ...this.options }
         );
       } else {
-        throw `No connection found with name ${connectionName}`;
+        throw new Error(`No connection found with name ${connectionName}`);
       }
     }
     return this.connections[connectionKey];


### PR DESCRIPTION
Some of the blank pages we were getting were because we throwing string literals instead of `Error` objects, resulting in `error.message` being `null`.