### PR TITLE
Handle unknown schema types in DuckDB and PostgreSQL 

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -522,7 +522,7 @@ export class BigQueryConnection
           structDef.fields.push({
             name,
             type: "string",
-            e: [`BigQuery type "${type}" not supported by Malloy`],
+            e: [`'BigQuery type "${type}" not supported by Malloy'`],
           });
         }
       }

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -261,7 +261,11 @@ export abstract class DuckDBCommon
               name,
             });
           } else {
-            throw new Error(`unknown duckdb type ${duckDBType}`);
+            structDef.fields.push({
+              name,
+              type: "string",
+              e: [`DuckDB type "${duckDBType}" not supported by Malloy`],
+            });
           }
         }
       }

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -264,7 +264,7 @@ export abstract class DuckDBCommon
             structDef.fields.push({
               name,
               type: "string",
-              e: [`DuckDB type "${duckDBType}" not supported by Malloy`],
+              e: [`'DuckDB type "${duckDBType}" not supported by Malloy'`],
             });
           }
         }

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -315,7 +315,11 @@ export class PostgresConnection
           name,
         });
       } else {
-        throw new Error(`unknown postgres type ${postgresDataType}`);
+        s.fields.push({
+          name,
+          type: "string",
+          e: [`Postgres type "${postgresDataType}" not supported by Malloy`],
+        });
       }
     }
   }

--- a/packages/malloy-db-postgres/src/postgres_connection.ts
+++ b/packages/malloy-db-postgres/src/postgres_connection.ts
@@ -318,7 +318,7 @@ export class PostgresConnection
         s.fields.push({
           name,
           type: "string",
-          e: [`Postgres type "${postgresDataType}" not supported by Malloy`],
+          e: [`'Postgres type "${postgresDataType}" not supported by Malloy'`],
         });
       }
     }

--- a/test/src/databases/bigquery/malloy_query.spec.ts
+++ b/test/src/databases/bigquery/malloy_query.spec.ts
@@ -990,4 +990,18 @@ describe("sql injection tests", () => {
     );
     expect(result.data.value[0].test).toBe("foo \\");
   });
+
+  it("passes test which should be deleted when type support improves", async () => {
+    const result = await runtime
+      .loadQuery(
+        `
+        sql: badType is || SELECT ST_GEOGFROMTEXT('LINESTRING(1 2, 3 4)') as geo ;;
+        query: from_sql(badType)->{ project: *}
+      `
+      )
+      .run();
+    expect(result.data.value[0].geo).toBe(
+      'BigQuery type "GEOGRAPHY" not supported by Malloy'
+    );
+  });
 });

--- a/test/src/databases/postgres/postgres.spec.ts
+++ b/test/src/databases/postgres/postgres.spec.ts
@@ -12,6 +12,7 @@
  * GNU General Public License for more details.
  */
 
+import { Result } from "@malloydata/malloy";
 import { RuntimeList } from "../../runtimes";
 import { describeIfDatabaseAvailable } from "../../util";
 
@@ -200,5 +201,19 @@ describe("Postgres tests", () => {
       )
       .run();
     expect(result.data.value[0].one).toBe(1);
+  });
+
+  it("passes test which should be deleted when type support improves", async () => {
+    const result = await runtime
+      .loadQuery(
+        `
+        sql: badType is || SELECT int4range(10, 20) as ranger ;;
+        query: from_sql(badType)->{ project: *}
+      `
+      )
+      .run();
+    expect(result.data.value[0].ranger).toBe(
+      'Postgres type "int4range" not supported by Malloy'
+    );
   });
 });


### PR DESCRIPTION
The bigquery reader has a hack, which I just moved forward to these readers ...

A better fix is a plan to pass an "unsupported" type to the compiler ( #900  ), but this is quick and will let people use tables with fields of unknown types.