### PR TITLE
Use vscode file buffer instead of file system

### DIFF
--- a/packages/malloy-vscode/src/worker/files.ts
+++ b/packages/malloy-vscode/src/worker/files.ts
@@ -12,11 +12,39 @@
  */
 
 import { URLReader } from "@malloydata/malloy";
-import * as fs from "fs/promises";
 import { fileURLToPath } from "url";
+import { Message } from "./types";
 
-export async function fetchFile(uri: string): Promise<string> {
-  return await fs.readFile(uri.replace(/^file:\/\//, ""), "utf-8");
+let idx = 1;
+
+/**
+ * Requests a file from the worker's controller. Although the
+ * file path is a file system path, reading the file off
+ * disk doesn't take into account unsaved changes that only
+ * VS Code is aware of.
+ *
+ * @param file File path to resolve
+ * @returns File contents
+ */
+export async function fetchFile(file: string): Promise<string> {
+  return new Promise((resolve) => {
+    // This could probably use some error handling (timeout?).
+    // For now just be relentlessly optimistic because there's
+    // a tight coupling with the worker controller.
+    const id = `${file}-${idx++}`;
+    const callback = (message: Message) => {
+      if (message.type === "read" && message.id === id) {
+        resolve(message.data);
+        process.off("message", callback);
+      }
+    };
+    process.on("message", callback);
+    process.send?.({
+      type: "read",
+      file,
+      id,
+    });
+  });
 }
 
 export class WorkerURLReader implements URLReader {

--- a/packages/malloy-vscode/src/worker/files.ts
+++ b/packages/malloy-vscode/src/worker/files.ts
@@ -27,14 +27,18 @@ let idx = 1;
  * @returns File contents
  */
 export async function fetchFile(file: string): Promise<string> {
-  return new Promise((resolve) => {
-    // This could probably use some error handling (timeout?).
+  return new Promise((resolve, reject) => {
+    // This could probably use some more error handling (timeout?).
     // For now just be relentlessly optimistic because there's
     // a tight coupling with the worker controller.
     const id = `${file}-${idx++}`;
     const callback = (message: Message) => {
       if (message.type === "read" && message.id === id) {
-        resolve(message.data);
+        if (message.data != null) {
+          resolve(message.data);
+        } else if (message.error != null) {
+          reject(new Error(message.error));
+        }
         process.off("message", callback);
       }
     };

--- a/packages/malloy-vscode/src/worker/types.ts
+++ b/packages/malloy-vscode/src/worker/types.ts
@@ -79,6 +79,13 @@ export interface MessageConfig {
   config: MalloyConfig;
 }
 
+export interface MessageRead {
+  type: "read";
+  id: string;
+  file: string;
+  data: string;
+}
+
 export interface MessageDownload {
   type: "download";
   query: WorkerQuerySpec;
@@ -92,6 +99,7 @@ export type Message =
   | MessageCancel
   | MessageConfig
   | MessageExit
+  | MessageRead
   | MessageRun
   | MessageDownload;
 
@@ -124,9 +132,16 @@ export interface WorkerStartMessage {
   type: "start";
 }
 
+export interface WorkerReadMessage {
+  type: "read";
+  id: string;
+  file: string;
+}
+
 export type WorkerMessage =
   | WorkerDeadMessage
   | WorkerDownloadMessage
   | WorkerLogMessage
   | WorkerQueryPanelMessage
+  | WorkerReadMessage
   | WorkerStartMessage;

--- a/packages/malloy-vscode/src/worker/types.ts
+++ b/packages/malloy-vscode/src/worker/types.ts
@@ -83,7 +83,8 @@ export interface MessageRead {
   type: "read";
   id: string;
   file: string;
-  data: string;
+  data?: string;
+  error?: string;
 }
 
 export interface MessageDownload {

--- a/packages/malloy-vscode/src/worker/worker_connection.ts
+++ b/packages/malloy-vscode/src/worker/worker_connection.ts
@@ -77,7 +77,11 @@ export class WorkerConnection {
 
   async readFile(message: WorkerReadMessage): Promise<void> {
     const { id, file } = message;
-    const data = await fetchFile(file);
-    this.send?.({ type: "read", id, file, data });
+    try {
+      const data = await fetchFile(file);
+      this.send?.({ type: "read", id, file, data });
+    } catch (error) {
+      this.send?.({ type: "read", id, file, error: error.message });
+    }
   }
 }


### PR DESCRIPTION
@anikaks pointed out that she now needed to save a file for VS Code to pick up changes, which didn't use to be the case. That's because the old code was using VS Code's notion of the file buffer, not the filesystem version. This restores that behavior by adding a message to retrieve the filed contents via VS Code.