### PR TITLE
fix new queries appending to old queries

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -1865,11 +1865,10 @@ export class ExistingQuery extends PipelineDesc {
       sourcePipe.pipeline,
       new DynamicSpace(walkStruct)
     );
-
+    const destPipe = { ...sourcePipe, pipeline: appended.opList };
     const query: model.Query = {
       type: "query",
-      ...sourcePipe,
-      ...appended.opList,
+      ...destPipe,
       structRef: queryHead.structRef(),
       location: this.location,
     };

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -16,6 +16,7 @@ import { TranslateResponse } from "..";
 import {
   DocumentLocation,
   DocumentPosition,
+  Query,
   SQLBlock,
   StructDef,
 } from "../../model";
@@ -67,6 +68,28 @@ class BetaModel extends Testable {
 
   unresolved(): DataRequestResponse {
     return this.importsAndTablesStep.step(this);
+  }
+
+  getSourceDef(srcName: string): StructDef | undefined {
+    const t = this.translate().translated;
+    if (t) {
+      const s = t.modelDef.contents[srcName];
+      if (s.type == "struct") {
+        return s;
+      }
+    }
+    return undefined;
+  }
+
+  getQuery(queryName: string): Query | undefined {
+    const t = this.translate().translated;
+    if (t) {
+      const s = t.modelDef.contents[queryName];
+      if (s.type == "query") {
+        return s;
+      }
+    }
+    return undefined;
   }
 }
 
@@ -154,16 +177,12 @@ expect.extend({
     const exprModel = new BetaModel(
       `explore: x is a { dimension: d is ${functionCall} }`
     );
-    const tx = exprModel.translate();
     expect(exprModel).toTranslate();
-    const model = tx.translated?.modelDef;
-    if (model) {
-      const x = model.contents.x;
-      expect(x).toBeDefined();
-      if (x?.type == "struct") {
-        const d = x.fields.find((f) => f.name === "d");
-        expect(d?.type).toBe(returnType);
-      }
+    const x = exprModel.getSourceDef("x");
+    expect(x).toBeDefined();
+    if (x) {
+      const d = x.fields.find((f) => f.name === "d");
+      expect(d?.type).toBe(returnType);
     }
     return {
       pass: true,
@@ -172,20 +191,18 @@ expect.extend({
   },
   compileToFailWith: function (s: MarkedSource | string, ...msgs: string[]) {
     const src = typeof s == "string" ? s : s.code;
-    let emsg = "Expected: ";
+    let emsg = "Compile Error expectation not met\nExpected error";
+    const qmsgs = msgs.map((s) => `error '${s}'`);
     if (msgs.length == 1) {
-      emsg += msgs[0];
+      emsg += ` ${qmsgs[0]}`;
     } else {
-      emsg += `[\n    ${msgs.join("\n    ")}]\n]`;
+      emsg += `s [\n${qmsgs.join("\n")}\n]`;
     }
     emsg += `\nSource:\n${src}`;
     const m = new BetaModel(src);
     const t = m.translate();
     if (t.translated) {
-      return {
-        pass: false,
-        message: () => `No errors in model\n${emsg}`,
-      };
+      return { pass: false, message: () => emsg };
     } else if (t.errors == undefined) {
       return {
         pass: false,
@@ -337,15 +354,11 @@ describe("model statements", () => {
     test("source refinement preserves original", () => {
       const x = new BetaModel("source: na is a + { dimension: one is 1 }");
       expect(x).toTranslate();
-      const t = x.translate().translated;
-      expect(t).toBeDefined();
-      if (t) {
-        const a = t.modelDef.contents.a;
-        if (a.type == "struct") {
-          const aFields = a.fields.map((f) => f.as || f.name);
-          expect(aFields).toContain("astr");
-          expect(aFields).not.toContain("one");
-        }
+      const a = x.getSourceDef("a");
+      if (a) {
+        const aFields = a.fields.map((f) => f.as || f.name);
+        expect(aFields).toContain("astr");
+        expect(aFields).not.toContain("one");
       }
     });
   });
@@ -428,16 +441,11 @@ describe("model statements", () => {
         query: nq is -> q + { group_by: astr }
       `);
       expect(x).toTranslate();
-      const t = x.translate().translated;
-      expect(t).toBeDefined();
-      if (t) {
-        const q = t.modelDef.contents.q;
-        expect(q).toBeDefined();
-        expect(q?.type).toBe("query");
-        if (q && q.type == "query") {
-          const qFields = q.pipeline[0].fields;
-          expect(qFields.length).toBe(1);
-        }
+      const q = x.getQuery("q");
+      expect(q).toBeDefined();
+      if (q) {
+        const qFields = q.pipeline[0].fields;
+        expect(qFields.length).toBe(1);
       }
     });
     test("query composition preserves original", () => {
@@ -446,15 +454,10 @@ describe("model statements", () => {
         query: nq is -> q -> { project: * }
       `);
       expect(x).toTranslate();
-      const t = x.translate().translated;
-      expect(t).toBeDefined();
-      if (t) {
-        const q = t.modelDef.contents.q;
-        expect(q).toBeDefined();
-        expect(q?.type).toBe("query");
-        if (q && q.type == "query") {
-          expect(q.pipeline.length).toBe(1);
-        }
+      const q = x.getQuery("q");
+      expect(q).toBeDefined();
+      if (q) {
+        expect(q.pipeline.length).toBe(1);
       }
     });
   });
@@ -601,30 +604,20 @@ describe("explore properties", () => {
   test("rename", modelOK("explore: c is a { rename: nn is ai }"));
   test("accept single", () => {
     const onlyAstr = new BetaModel("explore: c is a { accept: astr }");
-    expect(onlyAstr).toCompile();
-    const m = onlyAstr.translate()?.translated?.modelDef;
-    expect(m).toBeDefined();
-    if (m) {
-      const c = m.contents.c;
-      expect(c.type).toBe("struct");
-      if (c.type == "struct") {
-        expect(c.fields.length).toBe(1);
-      }
+    expect(onlyAstr).toTranslate();
+    const c = onlyAstr.getSourceDef("c");
+    if (c) {
+      expect(c.fields.length).toBe(1);
     }
   });
   test("accept multi", modelOK("explore: c is a { accept: astr, af }"));
   test("except single", () => {
     const noAstr = new BetaModel("explore: c is a { except: astr }");
-    expect(noAstr).toCompile();
-    const m = noAstr.translate()?.translated?.modelDef;
-    expect(m).toBeDefined();
-    if (m) {
-      const c = m.contents.c;
-      expect(c.type).toBe("struct");
-      if (c.type == "struct") {
-        const foundAstr = c.fields.find((f) => f.name == "astr");
-        expect(foundAstr).toBeUndefined();
-      }
+    expect(noAstr).toTranslate();
+    const c = noAstr.getSourceDef("c");
+    if (c) {
+      const foundAstr = c.fields.find((f) => f.name == "astr");
+      expect(foundAstr).toBeUndefined();
     }
   });
   test("except multi", modelOK("explore: c is a { except: astr, af }"));
@@ -740,8 +733,7 @@ describe("qops", () => {
   test(`filters preserve source formatting in code:`, () => {
     const model = new BetaModel(`source: notb is a + { where: astr  !=  'b' }`);
     expect(model).toTranslate();
-    const t = model.translate();
-    const notb = t.translated?.modelDef.contents.notb;
+    const notb = model.getSourceDef("notb");
     expect(notb).toBeDefined();
     if (notb) {
       const f = notb.filterList;
@@ -756,11 +748,9 @@ describe("qops", () => {
       `source: notb is a + { dimension: d is 1 +   2 }`
     );
     expect(model).toTranslate();
-    const t = model.translate();
-    const notb = t.translated?.modelDef.contents.notb;
+    const notb = model.getSourceDef("notb");
     expect(notb).toBeDefined();
-    expect(notb?.type).toBe("struct");
-    if (notb?.type === "struct") {
+    if (notb) {
       const d = notb.fields.find((f) => f.as || f.name === "d");
       expect(d).toBeDefined();
       expect(d?.type).toBe("number");
@@ -1107,9 +1097,7 @@ describe("sql backdoor", () => {
         model.update({ sqlStructs: { [refKey]: makeSchemaResponse(sql) } });
         expect(model).toTranslate();
       }
-      const modelDef = model.translate().translated?.modelDef;
-      expect(modelDef).toBeDefined();
-      const users = modelDef?.contents.malloyUsers;
+      const users = model.getSourceDef("malloyUsers");
       expect(users).toBeDefined();
       expect(users).toHaveProperty(
         "structSource.sqlBlock.connection",
@@ -2169,6 +2157,20 @@ describe("pipeline comprehension", () => {
       query: aqf is aq -> { project: * }
     `)
   );
+  test("new query appends to existing query", () => {
+    const src = `
+      query: s1 is table('malloytest.flights') -> {
+        group_by: origin, destination
+      }
+      query: s2 is ->s1 ->{
+        group_by: destination
+      }
+    `;
+    const m = new BetaModel(src);
+    expect(m).toTranslate();
+    const s2 = m.getQuery("s2");
+    expect(s2?.pipeline.length).toBe(2);
+  });
 });
 
 describe("standard sql function return types", () => {


### PR DESCRIPTION
Fixes #687

I don't think appending to an existing named query has worked since the `:{}` event.

Fixed, now, and added the missing test.