### PR TITLE
avoid compiler crash by catching error in translator

### DIFF
--- a/packages/malloy/src/lang/ast/source-properties/renames.ts
+++ b/packages/malloy/src/lang/ast/source-properties/renames.ts
@@ -53,6 +53,16 @@ export class RenameField extends MalloyElement implements Noteable, MakeEntry {
       );
       return;
     }
+
+    // Check if the new name would shadow an existing field
+    if (fs.entry(this.newName)) {
+      this.logError(
+        'invalid-rename-with-same-name',
+        `Can't rename to '${this.newName}', field already exists`
+      );
+      return;
+    }
+
     const oldValue = this.oldName.getField(fs);
     /*
 

--- a/packages/malloy/src/lang/test/source.spec.ts
+++ b/packages/malloy/src/lang/test/source.spec.ts
@@ -887,6 +887,21 @@ describe('source:', () => {
     test('rename', () => {
       expect('source: c is a extend { rename: nn is ai }').toTranslate();
     });
+    test('rename measure to existing field name causes error', () => {
+      expect(
+        markSource`
+          ##! experimental.access_modifiers
+          source: sales is a include {
+            private: *
+            public: astr, ad
+          } extend {
+            measure: af_sum is sum(af)
+          } extend {
+            rename: ${'af is af_sum'}
+          }
+        `
+      ).toLog(errorMessage("Can't rename to 'af', field already exists"));
+    });
     test('accept single', () => {
       const onlyAstr = new TestTranslator(
         'source: c is a extend { accept: astr }'


### PR DESCRIPTION
Renaming a measure to the same name as a private field it references creates a circular reference causing a stack overflow during SQL compilation.

Fixes #2579 