### PR TITLE
Add publish script for patch  of vscode extension.

### DIFF
--- a/cloudbuild/deploy/deploy-patch-extension.sh
+++ b/cloudbuild/deploy/deploy-patch-extension.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -euxo pipefail
+
+nix-shell --pure --keep VSCE_PAT --command  "$(cat <<NIXCMD
+  cd /workspace
+  yarn install --frozen-lockfile
+  yarn build && yarn vscode-publish-extensions patch
+NIXCMD
+)"

--- a/packages/malloy-vscode/scripts/publish-extensions.ts
+++ b/packages/malloy-vscode/scripts/publish-extensions.ts
@@ -85,7 +85,7 @@ if (!version)
     "No version passed to publish script. Call it with a semver version or pass 'pre-release'."
   );
 
-console.log(`Starting publish for ${version} extensions`);
+console.log(`Starting ${version} publish for extensions`);
 
 doPublish(version)
   .then(() => {

--- a/packages/malloy-vscode/scripts/publish-extensions.ts
+++ b/packages/malloy-vscode/scripts/publish-extensions.ts
@@ -13,22 +13,61 @@
 /* eslint-disable no-console */
 
 import * as semver from "semver";
+import { readFileSync } from "fs";
 import { publishVSIX } from "vsce";
 import { Target, targetKeytarMap } from "./build-extension";
 import { doPackage } from "./package-extension";
 
+/**
+ * @returns Array of version bits. [major, minor, patch]
+ */
+function getVersionBits(): Array<number> {
+  return JSON.parse(readFileSync("package.json", "utf-8"))
+    .version.split(".")
+    .map(Number);
+}
+
 async function doPublish(version: string) {
   let preRelease = false;
-  if (version == "pre-release") {
-    // NOTE: pre-release is pinned to 0.1 here. We'll need to increment the minor if we
-    // ever push production version > 0.0.x
-    version = `0.1.${Math.floor(Date.now() / 1000)}`;
-    preRelease = true;
-  } else if (!semver.valid(version))
-    throw new Error(`Invalid semver: ${version}`);
+  const versionBits = getVersionBits();
 
+  // Enforcing recommendation that Releases use even numbered minor versions and pre-release uses odd minor versions.
+  // See: https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+  // Only release versions incrementing major or minor should be committed. (until incrementing is automated)
+  // The final version bit (patch) will be auto-generated.
+  if (versionBits[1] % 2 != 0) {
+    throw new Error(
+      "Invalid release version found in package.json. Release minor version should be even."
+    );
+  }
+  switch (version) {
+    case "pre-release":
+      versionBits[1] += 1;
+      versionBits[2] = Math.floor(Date.now() / 1000);
+      preRelease = true;
+      break;
+    case "patch":
+    case "minor":
+    case "major":
+      versionBits[2] = Math.floor(Date.now() / 1000);
+      break;
+    default:
+      throw new Error(`Unknown version tag: ${version}.`);
+  }
+
+  const versionCode = versionBits.join(".");
+  if (!semver.valid(versionCode))
+    throw new Error(`Invalid semver: ${versionCode}`);
+
+  console.log(
+    `Publishing ${version} extensions with version code: ${versionCode}`
+  );
   for (const target in targetKeytarMap) {
-    const packagePath = await doPackage(target as Target, version, preRelease);
+    const packagePath = await doPackage(
+      target as Target,
+      versionCode,
+      preRelease
+    );
 
     await publishVSIX(packagePath, {
       githubBranch: "main",
@@ -46,7 +85,7 @@ if (!version)
     "No version passed to publish script. Call it with a semver version or pass 'pre-release'."
   );
 
-console.log(`Publishing extensions with version ${version}`);
+console.log(`Starting publish for ${version} extensions`);
 
 doPublish(version)
   .then(() => {


### PR DESCRIPTION
Updates publish script to expand publish automation.
- converts to specifying `major`, `minor`, `patch`, or `pre-release` as input to the publish script
- version format follows semver with `<major>.<minor>.<patch>`
- will auto-generate `patch` number for all publish types
- only increments to `major` or `minor` require a commit.
- `minor` must be EVEN, pre-releases will use ODD numbers as recommended by the documentation (see https://code.visualstudio.com/api/working-with-extensions/publishing-extension)