### PR TITLE
Flatten query API

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -15,9 +15,7 @@
 export type {
   QueryDataRow,
   // Currently needed only by tests
-  ModelDef,
   Fragment,
-  Query,
   // Needed for DB
   StructDef,
   StructRelationship,
@@ -44,6 +42,9 @@ export type {
   TurtleDef,
   SearchValueMapResult,
   SearchIndexResult,
+  ModelDef,
+  Query,
+  NamedQuery,
 } from "./model";
 export {
   // Used in Composer Demo

--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -43,6 +43,7 @@ import {
   DocumentPosition as ModelDocumentPosition,
   SearchIndexResult,
   SearchValueMapResult,
+  NamedQuery,
 } from "./model";
 import {
   LookupConnection,
@@ -699,9 +700,9 @@ export class Model {
  * A prepared query which has all the necessary information to produce its SQL.
  */
 export class PreparedQuery {
-  private _modelDef: ModelDef;
-  private _query: InternalQuery;
-  private name?: string;
+  public _modelDef: ModelDef;
+  public _query: InternalQuery | NamedQuery;
+  public name?: string;
 
   constructor(query: InternalQuery, model: ModelDef, name?: string) {
     this._query = query;
@@ -736,6 +737,28 @@ export class PreparedQuery {
       throw new Error("Invalid source for query");
     }
     return source.dialect;
+  }
+
+  /**
+   * Get the flattened version of a query -- one that does not have a `pipeHead`.
+   */
+  public getFlattenedQuery(defaultName: string): PreparedQuery {
+    let structRef = this._query.structRef;
+    if (typeof structRef !== "string") {
+      structRef = structRef.as || structRef.name;
+    }
+    const queryModel = new QueryModel(this._modelDef);
+    const queryStruct = queryModel.getStructByName(structRef);
+    const turtleDef = queryStruct.flattenTurtleDef({
+      name: defaultName,
+      ...this._query,
+      type: "turtle",
+    });
+    return new PreparedQuery(
+      { ...turtleDef, structRef, type: "query" },
+      this._modelDef,
+      this.name || turtleDef.as || turtleDef.name
+    );
   }
 }
 

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3209,7 +3209,7 @@ FROM ${resultStage}\n`
 }
 
 /** Structure object as it is used to build a query */
-export class QueryStruct extends QueryNode {
+class QueryStruct extends QueryNode {
   fieldDef: StructDef;
   parent: QueryStruct | undefined;
   model: QueryModel;

--- a/packages/malloy/src/model/malloy_query.ts
+++ b/packages/malloy/src/model/malloy_query.ts
@@ -3209,7 +3209,7 @@ FROM ${resultStage}\n`
 }
 
 /** Structure object as it is used to build a query */
-class QueryStruct extends QueryNode {
+export class QueryStruct extends QueryNode {
   fieldDef: StructDef;
   parent: QueryStruct | undefined;
   model: QueryModel;


### PR DESCRIPTION
Some small changes for the Composer. Adds a `getFlattenedQuery` method to a `PreparedQuery`, which converts a query with a `pipeHead` into one without a `pipeHead`. Also exports a couple extra types for the Composer to use.