### PR TITLE
Syntax highlight (etc.) declare correctly

### DIFF
--- a/demo/malloy-demo-composer/src/app/malloyGrammar.ts
+++ b/demo/malloy-demo-composer/src/app/malloyGrammar.ts
@@ -316,6 +316,10 @@ export const MALLOY_GRAMMAR = {
           match: "(?i)\\bwhere\\b",
           name: "keyword.control.where",
         },
+        {
+          match: "(?i)\\bdeclare\\b",
+          name: "keyword.control.declare",
+        },
       ],
     },
     keywords: {

--- a/demo/malloy-duckdb-wasm/src/utils/malloyGrammar.ts
+++ b/demo/malloy-duckdb-wasm/src/utils/malloyGrammar.ts
@@ -316,6 +316,10 @@ export const MALLOY_GRAMMAR = {
           match: "(?i)\\bwhere\\b",
           name: "keyword.control.where",
         },
+        {
+          match: "(?i)\\bdeclare\\b",
+          name: "keyword.control.declare",
+        },
       ],
     },
     keywords: {

--- a/packages/malloy/src/lang/parse-tree-walkers/document-completion-walker.ts
+++ b/packages/malloy/src/lang/parse-tree-walkers/document-completion-walker.ts
@@ -34,6 +34,7 @@ const EXPLORE_PROPERTIES = [
   "accept",
   "except",
   "query",
+  "declare",
 ];
 
 const QUERY_PROPERTIES = [
@@ -47,6 +48,7 @@ const QUERY_PROPERTIES = [
   "where",
   "having",
   "nest",
+  "declare",
 ];
 
 const MODEL_PROPERTIES = ["source", "explore", "query", "sql"];

--- a/vscode-extension/malloy.tmGrammar.json
+++ b/vscode-extension/malloy.tmGrammar.json
@@ -308,6 +308,10 @@
         {
           "match": "(?i)\\bwhere\\b",
           "name": "keyword.control.where"
+        },
+        {
+          "match": "(?i)\\bdeclare\\b",
+          "name": "keyword.control.declare"
         }
       ]
     },

--- a/vscode-extension/src/server/completions/completion_docs.ts
+++ b/vscode-extension/src/server/completions/completion_docs.ts
@@ -176,6 +176,22 @@ query: flights -> {
 View [the full documentation](${DOCS_ROOT}/language/nesting.html).
 `;
 
+const QUERY_DECLARE_DOC = `Use \`declare\` to introduce new reusable dimensions and measures within a query.
+
+\`\`\`malloy
+query: flights -> {
+  declare: flight_count is count()
+  aggregate: flight_count
+  nest: by_carrier is {
+    group_by: carrier
+    aggregate: flight_count
+  }
+}
+\`\`\`
+
+Note: \`declare\` is an experimental feature.
+`;
+
 const SOURCE_DIMENSION_DOC = `Use \`dimension\` to define a non-aggregate calculation.
 
 \`\`\`malloy
@@ -295,6 +311,19 @@ source: airports is table('malloy-data.faa.airports') {
 View [the full documentation](${DOCS_ROOT}/language/explore.html#limiting-access-to-fields).
 `;
 
+const SOURCE_DECLARE_DOC = `Use \`declare\` to declare either dimensions or measures.
+
+\`\`\`malloy
+source: flights is table('malloy-data.faa.flights') {
+  declare:
+    flight_count is count()
+    distance_km is distance * 1.609
+}
+\`\`\`
+
+Note: \`declare\` is an experimental feature.
+`;
+
 export const COMPLETION_DOCS: {
   [kind: string]: { [property: string]: string };
 } = {
@@ -314,6 +343,7 @@ export const COMPLETION_DOCS: {
     where: QUERY_WHERE_DOC,
     having: QUERY_HAVING_DOC,
     nest: QUERY_NEST_DOC,
+    declare: QUERY_DECLARE_DOC,
   },
   explore_property: {
     dimension: SOURCE_DIMENSION_DOC,
@@ -327,5 +357,6 @@ export const COMPLETION_DOCS: {
     rename: SOURCE_RENAME_DOC,
     accept: SOURCE_ACCEPT_DOC,
     except: SOURCE_EXCEPT_DOC,
+    declare: SOURCE_DECLARE_DOC,
   },
 };


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/706

In docs:
<img width="985" alt="Screen Shot 2022-09-29 at 10 35 30 AM" src="https://user-images.githubusercontent.com/3538955/193076109-bb09d9de-74db-4cca-9157-d1f4f43a2dcd.png">

In VSCode as a source property:
<img width="653" alt="Screen Shot 2022-09-29 at 10 35 53 AM" src="https://user-images.githubusercontent.com/3538955/193076146-ca29ac98-7e69-4c67-bbff-680072654cd2.png">

In VSCode as a query property:
<img width="723" alt="Screen Shot 2022-09-29 at 10 36 14 AM" src="https://user-images.githubusercontent.com/3538955/193076178-f24abcad-63e1-49b5-a69f-a7c4205b28c9.png">

In the DuckDB WASM demo:
<img width="498" alt="Screen Shot 2022-09-29 at 10 40 48 AM" src="https://user-images.githubusercontent.com/3538955/193076646-e2c42723-8680-4500-a090-f41d587edca8.png">
