### PR TITLE
Don't show errors for imported files in the importing file

### DIFF
--- a/vscode-extension/src/server/diagnostics/diagnostics.ts
+++ b/vscode-extension/src/server/diagnostics/diagnostics.ts
@@ -28,8 +28,12 @@ const DEFAULT_RANGE = {
 export async function getMalloyDiagnostics(
   documents: TextDocuments<TextDocument>,
   document: TextDocument
-): Promise<Diagnostic[]> {
-  const diagnostics: Diagnostic[] = [];
+): Promise<{ [uri: string]: Diagnostic[] }> {
+  const byURI: { [uri: string]: Diagnostic[] } = {
+    // Important that the requested document starts out as empty array,
+    // so that we clear old diagnostics
+    [document.uri]: [],
+  };
   let errors: LogMessage[] = [];
   try {
     await translateWithCache(document, documents);
@@ -38,7 +42,7 @@ export async function getMalloyDiagnostics(
       errors = error.log;
     } else {
       // TODO this kind of error should cease to exist. All errors should have source info.
-      diagnostics.push({
+      byURI[document.uri].push({
         severity: DiagnosticSeverity.Error,
         range: DEFAULT_RANGE,
         message: error.message,
@@ -55,15 +59,19 @@ export async function getMalloyDiagnostics(
         ? DiagnosticSeverity.Information
         : DiagnosticSeverity.Error;
 
-    if (!err.at || err.at.url === document.uri) {
-      diagnostics.push({
-        severity: sev,
-        range: err.at?.range || DEFAULT_RANGE,
-        message: err.message,
-        source: "malloy",
-      });
+    const uri = err.at ? err.at.url : document.uri;
+
+    if (byURI[uri] === undefined) {
+      byURI[uri] = [];
     }
+
+    byURI[uri].push({
+      severity: sev,
+      range: err.at?.range || DEFAULT_RANGE,
+      message: err.message,
+      source: "malloy",
+    });
   }
 
-  return diagnostics;
+  return byURI;
 }

--- a/vscode-extension/src/server/diagnostics/diagnostics.ts
+++ b/vscode-extension/src/server/diagnostics/diagnostics.ts
@@ -55,12 +55,14 @@ export async function getMalloyDiagnostics(
         ? DiagnosticSeverity.Information
         : DiagnosticSeverity.Error;
 
-    diagnostics.push({
-      severity: sev,
-      range: err.at?.range || DEFAULT_RANGE,
-      message: err.message,
-      source: "malloy",
-    });
+    if (!err.at || err.at.url === document.uri) {
+      diagnostics.push({
+        severity: sev,
+        range: err.at?.range || DEFAULT_RANGE,
+        message: err.message,
+        source: "malloy",
+      });
+    }
   }
 
   return diagnostics;


### PR DESCRIPTION
Fixes an issue in the VSCode extension where errors in an imported file appear at the same line number in the importing file. E.g.:

`a.malloy`
```
// 
source: foo is table('this.table.does.not.exist') {}
```

`b.malloy`
```
import "a.malloy"

source: bar is foo {}
```

Line 2 of `b.malloy` would show an error for the invalid table.

Additionally, reports diagnostics for the imported file (but with the correct URI). Now, as long as you have the "Problems" tab open, or have the imported file visible, you should see an indication that there's an error in the imported file.