### PR TITLE
fix: maybeQuoteIdentifier incorrectly splits identifiers containing dots

### DIFF
--- a/packages/malloy-interfaces/src/util.ts
+++ b/packages/malloy-interfaces/src/util.ts
@@ -7,11 +7,8 @@ function shouldQuoteIdentifier(name: string) {
 }
 
 export function maybeQuoteIdentifier(name: string): string {
-  const path = name.split('.');
-  for (let i = 0; i < path.length; i++) {
-    if (shouldQuoteIdentifier(path[i])) {
-      path[i] = `\`${path[i]}\``;
-    }
+  if (shouldQuoteIdentifier(name)) {
+    return `\`${name}\``;
   }
-  return path.join('.');
+  return name;
 }

--- a/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
+++ b/packages/malloy/src/lang/test/malloy-to-stable-query.spec.ts
@@ -741,6 +741,122 @@ describe('Malloy to Stable Query', () => {
       });
     });
   });
+  describe('quoted identifiers', () => {
+    test('source name with dots is quoted as single identifier', () => {
+      idempotent('run: `foo.bar` -> { group_by: carrier }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'foo.bar',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('source name with hyphens and dots is quoted as single identifier', () => {
+      idempotent('run: `foo-bar.baz` -> { group_by: carrier }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'foo-bar.baz',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+    test('source name with colons is quoted as single identifier', () => {
+      idempotent('run: `foo:bar:baz` -> { group_by: carrier }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'foo:bar:baz',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+
+    test('field path with quoted segment containing dot', () => {
+      idempotent('run: a -> { group_by: `foo.bar`.baz }', {
+        query: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'a',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'group_by',
+                  field: {
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'baz',
+                      path: ['foo.bar'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        logs: [],
+      });
+    });
+  });
   describe('Render annotations', () => {
     test('single render annotation', () => {
       idempotent('# bar_chart\nrun: flights -> { group_by: carrier }', {


### PR DESCRIPTION
The function was splitting identifiers by '.' and quoting each segment individually, producing `foo-bar`.baz instead of `foo-bar.baz`.

This caused parsing errors when converting a query AST back to Malloy text via queryToMalloy(), as the parser interprets the split version as a path expression rather than a single quoted identifier.

Fixes https://github.com/malloydata/malloy/issues/2601