### PR TITLE
Add renderNumberCell helper for correct bigint display

### DIFF
--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -6,10 +6,7 @@
  */
 
 import type {JSXElement} from 'solid-js';
-import {
-  renderNumericField,
-  renderBigNumberField,
-} from '@/component/render-numeric-field';
+import {renderNumberCell} from '@/component/render-numeric-field';
 import {renderLink} from '@/component/render-link';
 import MalloyTable from '@/component/table/table';
 import {renderList} from '@/component/render-list';
@@ -54,12 +51,7 @@ export function applyRenderer(props: RendererProps) {
     switch (renderAs) {
       case 'cell': {
         if (dataColumn.isNumber()) {
-          // Use string value for precision when available (bigint/bigdecimal)
-          if (dataColumn.stringValue !== undefined) {
-            renderValue = renderBigNumberField(field, dataColumn.stringValue);
-          } else {
-            renderValue = renderNumericField(field, dataColumn.value);
-          }
+          renderValue = renderNumberCell(dataColumn);
         } else if (dataColumn.isString()) {
           renderValue = dataColumn.value;
         } else if (field.isTime()) {


### PR DESCRIPTION
## Summary

The addition of bigint support made rendering numbers more complex - code must check for `stringValue` to preserve precision for large integers. This PR consolidates that complexity into a single helper function.

- Add `renderNumberCell(cell)` - handles both regular numbers and bigints correctly, checking `stringValue` automatically for precision preservation
- Fix `renderBigNumberField` to preserve precision for currency formatting instead of converting to Number (which was lossy for bigints)
- Update `apply-renderer.tsx` to use the new helper

## Usage

Plugin authors should use:
```ts
import {renderNumberCell} from '@/component/render-numeric-field';
const displayValue = renderNumberCell(cell);
```

## Test plan

- [x] Build passes
- [x] Manual testing with bigint currency values