### PR TITLE
Add vega dependency to render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24132,8 +24132,6 @@
         "react-popper-tooltip": "^4.3.1",
         "shiki": "^0.10.0",
         "styled-components": "^5.3.3",
-        "vega": "5.21.0",
-        "vega-lite": "5.2.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",
         "vscode-languageserver-textdocument": "^1.0.1"
@@ -35878,8 +35876,6 @@
         "shiki": "^0.10.0",
         "styled-components": "^5.3.3",
         "uuid": "^8.3.2",
-        "vega": "5.21.0",
-        "vega-lite": "5.2.0",
         "vsce": "^2.6.3",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24101,7 +24101,9 @@
       "license": "GPL-2.0",
       "dependencies": {
         "@malloydata/malloy": "*",
-        "us-atlas": "^3.0.0"
+        "us-atlas": "^3.0.0",
+        "vega": "^5.21.0",
+        "vega-lite": "^5.2.0"
       }
     },
     "test": {
@@ -28170,7 +28172,9 @@
       "version": "file:packages/malloy-render",
       "requires": {
         "@malloydata/malloy": "*",
-        "us-atlas": "^3.0.0"
+        "us-atlas": "^3.0.0",
+        "vega": "^5.21.0",
+        "vega-lite": "^5.2.0"
       }
     },
     "@mapbox/node-pre-gyp": {

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@malloydata/malloy": "*",
-    "us-atlas": "^3.0.0"
+    "us-atlas": "^3.0.0",
+    "vega": "^5.21.0",
+    "vega-lite": "^5.2.0"
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -331,8 +331,6 @@
     "react-popper-tooltip": "^4.3.1",
     "shiki": "^0.10.0",
     "styled-components": "^5.3.3",
-    "vega": "5.21.0",
-    "vega-lite": "5.2.0",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1"


### PR DESCRIPTION
If you install `@malloydata/render` from npm by itself, it doesn't include the required `vega` and `vega-lite` dependencies.