### PR TITLE
Prevent stack overflow when a query is defined with an existing name

### DIFF
--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -151,6 +151,9 @@ class ConstantFieldSpace implements FieldSpace {
       found: undefined,
     };
   }
+  contains(_name: string): boolean {
+    return false;
+  }
   getDialect(): Dialect {
     // well dialects totally make this wrong and broken and stupid and useless
     // but since this is only used for parameters which are also wrong and

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -81,6 +81,10 @@ export class ErrorFactory {
   static get indexSegment(): model.IndexSegment {
     return { type: "index", fields: [] };
   }
+
+  static get turtleDef(): model.TurtleDef {
+    return { type: "turtle", name: "turtleDefError", pipeline: [] };
+  }
 }
 
 function opOutputStruct(
@@ -1992,6 +1996,10 @@ export class TurtleDecl extends TurtleHeadedPipe {
   }
 
   getFieldDef(inputFS: FieldSpace): model.TurtleDef {
+    if (inputFS.contains(this.name)) {
+      this.log(`Cannot redefine '${this.name}'`);
+      return ErrorFactory.turtleDef;
+    }
     const pipe = this.getPipeline(inputFS);
     return {
       type: "turtle",

--- a/packages/malloy/src/lang/field-space.ts
+++ b/packages/malloy/src/lang/field-space.ts
@@ -73,6 +73,7 @@ export interface FieldSpace {
   structDef(): model.StructDef;
   emptyStructDef(): model.StructDef;
   lookup(symbol: FieldName[]): LookupResult;
+  contains(name: string): boolean;
   getDialect(): Dialect;
 }
 
@@ -186,6 +187,10 @@ export class StaticSpace implements FieldSpace {
       };
     }
     return { found, error: undefined };
+  }
+
+  contains(name: string): boolean {
+    return this.map[name] != undefined;
   }
 }
 
@@ -638,6 +643,9 @@ export class DefSpace implements FieldSpace {
       };
     }
     return this.realFS.lookup(symbol);
+  }
+  contains(name: string): boolean {
+    return this.realFS.contains(name);
   }
   getDialect(): Dialect {
     return this.realFS.getDialect();

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1155,6 +1155,13 @@ describe("sql backdoor", () => {
 });
 
 describe("error handling", () => {
+  test("field and query with same name does not overflow", () => {
+    expect(`
+      source: flights is table('malloytest.flights') {
+        query: carrier is { group_by: carrier }
+      }
+    `).compileToFailWith("Cannot redefine 'carrier'");
+  });
   test("redefine source", () => {
     expect(markSource`
       source: airports is table('malloytest.airports') + {


### PR DESCRIPTION
For #721 -- this doesn't fix anything though.