### PR TITLE
don't write errors to schema cache

### DIFF
--- a/packages/malloy/src/connection/base_connection.ts
+++ b/packages/malloy/src/connection/base_connection.ts
@@ -74,17 +74,19 @@ export abstract class BaseConnection implements Connection {
       try {
         const cacheResponse = await fillCache();
         if (typeof cacheResponse === 'string') {
-          cached = {error: cacheResponse};
+          // Don't cache errors - just return them
+          return {error: cacheResponse};
         } else {
           cached = {
             schema: cacheResponse,
             timestamp: refreshTimestamp ?? Date.now(),
           };
+          this.schemaCache[schemaKey] = cached;
         }
       } catch (uncaught) {
-        cached = {error: uncaught.message};
+        // Don't cache errors - just return them
+        return {error: uncaught.message};
       }
-      this.schemaCache[schemaKey] = cached;
     }
     if (cached.error) {
       return cached;


### PR DESCRIPTION
From slack:

> _It seems that schema cache lives forever within BaseConnection when the response is an error. Therefore, when a request for schema returns an error, Malloy can never recover without refreshing the connection. My problem started when in a server I built where a connection lives forever; when Trino hiccups and there's a schema fetch from Malloy, the next try fails too, even if Trino is already healthy. Once this cache behavior is implemented in the BaseConnection, I think this occurs in all other connections._

I think caching error responses was a mistake.