### PR TITLE
Fix interval extraction for Postgres and DuckDB

### DIFF
--- a/docs/_src/language/expressions.md
+++ b/docs/_src/language/expressions.md
@@ -230,7 +230,7 @@ one of the below extraction functions. This is Malloy's take on SQL's <code>DATE
 
 expression | meaning
 ---- | ----
-`seconds(t1 to t2)` | Number of seconds from t1 until t2
+`seconds(t1 to t2)` | Number of seconds from `t1` until `t2`
 `minutes(t1 to t2)` | ... minutes ...
 `hours(t1 to t2)` | ... hours ...
 `days(t1 to t2)` | ... days ...
@@ -239,7 +239,11 @@ expression | meaning
 `quarters(t1 to t2)` | ... quarters ...
 `years(t1 to t2)` | ... years ...
 
-These will return a negative number if t1 is later than t2.
+These will return a negative number if `t1` is later than `t2`.
+
+For `seconds`, `minutes`, and `hours`, the returned values is the number of complete seconds/minutes/hours beween the two values. For example, `hours(@2022-10-03 10:30:00 to @2022-10-03 11:29:00)` would return 0, because the range spans only 59 minutes, despite crossing over the hour boundry from 10 to 11. Likewise, `minutes(now to now + 59 seconds)` will always return 0, regardless of what time it is.
+
+For `days`, `weeks`, `months`, `quarters`, and `years`, the returned value is the number of day/week/month/quarter/year boundaries crossed between the two dates. For example, `days(@2022-10-03 11:59 to @2022-10-04 00:00)` is 1, because the end time is on the day after the start time, even though only one minute passed between them. So `weeks(now to now + 6 days)` will return either 0 or 1 depending on the day of the week.
 
 ### Time Literals
 

--- a/packages/malloy/src/dialect/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb.ts
@@ -127,8 +127,6 @@ const inSeconds: Record<string, number> = {
   second: 1,
   minute: 60,
   hour: 3600,
-  day: 86400,
-  week: 604800,
 };
 
 export class DuckDBDialect extends Dialect {
@@ -314,21 +312,20 @@ export class DuckDBDialect extends Dialect {
       const duration = mkExpr`(${rVal} - ${lVal})`;
       return units == "second"
         ? duration
-        : mkExpr`TRUNC(${duration}/${inSeconds[units].toString()})`;
+        : mkExpr`FLOOR(${duration}/${inSeconds[units].toString()})`;
     }
-    const yearDiff = mkExpr`TRUNC(EXTRACT(YEAR FROM ${rVal}) - EXTRACT(YEAR FROM ${lVal}))`;
-    if (units == "year") {
-      return yearDiff;
+    if (from.valueType != "date") {
+      lVal = mkExpr`CAST((${lVal}) AS DATE)`;
     }
-    if (units == "month") {
-      const monthDiff = mkExpr`TRUNC(EXTRACT(MONTH FROM ${rVal}) - EXTRACT(MONTH FROM ${lVal}))`;
-      return mkExpr`${yearDiff} * 12 + ${monthDiff}`;
+    if (to.valueType != "date") {
+      rVal = mkExpr`CAST((${rVal}) AS DATE)`;
     }
-    if (units == "quarter") {
-      const qDiff = mkExpr`TRUNC(EXTRACT(QUARTER FROM ${rVal}) - EXTRACT(QUARTER FROM ${lVal}))`;
-      return mkExpr`${yearDiff} * 4 + ${qDiff}`;
+    if (units == "week") {
+      // DuckDB's weeks start on Monday, but Malloy's weeks start on Sunday
+      lVal = mkExpr`(${lVal} + INTERVAL 1 DAY)`;
+      rVal = mkExpr`(${rVal} + INTERVAL 1 DAY)`;
     }
-    throw new Error(`Unknown or unhandled postgres time unit: ${units}`);
+    return mkExpr`DATE_DIFF('${units}', ${lVal}, ${rVal})`;
   }
 
   sqlNow(): Expr {
@@ -339,10 +336,10 @@ export class DuckDBDialect extends Dialect {
     // adjusting for monday/sunday weeks
     const week = units == "week";
     const truncThis = week
-      ? mkExpr`${sqlTime.value}+interval'1'day`
+      ? mkExpr`${sqlTime.value} + INTERVAL 1 DAY`
       : sqlTime.value;
     const trunced = mkExpr`DATE_TRUNC('${units}', ${truncThis})`;
-    return week ? mkExpr`(${trunced}-interval'1'day)` : trunced;
+    return week ? mkExpr`(${trunced} - INTERVAL 1 DAY)` : trunced;
   }
 
   sqlExtract(from: TimeValue, units: ExtractUnit): Expr {
@@ -357,16 +354,22 @@ export class DuckDBDialect extends Dialect {
     n: Expr,
     timeframe: DateUnit
   ): Expr {
+    let repeat = 1;
     if (timeframe == "quarter") {
       timeframe = "month";
-      n = mkExpr`${n}*3`;
+      repeat = 3;
     }
     if (timeframe == "week") {
       timeframe = "day";
-      n = mkExpr`${n}*7`;
+      repeat = 7;
     }
     const interval = mkExpr`INTERVAL ${n} ${timeframe}`;
-    return mkExpr`((${expr.value})${op}${interval})`;
+    const opInterval = mkExpr`${op} ${interval}`;
+    const repeatedOpInterval = Array.from(
+      { length: opInterval.length * repeat },
+      (_, i) => opInterval[i % opInterval.length]
+    );
+    return mkExpr`((${expr.value}))${repeatedOpInterval}`;
   }
 
   sqlCast(cast: TypecastFragment): Expr {
@@ -387,7 +390,7 @@ export class DuckDBDialect extends Dialect {
     _timezone: string
   ): string {
     if (type == "date") {
-      return `DATE('${timeString}')`;
+      return `DATE '${timeString}'`;
     } else if (type == "timestamp") {
       return `TIMESTAMP '${timeString}'`;
     } else {

--- a/packages/malloy/src/dialect/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb.ts
@@ -354,22 +354,16 @@ export class DuckDBDialect extends Dialect {
     n: Expr,
     timeframe: DateUnit
   ): Expr {
-    let repeat = 1;
     if (timeframe == "quarter") {
       timeframe = "month";
-      repeat = 3;
+      n = mkExpr`${n}*3`;
     }
     if (timeframe == "week") {
       timeframe = "day";
-      repeat = 7;
+      n = mkExpr`${n}*7`;
     }
-    const interval = mkExpr`INTERVAL ${n} ${timeframe}`;
-    const opInterval = mkExpr`${op} ${interval}`;
-    const repeatedOpInterval = Array.from(
-      { length: opInterval.length * repeat },
-      (_, i) => opInterval[i % opInterval.length]
-    );
-    return mkExpr`((${expr.value}))${repeatedOpInterval}`;
+    const interval = mkExpr`INTERVAL (${n}) ${timeframe}`;
+    return mkExpr`((${expr.value})) ${op} ${interval}`;
   }
 
   sqlCast(cast: TypecastFragment): Expr {

--- a/packages/malloy/src/dialect/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb.ts
@@ -354,22 +354,8 @@ export class DuckDBDialect extends Dialect {
     n: Expr,
     timeframe: DateUnit
   ): Expr {
-    let repeat = 1;
-    if (timeframe == "quarter") {
-      timeframe = "month";
-      repeat = 3;
-    }
-    if (timeframe == "week") {
-      timeframe = "day";
-      repeat = 7;
-    }
     const interval = mkExpr`INTERVAL ${n} ${timeframe}`;
-    const opInterval = mkExpr`${op} ${interval}`;
-    const repeatedOpInterval = Array.from(
-      { length: opInterval.length * repeat },
-      (_, i) => opInterval[i % opInterval.length]
-    );
-    return mkExpr`((${expr.value}))${repeatedOpInterval}`;
+    return mkExpr`((${expr.value}))${op} ${interval}`;
   }
 
   sqlCast(cast: TypecastFragment): Expr {

--- a/packages/malloy/src/dialect/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb.ts
@@ -354,8 +354,22 @@ export class DuckDBDialect extends Dialect {
     n: Expr,
     timeframe: DateUnit
   ): Expr {
+    let repeat = 1;
+    if (timeframe == "quarter") {
+      timeframe = "month";
+      repeat = 3;
+    }
+    if (timeframe == "week") {
+      timeframe = "day";
+      repeat = 7;
+    }
     const interval = mkExpr`INTERVAL ${n} ${timeframe}`;
-    return mkExpr`((${expr.value}))${op} ${interval}`;
+    const opInterval = mkExpr`${op} ${interval}`;
+    const repeatedOpInterval = Array.from(
+      { length: opInterval.length * repeat },
+      (_, i) => opInterval[i % opInterval.length]
+    );
+    return mkExpr`((${expr.value}))${repeatedOpInterval}`;
   }
 
   sqlCast(cast: TypecastFragment): Expr {

--- a/test/src/databases/all/expr.spec.ts
+++ b/test/src/databases/all/expr.spec.ts
@@ -617,6 +617,103 @@ runtimes.runtimeMap.forEach((runtime, databaseName) => {
       expect(result).isSqlEq();
     });
   });
+
+  describe(`interval extraction - ${databaseName}`, () => {
+    const sqlEq = mkSqlEqWith(runtime);
+
+    test("seconds", async () => {
+      expect(await sqlEq("seconds(now to now + 1 second)", 1)).isSqlEq();
+      expect(await sqlEq("seconds(now to now)", 0)).isSqlEq();
+      expect(await sqlEq("seconds(now to now + 2 seconds)", 2)).isSqlEq();
+      expect(await sqlEq("seconds(now to now - 2 seconds)", -2)).isSqlEq();
+    });
+
+    test("minutes", async () => {
+      expect(
+        await sqlEq("minutes(@2022-10-03 10:23:08 to @2022-10-03 10:24:07)", 0)
+      ).isSqlEq();
+
+      expect(await sqlEq("minutes(now to now + 1 minute)", 1)).isSqlEq();
+      expect(await sqlEq("minutes(now to now + 59 seconds)", 0)).isSqlEq();
+      expect(await sqlEq("minutes(now to now + 2 minutes)", 2)).isSqlEq();
+      expect(await sqlEq("minutes(now to now - 2 minutes)", -2)).isSqlEq();
+    });
+
+    test("hours", async () => {
+      expect(
+        await sqlEq("hours(@2022-10-03 10:23:00 to @2022-10-03 11:22:00)", 0)
+      ).isSqlEq();
+      expect(await sqlEq("hours(now to now + 1 hour)", 1)).isSqlEq();
+      expect(await sqlEq("hours(now to now + 59 minutes)", 0)).isSqlEq();
+      expect(await sqlEq("hours(now to now + 120 minutes)", 2)).isSqlEq();
+      expect(await sqlEq("hours(now to now - 2 hours)", -2)).isSqlEq();
+    });
+
+    test("days", async () => {
+      expect(await sqlEq("days(now.day to now.day + 1 day)", 1)).isSqlEq();
+      expect(await sqlEq("days(now.day to now.day + 23 hours)", 0)).isSqlEq();
+      expect(await sqlEq("days(now.day to now.day + 48 hours)", 2)).isSqlEq();
+      expect(await sqlEq("days(now.day to now.day - 48 hours)", -2)).isSqlEq();
+
+      expect(
+        await sqlEq("days(@2022-10-03 10:23:00 to @2022-10-04 09:23:00)", 1)
+      ).isSqlEq();
+    });
+
+    test("weeks", async () => {
+      expect(await sqlEq("weeks(now.week to now.week + 1 week)", 1)).isSqlEq();
+      expect(await sqlEq("weeks(now.week to now.week + 6 days)", 0)).isSqlEq();
+      expect(await sqlEq("weeks(now.week to now.week + 14 days)", 2)).isSqlEq();
+      expect(
+        await sqlEq("weeks(now.week to now.week - 14 days)", -2)
+      ).isSqlEq();
+      expect(await sqlEq("weeks(@2022-10-03 to @2022-10-10)", 1)).isSqlEq();
+      expect(await sqlEq("weeks(@2022-10-03 to @2022-10-09)", 1)).isSqlEq();
+      expect(await sqlEq("weeks(@2022-10-02 to @2022-10-08)", 0)).isSqlEq();
+      expect(await sqlEq("weeks(@2022-10-02 to @2023-10-02)", 52)).isSqlEq();
+
+      expect(
+        await sqlEq("weeks(@2022-10-02 10:00 to @2023-10-02 10:00)", 52)
+      ).isSqlEq();
+    });
+
+    test("months", async () => {
+      expect(await sqlEq("months(now to now + 1 month)", 1)).isSqlEq();
+      expect(
+        await sqlEq("months(now.month to now.month + 27 days)", 0)
+      ).isSqlEq();
+      expect(await sqlEq("months(now to now + 2 months)", 2)).isSqlEq();
+      expect(await sqlEq("months(now to now - 2 months)", -2)).isSqlEq();
+
+      expect(
+        await sqlEq("months(@2022-10-02 10:00 to @2022-11-02 09:00)", 1)
+      ).isSqlEq();
+    });
+
+    test("quarters", async () => {
+      expect(await sqlEq("quarters(@2022-03-31 to @2022-04-01)", 1)).isSqlEq();
+      expect(await sqlEq("quarters(now to now + 1 quarter)", 1)).isSqlEq();
+      expect(
+        await sqlEq("quarters(now.quarter to now.quarter + 27 days)", 0)
+      ).isSqlEq();
+      expect(await sqlEq("quarters(now to now + 2 quarters)", 2)).isSqlEq();
+      expect(await sqlEq("quarters(now to now - 2 quarters)", -2)).isSqlEq();
+
+      expect(
+        await sqlEq("quarters(@2022-10-02 10:00 to @2023-04-02 09:00)", 2)
+      ).isSqlEq();
+    });
+
+    test("years", async () => {
+      expect(await sqlEq("years(@2022 to @2023)", 1)).isSqlEq();
+      expect(await sqlEq("years(@2022-01-01 to @2022-12-31)", 0)).isSqlEq();
+      expect(await sqlEq("years(@2022 to @2024)", 2)).isSqlEq();
+      expect(await sqlEq("years(@2024 to @2022)", -2)).isSqlEq();
+      expect(
+        await sqlEq("years(@2022-01-01 10:00 to @2024-01-01 09:00)", 2)
+      ).isSqlEq();
+    });
+  });
 });
 
 afterAll(async () => {

--- a/test/src/util/index.ts
+++ b/test/src/util/index.ts
@@ -77,7 +77,7 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   return async function (
     expr: string,
-    result: string | boolean
+    result: string | boolean | number
   ): Promise<Result> {
     const qExpr = expr.replace(/'/g, "`");
     const sqlV = initV?.sql || "SELECT 1 as one";
@@ -99,6 +99,17 @@ export function mkSqlEqWith(runtime: Runtime, initV?: InitValues) {
           -> { project: ${varName} is ${expr} }
           -> {
             project: calc is pick ${whenPick} else ${elsePick}
+          }`;
+    } else if (typeof result === "number") {
+      query = `${sourceDef}
+          query: basicTypes
+          -> {
+            project: expect is ${result}
+            project: got is ${expr}
+          } -> {
+            project: calc is
+              pick '=' when expect = got
+              else concat('sqlEq failed', CHR(10), '    Expected: ${qExpr} == ${result}', CHR(10), '    Received: ', got::string)
           }`;
     } else {
       const qResult = result.replace(/'/g, "`");


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/801

Initial task was to fix https://github.com/looker-open-source/malloy/issues/801, which was that `TRUNC` was used in DuckDB where `FLOOR` was intended (this was a copypasta when interval extraction was initially implemented).

Doing so revealed several other problems.

1. Date literals didn't work in DuckDB

```
query: stuff -> {
  group_by: thing is @2020-01-01
}
```

```
Catalog Error: Scalar Function with name date does not exist!
Did you mean "day"?
LINE 2:    DATE('2020-01-01') as "thing"
           ^
```

We were just using the wrong syntax for creating a date from a literal.

2. Adding durations in week or quarter units didn't work in DuckDB

```
query: stuff -> {
  group_by: thing is now + 1 week
}
```
```
Parser Error: syntax error at or near "day"
LINE 2:    ((CURRENT_TIMESTAMP)+INTERVAL 1*7 day) as "thing"
```

It seems like you can't use expressions in the `INTERVAL N DAY` syntax, which we were doing I think because documentation wasn't clear whether you could use `WEEK` and `QUARTER` as units there. ~~It seems you can.~~ I guess you cannot. Back to my hacky solution: `time + INTERVAL N DAY + INTERVAL N DAY + INTERVAL N DAY + INTERVAL N DAY + INTERVAL N DAY + INTERVAL N DAY + INTERVAL N DAY`...

3. Week and day interval extraction in Postgres and DuckDB did not match BigQuery behavior

In BigQuery, `days(@2022-10-03 11:59 to @2022-10-04 00:00)` would be 1, whereas in Postgres and DuckDB, it would be 0 (because 24 hours had not elapsed).

I've updated the DuckDB and Postgres implementations to match the BigQuery behavior and added some more notes to the documentation describing the desired functionality.

I also wrote some tests for the interval extraction, which also expose the other two issues.