### PR TITLE
Allow ungroup anywhere in the dimensional heirachy

### DIFF
--- a/packages/malloy/src/lang/grammar/Malloy.g4
+++ b/packages/malloy/src/lang/grammar/Malloy.g4
@@ -354,7 +354,7 @@ timeframe
   ;
 
 ungrouped
-  : UNGROUPED | ALL
+  : UNGROUPED | ALL | EXCLUDE
   ;
 
 fieldExpr
@@ -512,6 +512,7 @@ DESC: D E S C ;
 DISTINCT: D I S T I N C T ;
 ELSE: E L S E ;
 END: E N D ;
+EXCLUDE: E X C L U D E;
 FALSE: F A L S E;
 FOR: F O R;
 FROM: F R O M ;

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1196,18 +1196,23 @@ class FieldInstanceResult implements FieldInstance {
   ): FieldInstanceField[] {
     let ret: FieldInstanceField[] = [];
 
-    if (ungroupSet !== undefined) {
-      ret = this.fields(
-        (fi) =>
-          isScalarField(fi.f) &&
-          fi.fieldUsage.type === "result" &&
-          ungroupSet.fields.indexOf(fi.f.getIdentifier()) !== -1
-      );
-    }
-    let p = this.parent;
+    // if (ungroupSet !== undefined) {
+    //   ret = this.fields(
+    //     (fi) =>
+    //       isScalarField(fi.f) &&
+    //       fi.fieldUsage.type === "result" &&
+    //       ungroupSet.fields.indexOf(fi.f.getIdentifier()) !== -1
+    //   );
+    // }
+    let p: FieldInstanceResult | undefined = this as FieldInstanceResult;
     while (p !== undefined) {
       ret = ret.concat(
-        p.fields((fi) => isScalarField(fi.f) && fi.fieldUsage.type === "result")
+        p.fields(
+          (fi) =>
+            isScalarField(fi.f) &&
+            fi.fieldUsage.type === "result" &&
+            !(ungroupSet?.fields.indexOf(fi.f.getIdentifier()) !== -1)
+        )
       );
       p = p.parent;
     }

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -1205,13 +1205,23 @@ class FieldInstanceResult implements FieldInstance {
     //   );
     // }
     let p: FieldInstanceResult | undefined = this as FieldInstanceResult;
+    let escapeFields: string[] = [];
+    // all defaults to all fields at the current level.
+    if (ungroupSet === undefined) {
+      // escape all dimensions at the
+      escapeFields = this.fields(
+        (fi) => isScalarField(fi.f) && fi.fieldUsage.type === "result"
+      ).map((fi) => fi.f.getIdentifier());
+    } else {
+      escapeFields = ungroupSet.fields;
+    }
     while (p !== undefined) {
       ret = ret.concat(
         p.fields(
           (fi) =>
             isScalarField(fi.f) &&
             fi.fieldUsage.type === "result" &&
-            !(ungroupSet?.fields.indexOf(fi.f.getIdentifier()) !== -1)
+            escapeFields.indexOf(fi.f.getIdentifier()) === -1
         )
       );
       p = p.parent;

--- a/samples/faa/flights.malloy
+++ b/samples/faa/flights.malloy
@@ -54,6 +54,24 @@ source: flights is table('malloy-data.faa.flights') {
     aggregate: destination_count is destination.count()
   }
 
+  query: carrier_overview is {
+    group_by: carrier_name is carriers.nickname
+    aggregate: 
+      flight_count
+      percent_of_this_carriers_flights_to_all_flights
+        is flight_count/all(flight_count)*100
+    nest: top_destinations is {
+      group_by: destination.code, destination.full_name
+      aggregate:
+        flight_count
+        percentage_of_this_carriers_flights_to_this_destination 
+          is flight_count/all(flight_count)*100
+        percentage_of_all_flights_on_all_carriers_to_this_destination 
+          is flight_count/all(flight_count, carrier_name)*100
+      limit: 3
+    }
+  }
+
   // shows year over year growth (line chart)
   query: year_over_year is {
     group_by: dep_month is month(dep_time)

--- a/samples/faa/flights.malloy
+++ b/samples/faa/flights.malloy
@@ -67,7 +67,7 @@ source: flights is table('malloy-data.faa.flights') {
         percentage_of_this_carriers_flights_to_this_destination 
           is flight_count/all(flight_count)*100
         percentage_of_all_flights_on_all_carriers_to_this_destination 
-          is flight_count/all(flight_count, carrier_name)*100
+          is flight_count/exclude(flight_count, carrier_name)*100
       limit: 3
     }
   }


### PR DESCRIPTION
For excluding dimensions we've switched to the word 'exclude' for clarity (this syntax may or may not change so please don't get too attached).  

When dealing with nested query, allow exclude to specify dimensions above the current nesting level.  For example..

```
         query: airports -> {
          where: state = 'TX' | 'NY'
          group_by:
            faa_region
            state
          aggregate:
            c
            all_ is all(c)
            airport_count is c {? fac_type = 'AIRPORT'}
          nest: fac_type is {
            group_by: fac_type
            aggregate:
              c
              all_ is all(c)
              all_state is all(c,state)
              all_state_region is exclude(c,fac_type)
              all_of_this_type is exclude(c, state, faa_region)
              all_top is exclude(c, state, faa_region, fac_type)
          }
        }

 ```

