### PR TITLE
StructSource with type "table" must have a tablePath

### DIFF
--- a/demo/malloy-demo-composer/src/core/query.ts
+++ b/demo/malloy-demo-composer/src/core/query.ts
@@ -80,18 +80,7 @@ class SourceUtils {
     stage: PipeSegment,
     source: StructDef
   ): StructDef {
-    try {
-      return QuerySegment.nextStructDef(source, stage);
-    } catch (error) {
-      return {
-        name: "pipe_stage",
-        type: "struct",
-        fields: [],
-        structSource: { type: "table" },
-        structRelationship: { type: "basetable", connectionName: "foo" },
-        dialect: source.dialect,
-      };
-    }
+    return QuerySegment.nextStructDef(source, stage);
   }
 }
 

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -36,7 +36,7 @@ import {
   QueryDataRow,
   toAsyncGenerator,
 } from "@malloydata/malloy";
-import { parseTableURL } from "@malloydata/malloy";
+import { parseTableURI } from "@malloydata/malloy";
 import { PooledConnection } from "@malloydata/malloy";
 import {
   FetchSchemaAndRunSimultaneously,
@@ -327,7 +327,7 @@ export class BigQueryConnection
   }
 
   public async getTableFieldSchema(tableURL: string): Promise<SchemaInfo> {
-    const { tablePath: tableName } = parseTableURL(tableURL);
+    const { tablePath: tableName } = parseTableURI(tableURL);
     const segments = tableName.split(".");
 
     // paths can have two or three segments
@@ -532,7 +532,7 @@ export class BigQueryConnection
   }
 
   private tableURLtoTablePath(tableURL: string): string {
-    const { tablePath } = parseTableURL(tableURL);
+    const { tablePath } = parseTableURI(tableURL);
     if (tablePath.split(".").length === 2) {
       return `${this.defaultProject}.${tablePath}`;
     } else {

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -291,14 +291,11 @@ export abstract class DuckDBCommon
 
   private async getTableSchema(tableURL: string): Promise<StructDef> {
     const { tablePath } = parseTableURI(tableURL);
-    const quotedTablePath = tablePath.match(/\//)
-      ? `'${tablePath}'`
-      : tablePath;
     const structDef: StructDef = {
       type: "struct",
       name: tablePath,
       dialect: "duckdb",
-      structSource: { type: "table", tablePath: quotedTablePath },
+      structSource: { type: "table", tablePath },
       structRelationship: {
         type: "basetable",
         connectionName: this.name,
@@ -306,6 +303,9 @@ export abstract class DuckDBCommon
       fields: [],
     };
 
+    const quotedTablePath = tablePath.match(/\//)
+      ? `'${tablePath}'`
+      : tablePath;
     const infoQuery = `DESCRIBE SELECT * FROM ${quotedTablePath}`;
     await this.schemaFromQuery(infoQuery, structDef);
     return structDef;

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -15,7 +15,7 @@ import {
   Connection,
   MalloyQueryData,
   NamedStructDefs,
-  parseTableURL,
+  parseTableURI,
   PersistSQLResults,
   FieldTypeDef,
   PooledConnection,
@@ -290,12 +290,15 @@ export abstract class DuckDBCommon
   }
 
   private async getTableSchema(tableURL: string): Promise<StructDef> {
-    const { tablePath: tableName } = parseTableURL(tableURL);
+    const { tablePath } = parseTableURI(tableURL);
+    const quotedTablePath = tablePath.match(/\//)
+      ? `'${tablePath}'`
+      : tablePath;
     const structDef: StructDef = {
       type: "struct",
-      name: tableName,
+      name: tablePath,
       dialect: "duckdb",
-      structSource: { type: "table" },
+      structSource: { type: "table", tablePath: quotedTablePath },
       structRelationship: {
         type: "basetable",
         connectionName: this.name,
@@ -303,20 +306,7 @@ export abstract class DuckDBCommon
       fields: [],
     };
 
-    // const { tablePath: tableName } = parseTableURL(tableURL);
-    // const [schema, table] = tableName.split(".");
-    // if (table === undefined) {
-    //   throw new Error("Default schema not yet supported in DuckDB");
-    // }
-    // const infoQuery = `
-    //   SELECT column_name, data_type FROM information_schema.columns
-    //   WHERE table_name = '${table}'
-    //     AND table_schema = '${schema}'
-    // `;
-
-    const infoQuery = `DESCRIBE SELECT * FROM ${
-      tableName.match(/\//) ? `'${tableName}'` : tableName
-    };`;
+    const infoQuery = `DESCRIBE SELECT * FROM ${quotedTablePath}`;
     await this.schemaFromQuery(infoQuery, structDef);
     return structDef;
   }

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -25,7 +25,7 @@ import {
   AtomicFieldTypeInner,
   QueryData,
   PooledConnection,
-  parseTableURL,
+  parseTableURI,
   SQLBlock,
   Connection,
   QueryDataRow,
@@ -323,20 +323,19 @@ export class PostgresConnection
   }
 
   private async getTableSchema(tableURL: string): Promise<StructDef> {
+    const { tablePath } = parseTableURI(tableURL);
     const structDef: StructDef = {
       type: "struct",
       name: tableURL,
       dialect: "postgres",
-      structSource: { type: "table" },
+      structSource: { type: "table", tablePath },
       structRelationship: {
         type: "basetable",
         connectionName: this.name,
       },
       fields: [],
     };
-
-    const { tablePath: tableName } = parseTableURL(tableURL);
-    const [schema, table] = tableName.split(".");
+    const [schema, table] = tablePath.split(".");
     if (table === undefined) {
       throw new Error("Default schema not yet supported in Postgres");
     }

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -70,7 +70,7 @@ export {
   DateTimeframe,
   TimestampTimeframe,
   Result,
-  parseTableURL,
+  parseTableURI,
   QueryMaterializer,
   CSVWriter,
   JSONWriter,

--- a/packages/malloy/src/lang/ast/ast-expr.ts
+++ b/packages/malloy/src/lang/ast/ast-expr.ts
@@ -129,20 +129,10 @@ class DollarReference extends ExpressionDef {
 class ConstantFieldSpace implements FieldSpace {
   readonly type = "fieldSpace";
   structDef(): StructDef {
-    return {
-      type: "struct",
-      name: "empty structdef",
-      structSource: { type: "table" },
-      structRelationship: {
-        type: "basetable",
-        connectionName: "noConnection",
-      },
-      fields: [],
-      dialect: "noDialect",
-    };
+    throw new Error("ConstantFieldSpace cannot generate a structDef");
   }
   emptyStructDef(): StructDef {
-    return { ...this.structDef(), fields: [] };
+    throw new Error("ConstantFieldSpace cannot generate a structDef");
   }
   lookup(_name: unknown): LookupResult {
     return {

--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -46,7 +46,7 @@ const theErrorStruct: model.StructDef = {
   type: "struct",
   name: "~malformed~",
   dialect: "~malformed~",
-  structSource: { type: "table" },
+  structSource: { type: "table", tablePath: "//undefined_error_table_path" },
   structRelationship: {
     type: "basetable",
     connectionName: "//undefined_error_connection",

--- a/packages/malloy/src/lang/test/field-symbols.spec.ts
+++ b/packages/malloy/src/lang/test/field-symbols.spec.ts
@@ -31,7 +31,7 @@ describe("structdef comprehension", () => {
       type: "struct",
       name: "test",
       dialect: "standardsql",
-      structSource: { type: "table" },
+      structSource: { type: "table", tablePath: "test" },
       structRelationship: { type: "basetable", connectionName: "test" },
       fields: [field],
     };
@@ -140,7 +140,7 @@ describe("structdef comprehension", () => {
           { type: "field", path: "t.a" },
         ],
       },
-      structSource: { type: "table" },
+      structSource: { type: "table", tablePath: "t" },
       fields: [{ type: "string", name: "a" }],
     };
     const struct = mkStructDef(field);

--- a/packages/malloy/src/lang/test/test-translator.ts
+++ b/packages/malloy/src/lang/test/test-translator.ts
@@ -37,7 +37,7 @@ const mockSchema: Record<string, StructDef> = {
     type: "struct",
     name: "aTable",
     dialect: "standardsql",
-    structSource: { type: "table" },
+    structSource: { type: "table", tablePath: "aTable" },
     structRelationship: { type: "basetable", connectionName: "test" },
     fields: [
       { type: "string", name: "astr" },

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -212,7 +212,7 @@ export class Malloy {
             Array<string>
           > = new Map();
           for (const connectionTableString of result.tables) {
-            const { connectionName } = parseTableURL(connectionTableString);
+            const { connectionName } = parseTableURI(connectionTableString);
 
             let connectionToTablesMap = tablesByConnection.get(connectionName);
             if (!connectionToTablesMap) {
@@ -257,6 +257,9 @@ export class Malloy {
           > = new Map();
           for (const missingSQLSchemaRef of result.sqlStructs) {
             const connectionName = missingSQLSchemaRef.connection;
+            // if (connectionName === undefined) {
+            //   throw new Error("Oops have not made it required here yet...");
+            // }
 
             let connectionToSQLReferencesMap =
               sqlRefsByConnection.get(connectionName);
@@ -736,11 +739,11 @@ export class PreparedQuery {
   }
 }
 
-export function parseTableURL(tableURL: string): {
+export function parseTableURI(tableURI: string): {
   connectionName?: string;
   tablePath: string;
 } {
-  const [firstPart, secondPart] = tableURL.split(":");
+  const [firstPart, secondPart] = tableURI.split(":");
   if (secondPart) {
     return { connectionName: firstPart, tablePath: secondPart };
   } else {

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -63,7 +63,6 @@ import {
 } from "./malloy_types";
 
 import { indent, AndChain } from "./utils";
-import { parseTableURL } from "../malloy";
 import md5 from "md5";
 import { ResultStructMetadataDef, SearchIndexResult } from ".";
 import { Connection } from "..";
@@ -2133,8 +2132,7 @@ class QueryQuery extends QueryField {
         type: "basetable",
         connectionName: this.parent.connectionName,
       },
-      // structSource: {type: 'query', query: this.fieldDef}
-      structSource: { type: "table" },
+      structSource: { type: "query_result" },
       resultMetadata: this.getResultMetadata(this.rootResult),
       type: "struct",
     };
@@ -3205,7 +3203,7 @@ FROM ${resultStage}\n`
         type: "basetable",
         connectionName: this.parent.connectionName,
       },
-      structSource: { type: "table" },
+      structSource: { type: "query_result" },
     };
   }
 }
@@ -3550,9 +3548,7 @@ class QueryStruct extends QueryNode {
   structSourceSQL(stageWriter: StageWriter): string {
     switch (this.fieldDef.structSource.type) {
       case "table": {
-        const { tablePath } = parseTableURL(
-          this.fieldDef.structSource.tablePath || this.fieldDef.name
-        );
+        const tablePath = this.fieldDef.structSource.tablePath;
         return this.dialect.quoteTablePath(tablePath);
       }
       case "sql":

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -624,11 +624,12 @@ interface SubquerySource {
 
 /** where does the struct come from? */
 export type StructSource =
-  | { type: "table"; tablePath?: string }
+  | { type: "table"; tablePath: string }
   | { type: "nested" }
   | { type: "inline" }
   | { type: "query"; query: Query }
   | { type: "sql"; method: "nested" | "lastStage" }
+  | { type: "query_result" }
   | SubquerySource;
 
 // Inline and nested tables, cannot have a StructRelationship

--- a/test/src/databases/bigquery/handexpr.spec.ts
+++ b/test/src/databases/bigquery/handexpr.spec.ts
@@ -74,7 +74,10 @@ describe("BigQuery hand-built expression test", () => {
     as: "aircraft_models",
     type: "struct",
     dialect: "standardsql",
-    structSource: { type: "table" },
+    structSource: {
+      type: "table",
+      tablePath: "malloy-data.malloytest.aircraft_models",
+    },
     structRelationship: { type: "basetable", connectionName: "bigquery" },
     fields: [
       { type: "string", name: "aircraft_model_code" },
@@ -171,7 +174,10 @@ describe("BigQuery hand-built expression test", () => {
     type: "struct",
     name: "malloy-data.malloytest.aircraft",
     dialect: "standardsql",
-    structSource: { type: "table" },
+    structSource: {
+      type: "table",
+      tablePath: "malloy-data.malloytest.aircraft",
+    },
     structRelationship: { type: "basetable", connectionName: "bigquery" },
     fields: [
       { type: "string", name: "tail_num" },

--- a/test/src/databases/bigquery/malloy_query.spec.ts
+++ b/test/src/databases/bigquery/malloy_query.spec.ts
@@ -636,7 +636,10 @@ describe("BigQuery expression tests", () => {
           dialect: "standardsql",
           as: "mtest",
           structRelationship: { type: "basetable", connectionName: "bigquery" },
-          structSource: { type: "table" },
+          structSource: {
+            type: "table",
+            tablePath: "malloy-data.malloytest.bq_medicare_test",
+          },
           fields: [
             {
               type: "number",

--- a/test/src/models/faa_model.ts
+++ b/test/src/models/faa_model.ts
@@ -33,7 +33,7 @@ export const FLIGHTS_EXPLORE: StructDef = {
   name: "malloy-data.malloytest.flights",
   as: "flights",
   dialect: "standardsql",
-  structSource: { type: "table" },
+  structSource: { type: "table", tablePath: "malloy-data.malloytest.flights" },
   structRelationship: { type: "basetable", connectionName: "bigquery" },
   primaryKey: "id2",
   fields: [
@@ -78,7 +78,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       name: "malloy-data.malloytest.carriers",
       as: "carriers",
       dialect: "standardsql",
-      structSource: { type: "table" },
+      structSource: {
+        type: "table",
+        tablePath: "malloy-data.malloytest.carriers",
+      },
       structRelationship: {
         type: "one",
         onExpression: [
@@ -101,7 +104,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       name: "malloy-data.malloytest.aircraft",
       as: "aircraft",
       dialect: "standardsql",
-      structSource: { type: "table" },
+      structSource: {
+        type: "table",
+        tablePath: "malloy-data.malloytest.aircraft",
+      },
       structRelationship: withJoin("tail_num", "aircraft.tail_num"),
       primaryKey: "tail_num",
       fields: [
@@ -156,7 +162,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
           as: "aircraft_models",
           dialect: "standardsql",
           primaryKey: "aircraft_model_code",
-          structSource: { type: "table" },
+          structSource: {
+            type: "table",
+            tablePath: "malloy-data.malloytest.aircraft_models",
+          },
           structRelationship: withJoin(
             "aircraft_model_code",
             "aircraft_models.aircraft_model_code"
@@ -204,7 +213,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       name: "malloy-data.malloytest.airports",
       as: "origin",
       dialect: "standardsql",
-      structSource: { type: "table" },
+      structSource: {
+        type: "table",
+        tablePath: "malloy-data.malloytest.airports",
+      },
       structRelationship: withJoin("origin_code", "origin.code"),
       primaryKey: "code",
       fields: [
@@ -250,7 +262,10 @@ export const FLIGHTS_EXPLORE: StructDef = {
       name: "malloy-data.malloytest.airports",
       as: "destination",
       dialect: "standardsql",
-      structSource: { type: "table" },
+      structSource: {
+        type: "table",
+        tablePath: "malloy-data.malloytest.airports",
+      },
       structRelationship: withJoin("destination_code", "destination.code"),
       primaryKey: "code",
       fields: [
@@ -829,7 +844,7 @@ const tableAirports: StructDef = {
   name: "malloy-data.malloytest.airports",
   as: "table_airports",
   dialect: "standardsql",
-  structSource: { type: "table" },
+  structSource: { type: "table", tablePath: "malloy-data.malloytest.airports" },
   structRelationship: { type: "basetable", connectionName: "bigquery" },
   primaryKey: "code",
   fields: [

--- a/test/src/models/medicare_model.ts
+++ b/test/src/models/medicare_model.ts
@@ -178,7 +178,10 @@ export const medicareModel: StructDef = {
   name: "malloy-data.malloytest.bq_medicare_test",
   primaryKey: "id",
   structRelationship: { type: "basetable", connectionName: "bigquery" },
-  structSource: { type: "table" },
+  structSource: {
+    type: "table",
+    tablePath: "malloy-data.malloytest.bq_medicare_test",
+  },
   type: "struct",
 };
 


### PR DESCRIPTION
This PR makes `tablePath` required in `StructDef`s with `structSource.type === 'table'`.

Previously, code generation could not rely on this being present, and had to recreate it from `theStructDef.name` using `parseTableURL` (now renamed to `parseTableURI`).