### PR TITLE
Don't generate StructRef references to non exported sources

### DIFF
--- a/packages/malloy/src/lang/ast/ast-main.ts
+++ b/packages/malloy/src/lang/ast/ast-main.ts
@@ -682,6 +682,12 @@ export class NamedSource extends Mallobj {
     if (this.isBlock) {
       return this.structDef();
     }
+    const modelEnt = this.modelEntry(this.ref);
+    if (modelEnt && !modelEnt.exported) {
+      // If we are not exporting the referenced structdef, don't
+      // use the reference
+      return this.structDef();
+    }
     return this.refName;
   }
 

--- a/packages/malloy/src/lang/grammar/build_parser.js
+++ b/packages/malloy/src/lang/grammar/build_parser.js
@@ -55,16 +55,16 @@ for (const fn of compilerSrcs) {
 }
 
 if (rebuild) {
+  console.log(`-- Constructing Malloy parser from antlr specification ...`);
   const antlr = `antlr4ts -Xexact-output-dir -o ../lib/Malloy`;
   if (
     run(`${antlr} MalloyLexer.g4`) &&
     run(`${antlr} -visitor MalloyParser.g4`)
   ) {
     writeFileSync(digestFile, versionDigest);
-    console.log(`Antlr generated Malloy parser -- Created`);
   } else {
     rmSync(digestFile);
   }
 } else {
-  console.log(`Antlr generated Malloy parser -- Already exists`);
+  console.log(`-- Using existing Malloy parser`);
 }


### PR DESCRIPTION
Fixes #911 

There may be other places where a change like this is needed. I leave that for future Michael to worry about.