### PR TITLE
Fix issue where FieldSpace was referenced instead of FSPair

### DIFF
--- a/packages/malloy/src/lang/ast/ast-time-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-time-expr.ts
@@ -320,7 +320,7 @@ export class GranularLiteral extends ExpressionDef {
 export class ExprNow extends ExpressionDef {
   elementType = "timestamp";
 
-  getExpression(_fs: FieldSpace): ExprValue {
+  getExpression(_fs: FSPair): ExprValue {
     return {
       dataType: "timestamp",
       aggregate: false,


### PR DESCRIPTION
Seems like https://github.com/looker-open-source/malloy/pull/759 missed one reference (perhaps it was added after that branch was checked and before it was merged)?