### PR TITLE
Clean up imports and exports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,11 @@ module.exports = {
     "no-console": "warn",
     "prettier/prettier": "error",
     "sort-keys": "off",
+    "no-duplicate-imports": "error",
+    "no-restricted-imports": [
+      "error",
+      { patterns: ["@malloydata/malloy/src/*"] },
+    ],
     "no-use-before-define": "off",
     "no-throw-literal": "error",
     "@typescript-eslint/no-unused-vars": [

--- a/demo/malloy-demo-composer/src/app/ActionMenu/ActionMenu.tsx
+++ b/demo/malloy-demo-composer/src/app/ActionMenu/ActionMenu.tsx
@@ -11,8 +11,11 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, StructDef } from "@malloydata/malloy";
-import { SearchValueMapResult } from "@malloydata/malloy";
+import {
+  FilterExpression,
+  SearchValueMapResult,
+  StructDef,
+} from "@malloydata/malloy";
 import { ReactElement, useState } from "react";
 import styled from "styled-components";
 import { compileFilter } from "../../core/compile";

--- a/demo/malloy-demo-composer/src/app/AddFilter/AddFilter.tsx
+++ b/demo/malloy-demo-composer/src/app/AddFilter/AddFilter.tsx
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, StructDef } from "@malloydata/malloy";
+import { FieldDef, FilterExpression, StructDef } from "@malloydata/malloy";
 import { useState } from "react";
 import { compileFilter } from "../../core/compile";
 import { CodeInput } from "../CodeInput";
@@ -25,7 +25,6 @@ import {
   FieldLabel,
   FormInputLabel,
 } from "../CommonElements";
-import { FieldDef } from "@malloydata/malloy";
 import { TypeIcon } from "../TypeIcon";
 import { StringFilterBuilder } from "./StringFilterBuilder";
 import {

--- a/demo/malloy-demo-composer/src/app/AggregateActionMenu/AggregateActionMenu.tsx
+++ b/demo/malloy-demo-composer/src/app/AggregateActionMenu/AggregateActionMenu.tsx
@@ -11,14 +11,18 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, StructDef } from "@malloydata/malloy";
+import {
+  FilterExpression,
+  QueryFieldDef,
+  SearchValueMapResult,
+  StructDef,
+} from "@malloydata/malloy";
 import { OrderByField, RendererName, StagePath } from "../../types";
 import { FilterContextBar } from "../FilterContextBar";
 import { RenameField } from "../RenameField";
 import { ActionMenu } from "../ActionMenu";
 import { DataStyleContextBar } from "../DataStyleContextBar";
 import { AddNewMeasure } from "../AddNewMeasure";
-import { QueryFieldDef, SearchValueMapResult } from "@malloydata/malloy";
 import { EditOrderBy } from "../EditOrderBy";
 
 interface AggregateActionMenuProps {

--- a/demo/malloy-demo-composer/src/app/DimensionActionMenu/DimensionActionMenu.tsx
+++ b/demo/malloy-demo-composer/src/app/DimensionActionMenu/DimensionActionMenu.tsx
@@ -11,8 +11,12 @@
  * GNU General Public License for more details.
  */
 
-import { FieldDef, FilterExpression, StructDef } from "@malloydata/malloy";
-import { QueryFieldDef } from "@malloydata/malloy";
+import {
+  FieldDef,
+  FilterExpression,
+  QueryFieldDef,
+  StructDef,
+} from "@malloydata/malloy";
 import {
   RendererName,
   StagePath,

--- a/demo/malloy-demo-composer/src/app/FilterContextBar/FilterContextBar.tsx
+++ b/demo/malloy-demo-composer/src/app/FilterContextBar/FilterContextBar.tsx
@@ -11,8 +11,12 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, StructDef } from "@malloydata/malloy";
-import { FieldDef, SearchValueMapResult } from "@malloydata/malloy";
+import {
+  FieldDef,
+  FilterExpression,
+  SearchValueMapResult,
+  StructDef,
+} from "@malloydata/malloy";
 import { useState } from "react";
 import { AddFilter } from "../AddFilter";
 import {

--- a/demo/malloy-demo-composer/src/app/NestQueryActionMenu/NestQueryActionMenu.tsx
+++ b/demo/malloy-demo-composer/src/app/NestQueryActionMenu/NestQueryActionMenu.tsx
@@ -23,9 +23,9 @@ import { NestContextBar } from "../NestContextBar";
 import { FilterContextBar } from "../FilterContextBar";
 import { AddLimit } from "../AddLimit";
 import { OrderByContextBar } from "../OrderByContextBar";
-import { FilterExpression } from "@malloydata/malloy";
 import { ActionMenu } from "../ActionMenu";
 import {
+  FilterExpression,
   QueryFieldDef,
   SearchValueMapResult,
   StructDef,

--- a/demo/malloy-demo-composer/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
+++ b/demo/malloy-demo-composer/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
@@ -11,8 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { ReactElement, useRef } from "react";
-import { useState } from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
 import {
   QuerySummary,
   QuerySummaryItem,
@@ -34,7 +33,6 @@ import { FilterActionMenu } from "../FilterActionMenu";
 import { SearchValueMapResult, StructDef } from "@malloydata/malloy";
 import { OrderByActionMenu } from "../OrderByActionMenu";
 import { EmptyMessage } from "../CommonElements";
-import { useEffect } from "react";
 import { DataStyleActionMenu } from "../DataStyleActionMenu";
 import { VisIcon } from "../VisIcon";
 import { StageActionMenu } from "../StageActionMenu";

--- a/demo/malloy-demo-composer/src/app/StageActionMenu/StageActionMenu.tsx
+++ b/demo/malloy-demo-composer/src/app/StageActionMenu/StageActionMenu.tsx
@@ -23,9 +23,9 @@ import { NestContextBar } from "../NestContextBar";
 import { FilterContextBar } from "../FilterContextBar";
 import { AddLimit } from "../AddLimit";
 import { OrderByContextBar } from "../OrderByContextBar";
-import { FilterExpression } from "@malloydata/malloy";
 import { ActionMenu } from "../ActionMenu";
 import {
+  FilterExpression,
   QueryFieldDef,
   SearchValueMapResult,
   StructDef,

--- a/demo/malloy-demo-composer/src/app/TypeIcon/TypeIcon.tsx
+++ b/demo/malloy-demo-composer/src/app/TypeIcon/TypeIcon.tsx
@@ -15,7 +15,7 @@ import { ReactComponent as TypeIconBoolean } from "../assets/img/type_icons/type
 import { ReactComponent as TypeIconDate } from "../assets/img/type_icons/type-icon-date.svg";
 import { ReactComponent as TypeIconNumber } from "../assets/img/type_icons/type-icon-number.svg";
 import { ReactComponent as TypeIconString } from "../assets/img/type_icons/type-icon-string.svg";
-import { ReactComponent as TypeIconQuery } from "../assets/img/type_icons/type-icon-projection.svg";
+import { ReactComponent as TypeIconQuery } from "../assets/img/type_icons/type-icon-query.svg";
 import { ReactComponent as TypeIconSource } from "../assets/img/type_icons/type-icon-projection.svg";
 import { ReactComponent as TypeIconMeasure } from "../assets/img/type_icons/type-icon-number-measure.svg";
 

--- a/demo/malloy-demo-composer/src/app/assets/img/type_icons/type-icon-query.svg
+++ b/demo/malloy-demo-composer/src/app/assets/img/type_icons/type-icon-query.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="1.5 1.5 13 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>type-icon-projection</title>
+    <g id="type-icon-projection" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M11.3362588,4 L11.3362588,12 L8,9.90676786 L4.6637412,12 L4.6637412,4 L11.3362588,4 Z M10.336,5 L5.663,5 L5.663,10.191 L8,8.72623637 L10.336,10.191 L10.336,5 Z" id="Rectangle" fill="#4285F4" class="primaryfill" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/demo/malloy-demo-composer/src/app/data/use_search.ts
+++ b/demo/malloy-demo-composer/src/app/data/use_search.ts
@@ -11,8 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { StructDef } from "@malloydata/malloy";
-import { SearchIndexResult } from "@malloydata/malloy";
+import { SearchIndexResult, StructDef } from "@malloydata/malloy";
 import { useQuery } from "react-query";
 
 async function search(

--- a/demo/malloy-demo-composer/src/core/compile.ts
+++ b/demo/malloy-demo-composer/src/core/compile.ts
@@ -13,6 +13,8 @@
 
 import {
   Connection,
+  FetchSchemaAndRunSimultaneously,
+  FetchSchemaAndRunStreamSimultaneously,
   FieldDef,
   FilterExpression,
   FixedConnectionMap,
@@ -20,17 +22,13 @@ import {
   Malloy,
   MalloyQueryData,
   ModelDef,
+  PersistSQLResults,
   PooledConnection,
   Runtime,
+  StreamingConnection,
   StructDef,
   URLReader,
 } from "@malloydata/malloy";
-import { PersistSQLResults } from "@malloydata/malloy";
-import {
-  FetchSchemaAndRunSimultaneously,
-  StreamingConnection,
-  FetchSchemaAndRunStreamSimultaneously,
-} from "@malloydata/malloy/src/runtime_types";
 
 class DummyFiles implements URLReader {
   async readURL(): Promise<string> {

--- a/demo/malloy-demo-composer/src/core/query.ts
+++ b/demo/malloy-demo-composer/src/core/query.ts
@@ -23,19 +23,19 @@ import {
   QuerySummaryItemFilter,
   stagePathParent,
 } from "../types";
-import { FilterExpression } from "@malloydata/malloy";
 import {
   FieldDef,
+  FilteredAliasedName,
+  FilterExpression,
   isFilteredAliasedName,
   PipeSegment,
   QueryFieldDef,
+  Segment as QuerySegment,
   StructDef,
   TurtleDef,
   FieldTypeDef,
 } from "@malloydata/malloy";
 import { DataStyles } from "@malloydata/render";
-import { Segment as QuerySegment } from "@malloydata/malloy";
-import { FilteredAliasedName } from "@malloydata/malloy/src/model";
 
 class SourceUtils {
   constructor(protected source: StructDef) {}

--- a/demo/malloy-demo-composer/src/electron/config.ts
+++ b/demo/malloy-demo-composer/src/electron/config.ts
@@ -11,8 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { promises as fs } from "fs";
-import { existsSync } from "fs";
+import { existsSync, promises as fs } from "fs";
 import * as path from "path";
 import * as os from "os";
 

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -25,25 +25,23 @@ import { ResourceStream } from "@google-cloud/paginator";
 import * as googleCommon from "@google-cloud/common";
 import { GaxiosError } from "gaxios";
 import {
+  FetchSchemaAndRunSimultaneously,
+  FetchSchemaAndRunStreamSimultaneously,
   Malloy,
+  PersistSQLResults,
+  PooledConnection,
   QueryData,
   StructDef,
+  StreamingConnection,
   MalloyQueryData,
   FieldTypeDef,
   NamedStructDefs,
   SQLBlock,
   Connection,
   QueryDataRow,
+  parseTableURI,
   toAsyncGenerator,
 } from "@malloydata/malloy";
-import { parseTableURI } from "@malloydata/malloy";
-import { PooledConnection } from "@malloydata/malloy";
-import {
-  FetchSchemaAndRunSimultaneously,
-  FetchSchemaAndRunStreamSimultaneously,
-  PersistSQLResults,
-  StreamingConnection,
-} from "@malloydata/malloy/src/runtime_types";
 
 export interface BigQueryManagerOptions {
   credentials?: {

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -13,22 +13,20 @@
 import {
   AtomicFieldTypeInner,
   Connection,
+  FetchSchemaAndRunSimultaneously,
+  FetchSchemaAndRunStreamSimultaneously,
   MalloyQueryData,
   NamedStructDefs,
   parseTableURI,
   PersistSQLResults,
   FieldTypeDef,
   PooledConnection,
+  RunSQLOptions,
   SQLBlock,
+  StreamingConnection,
   StructDef,
   QueryDataRow,
 } from "@malloydata/malloy";
-import {
-  FetchSchemaAndRunSimultaneously,
-  FetchSchemaAndRunStreamSimultaneously,
-  StreamingConnection,
-} from "@malloydata/malloy/src/runtime_types";
-import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
 
 const duckDBToMalloyTypes: { [key: string]: AtomicFieldTypeInner } = {
   BIGINT: "number",

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -14,8 +14,7 @@
 import * as crypto from "crypto";
 import { DuckDBCommon } from "./duckdb_common";
 import { Database, OPEN_READWRITE, Row } from "duckdb";
-import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
-import { QueryDataRow } from "@malloydata/malloy";
+import { QueryDataRow, RunSQLOptions } from "@malloydata/malloy";
 
 export class DuckDBConnection extends DuckDBCommon {
   protected connection;

--- a/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_wasm_connection.ts
@@ -10,10 +10,9 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  */
-import { QueryDataRow } from "@malloydata/malloy";
+import { QueryDataRow, RunSQLOptions } from "@malloydata/malloy";
 import * as duckdb from "@duckdb/duckdb-wasm";
 import { StructRow, Table, Vector } from "apache-arrow";
-import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
 import { DuckDBCommon } from "./duckdb_common";
 
 /**

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -19,6 +19,11 @@
 
 import * as crypto from "crypto";
 import {
+  FetchSchemaAndRunSimultaneously,
+  FetchSchemaAndRunStreamSimultaneously,
+  PersistSQLResults,
+  RunSQLOptions,
+  StreamingConnection,
   StructDef,
   MalloyQueryData,
   NamedStructDefs,
@@ -30,15 +35,8 @@ import {
   Connection,
   QueryDataRow,
 } from "@malloydata/malloy";
-import {
-  FetchSchemaAndRunSimultaneously,
-  FetchSchemaAndRunStreamSimultaneously,
-  PersistSQLResults,
-  StreamingConnection,
-} from "@malloydata/malloy/src/runtime_types";
 import { Client, Pool, PoolClient } from "pg";
 import QueryStream from "pg-query-stream";
-import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
 
 const postgresToMalloyTypes: { [key: string]: AtomicFieldTypeInner } = {
   "character varying": "string",

--- a/packages/malloy-render/src/html/html_view.ts
+++ b/packages/malloy-render/src/html/html_view.ts
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-import { DataArray, Field, Explore } from "@malloydata/malloy";
+import { AtomicFieldType, DataArray, Field, Explore } from "@malloydata/malloy";
 import { TopLevelSpec } from "vega-lite";
 import { DataStyles, StyleDefaults } from "../data_styles";
 import { Renderer } from "../renderer";
@@ -37,7 +37,6 @@ import { HTMLTableRenderer } from "./table";
 import { HTMLTextRenderer } from "./text";
 import { HTMLVegaSpecRenderer } from "./vega_spec";
 import { ContainerRenderer } from "./container";
-import { AtomicFieldType } from "@malloydata/malloy";
 import { createErrorElement } from "./utils";
 import { DrillFunction } from "../drill";
 

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -20,6 +20,7 @@ export type {
   Query,
   // Needed for DB
   StructDef,
+  StructRelationship,
   NamedStructDefs,
   MalloyQueryData,
   AtomicFieldType as AtomicFieldTypeInner,
@@ -37,6 +38,7 @@ export type {
   SQLBlock,
   // Used in Composer Demo
   FieldDef,
+  FilteredAliasedName,
   PipeSegment,
   QueryFieldDef,
   TurtleDef,
@@ -93,6 +95,7 @@ export type {
   DocumentSymbol,
   DocumentHighlight,
   ResultJSON,
+  RunSQLOptions,
   PreparedResultMaterializer,
   SQLBlockMaterializer,
   ExploreMaterializer,
@@ -110,6 +113,9 @@ export type {
   PooledConnection,
   TestableConnection,
   PersistSQLResults,
+  FetchSchemaAndRunSimultaneously,
+  StreamingConnection,
+  FetchSchemaAndRunStreamSimultaneously,
 } from "./runtime_types";
 export type { Loggable } from "./malloy";
 export { toAsyncGenerator } from "./connection_utils";

--- a/packages/malloy/src/lang/parse-to-ast.ts
+++ b/packages/malloy/src/lang/parse-to-ast.ts
@@ -17,10 +17,9 @@ import { AbstractParseTreeVisitor } from "antlr4ts/tree/AbstractParseTreeVisitor
 import { MalloyParserVisitor } from "./lib/Malloy/MalloyParserVisitor";
 import * as parse from "./lib/Malloy/MalloyParser";
 import * as ast from "./ast";
-import { MessageLogger } from "./parse-log";
+import { LogSeverity, MessageLogger } from "./parse-log";
 import { MalloyParseRoot } from "./parse-malloy";
 import { Interval as StreamInterval } from "antlr4ts/misc/Interval";
-import { LogSeverity } from "./parse-log";
 
 /**
  * ANTLR visitor pattern parse tree traversal. Generates a Malloy

--- a/test/src/databases/bigquery/handexpr.spec.ts
+++ b/test/src/databases/bigquery/handexpr.spec.ts
@@ -12,7 +12,12 @@
  * GNU General Public License for more details.
  */
 
-import { ModelDef, Query, StructDef } from "@malloydata/malloy";
+import {
+  ModelDef,
+  Query,
+  StructDef,
+  StructRelationship,
+} from "@malloydata/malloy";
 import {
   describeIfDatabaseAvailable,
   fStringEq,
@@ -21,7 +26,6 @@ import {
 
 import * as malloy from "@malloydata/malloy";
 import { RuntimeList } from "../../runtimes";
-import { StructRelationship } from "@malloydata/malloy/src/model";
 
 const [describe] = describeIfDatabaseAvailable(["bigquery"]);
 

--- a/test/src/models/faa_model.ts
+++ b/test/src/models/faa_model.ts
@@ -11,10 +11,9 @@
  * GNU General Public License for more details.
  */
 
-import { ModelDef, StructDef } from "@malloydata/malloy";
+import { ModelDef, StructDef, StructRelationship } from "@malloydata/malloy";
 import { medicareModel, medicareStateFacts } from "./medicare_model";
 import { fStringEq, fYearEq } from "../util";
-import { StructRelationship } from "@malloydata/malloy/src/model";
 
 function withJoin(leftKey: string, rightKey: string): StructRelationship {
   return {

--- a/test/src/runtimes.ts
+++ b/test/src/runtimes.ts
@@ -15,12 +15,12 @@ import {
   EmptyURLReader,
   Result,
   MalloyQueryData,
+  RunSQLOptions,
   SingleConnectionRuntime,
 } from "@malloydata/malloy";
 import { BigQueryConnection } from "@malloydata/db-bigquery";
 import { PooledPostgresConnection } from "@malloydata/db-postgres";
 import { DuckDBConnection } from "@malloydata/db-duckdb";
-import { RunSQLOptions } from "@malloydata/malloy/src/malloy";
 
 export class BigQueryTestConnection extends BigQueryConnection {
   // we probably need a better way to do this.

--- a/vscode-extension/src/extension/webviews/connections_page/connections_vscode_context.ts
+++ b/vscode-extension/src/extension/webviews/connections_page/connections_vscode_context.ts
@@ -12,8 +12,7 @@
  */
 
 import { ConnectionPanelMessage } from "../../message_types";
-import { makeVSCodeContext } from "../vscode_context";
-import { makeUseVSCodeContext } from "../vscode_context";
+import { makeUseVSCodeContext, makeVSCodeContext } from "../vscode_context";
 
 export const ConnectionsVSCodeContext = makeVSCodeContext<
   void,

--- a/vscode-extension/src/extension/webviews/query_page/query_vscode_context.ts
+++ b/vscode-extension/src/extension/webviews/query_page/query_vscode_context.ts
@@ -12,8 +12,7 @@
  */
 
 import { QueryPanelMessage } from "../../message_types";
-import { makeVSCodeContext } from "../vscode_context";
-import { makeUseVSCodeContext } from "../vscode_context";
+import { makeUseVSCodeContext, makeVSCodeContext } from "../vscode_context";
 
 export const QueryVSCodeContext = makeVSCodeContext<void, QueryPanelMessage>();
 

--- a/vscode-extension/src/worker/run_query.ts
+++ b/vscode-extension/src/worker/run_query.ts
@@ -17,7 +17,7 @@ import { DataStyles } from "@malloydata/render";
 import { HackyDataStylesAccumulator } from "./data_styles";
 import { WorkerURLReader } from "./files";
 import { log } from "./logger";
-import { MessageCancel, MessageRun } from "./types";
+import { MessageCancel, MessageRun, WorkerQueryPanelMessage } from "./types";
 
 import { CONNECTION_MANAGER } from "../server/connections";
 import {
@@ -25,7 +25,6 @@ import {
   QueryPanelMessage,
   QueryRunStatus,
 } from "../extension/message_types";
-import { WorkerQueryPanelMessage } from "./types";
 import { createRunnable } from "./utils";
 
 interface QueryEntry {


### PR DESCRIPTION
Makes sure we're not deep importing from Malloy packages because this reflects bad API hygiene, and make sure we're only importing each package once.