### PR TITLE
Increase gradient contrast

### DIFF
--- a/packages/malloy-render/src/html/utils.ts
+++ b/packages/malloy-render/src/html/utils.ts
@@ -23,14 +23,14 @@ export function getColorScale(
   }
   switch (type) {
     case "ordinal":
-      return { range: ["#12B5CB", "#1A73E8"] };
+      return { range: ["#C2D5EE", "#1A73E8"] };
     case "temporal":
     case "quantitative":
       return isRectMark
         ? hasOverlappingText
           ? { range: ["#6BA4EE", "#EEA361"] }
           : { range: ["#1A73E8", "#E8710A"] }
-        : { range: ["#1A73E8", "#12B5CB"] };
+        : { range: ["#C2D5EE", "#1A73E8"] };
     case "nominal":
       return hasOverlappingText
         ? {


### PR DESCRIPTION
Create a more distinct gradient for maps and other visualizations than the current teal -> blue gradient.

Fixes: https://github.com/looker-open-source/malloy/issues/671

Before: 

![image](https://user-images.githubusercontent.com/1093458/181917550-7c8324b0-95ca-4423-9f55-d79dc2fab2b3.png)

After:
<img width="1021" alt="Screen Shot 2022-08-01 at 2 28 15 PM" src="https://user-images.githubusercontent.com/2958002/182249680-a13a6933-0b2f-45aa-9539-19ee3733706e.png">

