### PR TITLE
Add a Copy HTML to Clipboard button

### DIFF
--- a/packages/malloy-vscode/src/extension/webviews/assets/copy.svg
+++ b/packages/malloy-vscode/src/extension/webviews/assets/copy.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="110px" height="110px" viewBox="0 0 110 110" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Copy HTML to Clipboard</title>
+    <g id="item_duplicate" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Rectangle" stroke="#4285F4" class="primarystroke" stroke-width="6" x="29.4307692" y="24" width="30.0923077" height="41.7692308" rx="5"></rect>
+        <rect id="Rectangle-Copy" stroke="#4285F4" class="primarystroke" stroke-width="6" fill="none" x="47.4769231" y="45.2307692" width="30.0923077" height="41.7692308" rx="5"></rect>
+    </g>
+</svg>

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -55,12 +55,12 @@ export const App: React.FC = () => {
   const [error, setError] = useState<string | undefined>(undefined);
   const [warning, setWarning] = useState<string | undefined>(undefined);
   const [resultKind, setResultKind] = useState<ResultKind>(ResultKind.HTML);
-  const [drillTooltipVisible, setDrillTooltipVisible] = useState(false);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
   const [observer, setObserver] = useState<MutationObserver>();
-  const drillTooltipId = useRef(0);
+  const tooltipId = useRef(0);
   const { setTooltipRef, setTriggerRef, getTooltipProps } = usePopperTooltip({
-    visible: drillTooltipVisible,
+    visible: tooltipVisible,
     placement: "top",
   });
 
@@ -120,11 +120,11 @@ export const App: React.FC = () => {
                 onDrill: (drillQuery, target) => {
                   navigator.clipboard.writeText(drillQuery);
                   setTriggerRef(target);
-                  setDrillTooltipVisible(true);
-                  const currentDrillTooltipId = ++drillTooltipId.current;
+                  setTooltipVisible(true);
+                  const currentTooltipId = ++tooltipId.current;
                   setTimeout(() => {
-                    if (currentDrillTooltipId === drillTooltipId.current) {
-                      setDrillTooltipVisible(false);
+                    if (currentTooltipId === tooltipId.current) {
+                      setTooltipVisible(false);
                     }
                   }, 1000);
                 },
@@ -160,6 +160,21 @@ export const App: React.FC = () => {
     window.addEventListener("message", listener);
     return () => window.removeEventListener("message", listener);
   });
+
+  const copyHTMLTopClipboard = useCallback(
+    ({ target }: MouseEvent) => {
+      navigator.clipboard.writeText(getStyledHTML(html));
+      setTriggerRef(target as HTMLElement);
+      setTooltipVisible(true);
+      const currentTooltipId = ++tooltipId.current;
+      setTimeout(() => {
+        if (currentTooltipId === tooltipId.current) {
+          setTooltipVisible(false);
+        }
+      }, 1000);
+    },
+    [html]
+  );
 
   return (
     <div
@@ -199,9 +214,7 @@ export const App: React.FC = () => {
       {!error && resultKind === ResultKind.HTML && (
         <Scroll>
           <div style={{ margin: "10px" }}>
-            <CopyHTMLButton
-              onClick={() => navigator.clipboard.writeText(getStyledHTML(html))}
-            />
+            <CopyHTMLButton onClick={copyHTMLTopClipboard} />
             <DOMElement element={html} />
           </div>
         </Scroll>
@@ -225,10 +238,10 @@ export const App: React.FC = () => {
       )}
       {error && <Error multiline={error.includes("\n")}>{error}</Error>}
       {warning && <Warning>{warning}</Warning>}
-      {drillTooltipVisible && (
-        <DrillTooltip ref={setTooltipRef} {...getTooltipProps()}>
-          Drill copied!
-        </DrillTooltip>
+      {tooltipVisible && (
+        <Tooltip ref={setTooltipRef} {...getTooltipProps()}>
+          Copied!
+        </Tooltip>
       )}
     </div>
   );
@@ -350,7 +363,7 @@ const DOMElement: React.FC<{ element: HTMLElement }> = ({ element }) => {
   return <div ref={ref}></div>;
 };
 
-const DrillTooltip = styled.div`
+const Tooltip = styled.div`
   background-color: #505050;
   color: white;
   border-radius: 5px;

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -13,7 +13,13 @@
 
 import { Result } from "@malloydata/malloy";
 import { HTMLView } from "@malloydata/render";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  DOMElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import styled from "styled-components";
 import {
   QueryMessageType,
@@ -194,7 +200,7 @@ export const App: React.FC = () => {
         <Scroll>
           <div style={{ margin: "10px" }}>
             <CopyHTMLButton
-              onClick={() => navigator.clipboard.writeText(html.outerHTML)}
+              onClick={() => navigator.clipboard.writeText(getStyledHTML(html))}
             />
             <DOMElement element={html} />
           </div>
@@ -239,6 +245,40 @@ function getStatusLabel(status: Status) {
     case Status.Displaying:
       return "Displaying";
   }
+}
+
+function getStyledHTML(html: HTMLElement): string {
+  const resolveStyles = getComputedStyle(html);
+  const styles = `<style>
+  :root {
+    --malloy-font-family: ${resolveStyles.getPropertyValue(
+      "--malloy-font-family"
+    )};
+    --malloy-title-color: ${resolveStyles.getPropertyValue(
+      "--malloy-title-color"
+    )};
+    --malloy-label-color: ${resolveStyles.getPropertyValue(
+      "--malloy-label-color"
+    )};
+    --malloy-border-color: ${resolveStyles.getPropertyValue(
+      "--malloy-border-color"
+    )};
+    --malloy-tile-background-color: ${resolveStyles.getPropertyValue(
+      "--malloy-tile-background-color"
+    )};
+  }
+  body {
+    color: ${resolveStyles.getPropertyValue("--foreground")};
+    background: ${resolveStyles.getPropertyValue("--background")};
+    font-family: var(--malloy-font-family);
+    font-size: 11px;
+  }
+  table {
+    font-size: 11px;
+  }
+</style>
+`;
+  return styles + html.outerHTML;
 }
 
 interface PrismContainerProps {

--- a/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/App.tsx
@@ -28,6 +28,8 @@ import "prismjs/components/prism-sql";
 import { usePopperTooltip } from "react-popper-tooltip";
 import { useQueryVSCodeContext } from "./query_vscode_context";
 import { DownloadButton } from "./DownloadButton";
+import { CopyHTMLButton } from "./CopyHTMLButton";
+import { Scroll } from "./Scroll";
 
 enum Status {
   Ready = "ready",
@@ -191,6 +193,9 @@ export const App: React.FC = () => {
       {!error && resultKind === ResultKind.HTML && (
         <Scroll>
           <div style={{ margin: "10px" }}>
+            <CopyHTMLButton
+              onClick={() => navigator.clipboard.writeText(html.outerHTML)}
+            />
             <DOMElement element={html} />
           </div>
         </Scroll>
@@ -235,11 +240,6 @@ function getStatusLabel(status: Status) {
       return "Displaying";
   }
 }
-
-const Scroll = styled.div`
-  height: 100%;
-  overflow: auto;
-`;
 
 interface PrismContainerProps {
   darkMode: boolean;

--- a/packages/malloy-vscode/src/extension/webviews/query_page/CopyHTMLButton.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/CopyHTMLButton.tsx
@@ -30,7 +30,7 @@ import styled from "styled-components";
 import { Scroll } from "./Scroll";
 
 interface CopyHTMLButtonProps {
-  onClick: () => void;
+  onClick: (event: MouseEvent) => void;
 }
 
 export const CopyHTMLButton: React.FC<CopyHTMLButtonProps> = ({ onClick }) => {

--- a/packages/malloy-vscode/src/extension/webviews/query_page/CopyHTMLButton.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/CopyHTMLButton.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import React from "react";
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import DownloadIcon from "../assets/copy.svg";
+import styled from "styled-components";
+import { Scroll } from "./Scroll";
+
+interface CopyHTMLButtonProps {
+  onClick: () => void;
+}
+
+export const CopyHTMLButton: React.FC<CopyHTMLButtonProps> = ({ onClick }) => {
+  return <StyledDownloadIcon onClick={onClick} />;
+};
+
+const StyledDownloadIcon = styled(DownloadIcon)`
+  ${Scroll} & {
+    display: none;
+  }
+  ${Scroll}:hover & {
+    display: block;
+  }
+  width: 25px;
+  height: 25px;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  background: var(--background);
+  border: 1px solid var(--dropdown-border);
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 1;
+`;

--- a/packages/malloy-vscode/src/extension/webviews/query_page/Scroll.tsx
+++ b/packages/malloy-vscode/src/extension/webviews/query_page/Scroll.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import styled from "styled-components";
+
+export const Scroll = styled.div`
+  height: 100%;
+  overflow: auto;
+`;


### PR DESCRIPTION
Feature request from @lloydtabb - adds a copy to clipboard button for quick export.

<img alt="Screen Shot 2022-08-22 at 6 32 18 PM" src="https://user-images.githubusercontent.com/2958002/186048856-078bb6f9-64d4-4a6e-b48d-943a87aeb91a.png">

