### PR TITLE
Multili stage index queries

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -297,6 +297,7 @@ topStatement
 indexElement
   : fieldPath (DOT STAR)?
   | STAR
+  | STARSTAR
   ;
 
 indexFields


### PR DESCRIPTION
Indexes on sources with many one to many joins can have very large cross products.  We break the index into multiple stages.  

Stuff left to do..

- [ ] Sampling in BigQuery needs a temorary table
- [ ] Need to figure out the minimum number of stages we should generate for performance tuning
- [ ] Deep wildcarding (**) seems to be broken.