### PR TITLE
Enhance Malloy Publisher API with MotherDuck support and schema validation

### DIFF
--- a/packages/malloy-db-publisher/publisher-api-doc.yaml
+++ b/packages/malloy-db-publisher/publisher-api-doc.yaml
@@ -1216,7 +1216,6 @@ paths:
         "501":
           $ref: "#/components/responses/NotImplemented"
 
-
   /projects/{projectName}/packages/{packageName}/databases:
     get:
       tags:
@@ -1280,14 +1279,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Connection'
+              $ref: "#/components/schemas/Connection"
       responses:
         "200":
           description: Connection test result
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConnectionStatus'
+                $ref: "#/components/schemas/ConnectionStatus"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1843,6 +1842,17 @@ components:
           type: string
           description: Trino password for authentication
 
+    MotherDuckConnection:
+      type: object
+      description: MotherDuck database connection configuration
+      properties:
+        accessToken:
+          type: string
+          description: MotherDuck access token
+        database:
+          type: string
+          description: MotherDuck database name
+
     DuckdbConnection:
       type: object
       description: DuckDB database connection configuration
@@ -1861,7 +1871,7 @@ components:
         type:
           type: string
           description: Type of database connection
-          enum: [bigquery, snowflake, postgres]
+          enum: [bigquery, snowflake, postgres, motherduck]
         attributes:
           $ref: "#/components/schemas/ConnectionAttributes"
         bigqueryConnection:
@@ -1870,7 +1880,8 @@ components:
           $ref: "#/components/schemas/SnowflakeConnection"
         postgresConnection:
           $ref: "#/components/schemas/PostgresConnection"
-
+        motherDuckConnection:
+          $ref: "#/components/schemas/MotherDuckConnection"
 
     # TODO: What is this?  Can we remove it?
     SqlSource:
@@ -1889,6 +1900,9 @@ components:
         resource:
           type: string
           description: Resource path to the table.
+        source:
+          type: string
+          description: Table source as a JSON string.
         columns:
           description: Table fields
           type: array

--- a/packages/malloy-db-publisher/src/client/api.ts
+++ b/packages/malloy-db-publisher/src/client/api.ts
@@ -65,12 +65,19 @@ export interface AttachedDatabase {
      * @memberof AttachedDatabase
      */
     'postgresConnection'?: PostgresConnection;
+    /**
+     * 
+     * @type {MotherDuckConnection}
+     * @memberof AttachedDatabase
+     */
+    'motherDuckConnection'?: MotherDuckConnection;
 }
 
 export const AttachedDatabaseTypeEnum = {
     Bigquery: 'bigquery',
     Snowflake: 'snowflake',
-    Postgres: 'postgres'
+    Postgres: 'postgres',
+    Motherduck: 'motherduck'
 } as const;
 
 export type AttachedDatabaseTypeEnum = typeof AttachedDatabaseTypeEnum[keyof typeof AttachedDatabaseTypeEnum];
@@ -461,6 +468,25 @@ export interface ModelError {
      * @memberof ModelError
      */
     'details'?: string;
+}
+/**
+ * MotherDuck database connection configuration
+ * @export
+ * @interface MotherDuckConnection
+ */
+export interface MotherDuckConnection {
+    /**
+     * MotherDuck access token
+     * @type {string}
+     * @memberof MotherDuckConnection
+     */
+    'accessToken'?: string;
+    /**
+     * MotherDuck database name
+     * @type {string}
+     * @memberof MotherDuckConnection
+     */
+    'database'?: string;
 }
 /**
  * MySQL database connection configuration
@@ -948,6 +974,12 @@ export interface Table {
      * @memberof Table
      */
     'resource'?: string;
+    /**
+     * Table source as a JSON string.
+     * @type {string}
+     * @memberof Table
+     */
+    'source'?: string;
     /**
      * Table fields
      * @type {Array<Column>}

--- a/packages/malloy-db-publisher/src/publisher_connection.ts
+++ b/packages/malloy-db-publisher/src/publisher_connection.ts
@@ -20,7 +20,6 @@ import type {
 } from '@malloydata/malloy';
 import {BaseConnection} from '@malloydata/malloy/connection';
 import type {
-  Column,
   Connection,
   ConnectionAttributes,
   PostSqlsourceRequest,
@@ -142,32 +141,19 @@ export class PublisherConnection
   }
 
   public async fetchTableSchema(
-    tableKey: string,
+    _tableKey: string,
     tablePath: string
   ): Promise<TableSourceDef> {
     const response = await this.connectionsApi.getTable(
       this.projectName,
       this.name,
-      tablePath.split('/')[0],
+      tablePath.split('.')[0],
       tablePath,
       {
         headers: PublisherConnection.getAuthHeaders(this.accessToken),
       }
     );
-    // Convert the Table response to TableSourceDef format
-    const tableData = response.data;
-    return {
-      type: 'table',
-      name: tableKey,
-      tablePath: tablePath,
-      connection: this.name,
-      dialect: this.dialectName,
-      fields:
-        tableData.columns?.map((col: Column) => ({
-          name: col.name,
-          type: col.type,
-        })) || [],
-    } as TableSourceDef;
+    return JSON.parse(response.data.source as string) as TableSourceDef;
   }
 
   public async fetchSelectSchema(

--- a/packages/malloy-db-publisher/src/publisher_connection.unit.spec.ts
+++ b/packages/malloy-db-publisher/src/publisher_connection.unit.spec.ts
@@ -251,6 +251,17 @@ describe('db:Publisher', () => {
               {name: 'id', type: 'number'},
               {name: 'name', type: 'string'},
             ],
+            source: JSON.stringify({
+              type: 'table',
+              name: 'test_key',
+              tablePath: 'test_path',
+              connection: 'test-connection',
+              dialect: 'bigquery',
+              fields: [
+                {name: 'id', type: 'number'},
+                {name: 'name', type: 'string'},
+              ],
+            }),
           },
           status: 200,
           statusText: 'OK',
@@ -321,7 +332,11 @@ describe('db:Publisher', () => {
         };
 
         const mockInvalidResponse: AxiosResponse = {
-          data: {resource: 'invalid json', columns: null},
+          data: {
+            resource: 'invalid json',
+            columns: null,
+            source: 'invalid json',
+          },
           status: 200,
           statusText: 'OK',
           headers: {},
@@ -339,19 +354,9 @@ describe('db:Publisher', () => {
           accessToken: 'test-token',
         });
 
-        const schema = await connection.fetchTableSchema(
-          'test_key',
-          'test_path'
-        );
-
-        expect(schema).toEqual({
-          type: 'table',
-          name: 'test_key',
-          tablePath: 'test_path',
-          connection: 'test-connection',
-          dialect: 'bigquery',
-          fields: [],
-        });
+        await expect(
+          connection.fetchTableSchema('test_key', 'test_path')
+        ).rejects.toThrow(SyntaxError);
       });
     });
 


### PR DESCRIPTION
- Added MotherDuckConnection schema to the API documentation and updated the AttachedDatabase interface to include MotherDuck support.
- Modified fetchTableSchema method to parse the table source as a JSON string, improving schema retrieval.
- Expanded integration and unit tests to validate the new schema structure and ensure robust error handling for table schema fetching.