### PR TITLE
Bump package versions to fix some packages

### DIFF
--- a/demo/malloy-demo-bq-cli/package.json
+++ b/demo/malloy-demo-bq-cli/package.json
@@ -18,7 +18,7 @@
     "run": "ts-node src/entry.ts"
   },
   "dependencies": {
-    "@malloydata/malloy": "*",
-    "@malloydata/db-bigquery": "*"
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/db-bigquery": "0.0.2"
   }
 }

--- a/demo/malloy-demo-composer/package.json
+++ b/demo/malloy-demo-composer/package.json
@@ -17,11 +17,11 @@
     "clean": "rm -rf ./node_modules"
   },
   "dependencies": {
-    "@malloydata/db-bigquery": "*",
-    "@malloydata/db-duckdb": "*",
-    "@malloydata/db-postgres": "*",
-    "@malloydata/malloy": "*",
-    "@malloydata/render": "*",
+    "@malloydata/db-bigquery": "0.0.2",
+    "@malloydata/db-duckdb": "0.0.2",
+    "@malloydata/db-postgres": "0.0.2",
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/render": "0.0.2",
     "@popperjs/core": "^2.11.4",
     "electron": "^18.2.3",
     "mdast-comment-marker": "^2.1.0",

--- a/demo/malloy-duckdb-wasm/package.json
+++ b/demo/malloy-duckdb-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "malloy-duckdb-wasm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "./dist/index.js",
   "scripts": {
@@ -12,9 +12,9 @@
   "author": "Malloy",
   "license": "GPL-2.0",
   "dependencies": {
-    "@malloydata/db-duckdb": "*",
-    "@malloydata/malloy": "*",
-    "@malloydata/render": "*",
+    "@malloydata/db-duckdb": "0.0.2",
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/render": "0.0.2",
     "apache-arrow": "^9.0.0",
     "monaco-editor": "^0.34.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@jest/globals": "^26.6.2",
-    "@malloydata/db-bigquery": "*",
-    "@malloydata/malloy": "*",
-    "@malloydata/render": "*",
+    "@malloydata/db-bigquery": "0.0.2",
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/render": "0.0.2",
     "@types/archiver": "^5.3.1",
     "@types/jest-expect-message": "^1.0.3",
     "@types/md5": "^2.3.1",

--- a/packages/malloy-db-bigquery/package.json
+++ b/packages/malloy-db-bigquery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/db-bigquery",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "GPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "^5.5.0",
     "@google-cloud/common": "^3.6.0",
-    "@malloydata/malloy": "*",
+    "@malloydata/malloy": "0.0.3",
     "gaxios": "^4.2.0"
   }
 }

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/db-duckdb",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "GPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,8 @@
     "malloyc": "ts-node ../../scripts/malloy-to-json"
   },
   "dependencies": {
-    "duckdb": "0.5.1",
-    "@duckdb/duckdb-wasm": "^1.17.0"
+    "@malloydata/malloy": "0.0.3",
+    "@duckdb/duckdb-wasm": "^1.17.0",
+    "duckdb": "0.5.1"
   }
 }

--- a/packages/malloy-db-postgres/package.json
+++ b/packages/malloy-db-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/db-postgres",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "GPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "malloyc": "ts-node ../../scripts/malloy-to-json"
   },
   "dependencies": {
-    "@malloydata/malloy": "*",
+    "@malloydata/malloy": "0.0.3",
     "@types/pg": "^8.6.1",
     "pg": "^8.7.1",
     "pg-query-stream": "4.2.3"

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/render",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "GPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "build": "tsc --build"
   },
   "dependencies": {
-    "@malloydata/malloy": "*",
+    "@malloydata/malloy": "0.0.3",
     "us-atlas": "^3.0.0",
     "vega": "^5.21.0",
     "vega-lite": "^5.2.0"

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@malloydata/malloy",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "GPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/package.json
+++ b/test/package.json
@@ -9,9 +9,9 @@
     "malloyc": "ts-node ../scripts/malloy-to-json"
   },
   "dependencies": {
-    "@malloydata/malloy": "*",
-    "@malloydata/db-bigquery": "*",
-    "@malloydata/db-postgres": "*",
-    "@malloydata/db-duckdb": "*"
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/db-bigquery": "0.0.2",
+    "@malloydata/db-postgres": "0.0.2",
+    "@malloydata/db-duckdb": "0.0.2"
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -318,11 +318,11 @@
     ]
   },
   "dependencies": {
-    "@malloydata/db-bigquery": "*",
-    "@malloydata/db-duckdb": "*",
-    "@malloydata/db-postgres": "*",
-    "@malloydata/malloy": "*",
-    "@malloydata/render": "*",
+    "@malloydata/db-bigquery": "0.0.2",
+    "@malloydata/db-duckdb": "0.0.2",
+    "@malloydata/db-postgres": "0.0.2",
+    "@malloydata/malloy": "0.0.3",
+    "@malloydata/render": "0.0.2",
     "@observablehq/plot": "^0.1.0",
     "@vscode/webview-ui-toolkit": "^1.0.0",
     "keytar": "7.7.0",


### PR DESCRIPTION
There's some weirdness in the way existing packages reference versions (@malloydata/render requires @malloydata/malloy 0.0.1 but the default @malloydata/malloy is now at 0.0.2), this attempts to fix that. I'm tempted to bump everything to 0.0.3 and make life simpler, however.