### PR TITLE
Language changes to enable passing parameter into query source

### DIFF
--- a/packages/malloy/src/lang/ast/query-elements/query-base.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-base.ts
@@ -34,12 +34,16 @@ import {
   type Query,
   type SourceDef,
 } from '../../../model/malloy_types';
+import type {ParameterSpace} from '../field-space/parameter-space';
 import {detectAndRemovePartialStages} from '../query-utils';
 import {MalloyElement} from '../types/malloy-element';
 import type {QueryComp} from '../types/query-comp';
 
 export abstract class QueryBase extends MalloyElement {
-  abstract queryComp(isRefOk: boolean): QueryComp;
+  abstract queryComp(
+    isRefOk: boolean,
+    parameterSpace: ParameterSpace | undefined
+  ): QueryComp;
 
   protected resolveCompositeSource(
     inputSource: SourceDef,
@@ -65,7 +69,7 @@ export abstract class QueryBase extends MalloyElement {
   }
 
   query(): Query {
-    const {query} = this.queryComp(true);
+    const {query} = this.queryComp(true, undefined);
 
     return {
       ...query,

--- a/packages/malloy/src/lang/ast/query-elements/query-refine.ts
+++ b/packages/malloy/src/lang/ast/query-elements/query-refine.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import type {ParameterSpace} from '../field-space/parameter-space';
 import {StaticSourceSpace} from '../field-space/static-space';
 import {getFinalStruct} from '../struct-utils';
 import type {QueryComp} from '../types/query-comp';
@@ -43,8 +44,11 @@ export class QueryRefine extends QueryBase implements QueryElement {
     super({base, refinement});
   }
 
-  queryComp(isRefOk: boolean): QueryComp {
-    const q = this.base.queryComp(isRefOk);
+  queryComp(
+    isRefOk: boolean,
+    parameterSpace: ParameterSpace | undefined
+  ): QueryComp {
+    const q = this.base.queryComp(isRefOk, parameterSpace);
     const inputFS = new StaticSourceSpace(q.inputStruct, 'public');
     const resultPipe = this.refinement.refine(
       inputFS,

--- a/packages/malloy/src/lang/ast/source-elements/query-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/query-source.ts
@@ -24,7 +24,7 @@
 import type {SourceDef, QuerySourceDef} from '../../../model/malloy_types';
 import {Source} from './source';
 import type {QueryElement} from '../types/query-element';
-import type {ParameterSpace} from '../field-space/parameter-space';
+import {ParameterSpace} from '../field-space/parameter-space';
 import type {HasParameter} from '../parameters/has-parameter';
 import {v4 as uuidv4} from 'uuid';
 
@@ -42,7 +42,8 @@ export class QuerySource extends Source {
     parameterSpace: ParameterSpace | undefined,
     pList: HasParameter[] | undefined
   ): SourceDef {
-    const comp = this.query.queryComp(false);
+    const paramSpace = parameterSpace ?? new ParameterSpace(pList ?? []);
+    const comp = this.query.queryComp(false, paramSpace);
     const queryStruct: QuerySourceDef = {
       ...comp.outputStruct,
       name: `QuerySource-${uuidv4()}`,

--- a/packages/malloy/src/lang/ast/types/query-element.ts
+++ b/packages/malloy/src/lang/ast/types/query-element.ts
@@ -28,9 +28,13 @@ import {QueryReference} from '../query-elements/query-reference';
 import {QueryRaw} from '../query-elements/query-raw';
 import type {Query} from '../../../model/malloy_types';
 import type {QueryComp} from './query-comp';
+import type {ParameterSpace} from '../field-space/parameter-space';
 
 export interface QueryElement extends MalloyElement {
-  queryComp(isRefOk: boolean): QueryComp;
+  queryComp(
+    isRefOk: boolean,
+    parameterSpace: ParameterSpace | undefined
+  ): QueryComp;
   query(): Query;
 }
 

--- a/test/src/core/parameters.spec.ts
+++ b/test/src/core/parameters.spec.ts
@@ -267,7 +267,7 @@ describe('parameters', () => {
       }
     `).malloyResultMatches(runtime, {s1: 'CA', s2: 'CA', c: 1});
   });
-  it.skip('can pass param into query definition', async () => {
+  it('can pass param into query source', async () => {
     await expect(`
       ##! experimental.parameters
       source: state_facts(
@@ -282,6 +282,18 @@ describe('parameters', () => {
         select: state
       }
     `).malloyResultMatches(runtime, {state: 'CA'});
+  });
+  it.skip('can pass param into query definition', async () => {
+    await expect(`
+      ##! experimental.parameters
+      source: state_facts is duckdb.table('malloytest.state_facts')
+
+      source: state_facts_query(the_state::string) is state_facts -> { select: the_state }
+
+      run: state_facts_query(the_state is "CA") -> {
+        select: the_state
+      }
+    `).malloyResultMatches(runtime, {the_state: 'CA'});
   });
   it('can use param in join on', async () => {
     await expect(`


### PR DESCRIPTION
This is just the translator-side changes to enable `source: x(param::string) is y(param) -> ...`. This needs compiler work in order to land.