### PR TITLE
Convert order by index to order by name in composer

### DIFF
--- a/demo/malloy-demo-composer/src/core/query.ts
+++ b/demo/malloy-demo-composer/src/core/query.ts
@@ -262,7 +262,17 @@ export class QueryBuilder extends SourceUtils {
           existingStage.limit = stage.limit;
         }
         if (stage.orderBy) {
-          existingStage.orderBy = stage.orderBy;
+          const newOrderBy = stage.orderBy
+            ? stage.orderBy.map((orderBy) => {
+                if (typeof orderBy.field === "string") {
+                  return { ...orderBy };
+                } else {
+                  const field = stage.fields[orderBy.field - 1];
+                  return { ...orderBy, field: this.nameOf(field) };
+                }
+              })
+            : undefined;
+          existingStage.orderBy = newOrderBy;
           existingStage.by = undefined;
         }
         existingStage.fields = stage.fields

--- a/demo/malloy-demo-composer/src/core/query.ts
+++ b/demo/malloy-demo-composer/src/core/query.ts
@@ -1176,14 +1176,13 @@ export class QueryWriter extends SourceUtils {
         }
         const byFieldQueryDef = stage.fields[byFieldIndex];
         if (byFieldQueryDef !== undefined) {
+          let as = undefined;
           let theField;
           if (typeof byFieldQueryDef === "string") {
             theField = this.getField(source, byFieldQueryDef);
           } else if (isFilteredAliasedName(byFieldQueryDef)) {
-            theField = this.getField(
-              source,
-              byFieldQueryDef.as || byFieldQueryDef.name
-            );
+            theField = this.getField(source, byFieldQueryDef.name);
+            as = byFieldQueryDef.as;
           } else {
             theField = byFieldQueryDef;
           }
@@ -1195,7 +1194,7 @@ export class QueryWriter extends SourceUtils {
             byField: {
               type: theField.type,
               fieldIndex: byFieldIndex,
-              name: this.nameOf(theField),
+              name: as || this.nameOf(theField),
             },
             direction: order.dir,
             orderByIndex,

--- a/demo/malloy-demo-composer/src/core/query.ts
+++ b/demo/malloy-demo-composer/src/core/query.ts
@@ -262,16 +262,14 @@ export class QueryBuilder extends SourceUtils {
           existingStage.limit = stage.limit;
         }
         if (stage.orderBy) {
-          const newOrderBy = stage.orderBy
-            ? stage.orderBy.map((orderBy) => {
-                if (typeof orderBy.field === "string") {
-                  return { ...orderBy };
-                } else {
-                  const field = stage.fields[orderBy.field - 1];
-                  return { ...orderBy, field: this.nameOf(field) };
-                }
-              })
-            : undefined;
+          const newOrderBy = stage.orderBy.map((orderBy) => {
+            if (typeof orderBy.field === "string") {
+              return { ...orderBy };
+            } else {
+              const field = stage.fields[orderBy.field - 1];
+              return { ...orderBy, field: this.nameOf(field) };
+            }
+          });
           existingStage.orderBy = newOrderBy;
           existingStage.by = undefined;
         }
@@ -632,16 +630,14 @@ export class QueryBuilder extends SourceUtils {
     if (definitionCopy.type === "turtle") {
       for (const stage of definitionCopy.pipeline) {
         if (stage.type === "reduce" && stage.orderBy) {
-          const newOrderBy = stage.orderBy
-            ? stage.orderBy.map((orderBy) => {
-                if (typeof orderBy.field === "string") {
-                  return { ...orderBy };
-                } else {
-                  const field = stage.fields[orderBy.field - 1];
-                  return { ...orderBy, field: this.nameOf(field) };
-                }
-              })
-            : undefined;
+          const newOrderBy = stage.orderBy.map((orderBy) => {
+            if (typeof orderBy.field === "string") {
+              return { ...orderBy };
+            } else {
+              const field = stage.fields[orderBy.field - 1];
+              return { ...orderBy, field: this.nameOf(field) };
+            }
+          });
           stage.orderBy = newOrderBy;
           stage.by = undefined;
         }


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/malloy/issues/883

In https://github.com/looker-open-source/malloy/issues/883, there was an issue when removing fields that are used in an order by which referenced the field by index instead of by name. Specifically, the code which removes the order by on a field when the field is removed did not account for order bys which referenced fields by index. This meant that if you had `order_by: 3` and you removed a field, you could change the meaning of the order by unintentionally, or invalidate it entirely. 

Rather than handle all of the edge cases (such as adding a field before the order by field, which would require incrementing the index), this PR just adds a conversion step when loading a query (either via "Load Query" or "Duplicate") which replaces order by index references with the name of the field.