### PR TITLE
fix: pass isSpark to getXAxisSettings for spark bar charts

### DIFF
--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -241,7 +241,7 @@ export function generateBarChartVegaSpecV2(
     xField,
     parentField: explore,
     vegaConfig,
-    isSpark: false,
+    isSpark: chartSettings.isSpark,
   });
 
   // x axes across rows should auto share when distinct values <=20, unless user has explicitly set independent setting


### PR DESCRIPTION
## Summary
- Spark bar charts were broken - they rendered at full size instead of compact 180x28px
- The `size=spark` tag was correctly detected and stored in `chartSettings.isSpark`
- But it was hardcoded to `false` when passed to `getXAxisSettings()` at line 244
- One-line fix: pass `chartSettings.isSpark` instead of `false`

## Test plan
- [x] Verified in storybook: "sparks", "sparks_nested", and "size_sheet" stories now render spark bar charts correctly