### PR TITLE
Don't throw "INTERNAL ERROR" when an imported file has errors

### DIFF
--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -767,11 +767,7 @@ export abstract class MalloyTranslation {
     const child = this.childTranslators.get(childURL);
     if (child) {
       const did = child.translate();
-      if (!did.translated) {
-        this.root.logger.log({
-          message: `INTERNAL ERROR: Load failure on import of ${importURL}`,
-        });
-      } else {
+      if (did.translated) {
         for (const fromChild of child.modelDef.exports) {
           const modelEntry = child.modelDef.contents[fromChild];
           if (modelEntry.type === "struct") {
@@ -779,6 +775,7 @@ export abstract class MalloyTranslation {
           }
         }
       }
+      // else nothing, assuming there are already errors in the log
     }
     return exports;
   }

--- a/packages/malloy/src/lang/test/parse.spec.ts
+++ b/packages/malloy/src/lang/test/parse.spec.ts
@@ -1213,7 +1213,10 @@ describe("sql backdoor", () => {
       import "createModel.malloy"
       source: foo is malloyUsers
     `);
-    model.importZone.define("internal://test/createModel.malloy", createModel);
+    model.importZone.define(
+      "internal://test/langtests/createModel.malloy",
+      createModel
+    );
     const needReq = model.translate();
     expect(model).toBeErrorless();
     const needs = needReq?.sqlStructs;

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -169,7 +169,7 @@ class TestRoot extends MalloyElement implements NameSpace {
   }
 }
 
-const testURI = "internal://test/root";
+const testURI = "internal://test/langtests/root.malloy";
 export class TestTranslator extends MalloyTranslator {
   testRoot?: TestRoot;
   /*
@@ -232,7 +232,7 @@ export class TestTranslator extends MalloyTranslator {
   constructor(source: string, rootRule = "malloyDocument") {
     super(testURI);
     this.grammarRule = rootRule;
-    this.importZone.define("internal://test/root", source);
+    this.importZone.define(testURI, source);
     for (const tableName in mockSchema) {
       this.schemaZone.define(tableName, mockSchema[tableName]);
     }
@@ -354,7 +354,7 @@ export function markSource(
     };
     const bitLines = mark.split("\n");
     const location = {
-      url: "internal://test/root",
+      url: testURI,
       range: {
         start,
         end: {


### PR DESCRIPTION
1) make tests actually work
2) don't add an extra error when importing a file with errors