### PR TITLE
refactor: consolidate BigNumberCell into NumberCell

### DIFF
--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -121,22 +121,6 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
       'timestamptz_type': 'TimestamptzType',
     },
   },
-  'BigNumberCell': {
-    'type': 'struct',
-    'name': 'BigNumberCell',
-    'fields': {
-      'number_value': {
-        'type': 'string',
-        'optional': false,
-        'array': false,
-      },
-      'subtype': {
-        'type': 'NumberSubtype',
-        'optional': true,
-        'array': false,
-      },
-    },
-  },
   'BooleanCell': {
     'type': 'struct',
     'name': 'BooleanCell',
@@ -215,7 +199,6 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
       'array_cell': 'ArrayCell',
       'null_cell': 'NullCell',
       'sql_native_cell': 'SQLNativeCell',
-      'big_number_cell': 'BigNumberCell',
     },
   },
   'CompileModelRequest': {
@@ -995,6 +978,11 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
       },
       'subtype': {
         'type': 'NumberSubtype',
+        'optional': true,
+        'array': false,
+      },
+      'string_value': {
+        'type': 'string',
         'optional': true,
         'array': false,
       },
@@ -1895,11 +1883,6 @@ export type AtomicTypeWithTimestamptzType = {
   kind: 'timestamptz_type';
 } & TimestamptzType;
 
-export type BigNumberCell = {
-  number_value: string;
-  subtype?: NumberSubtype;
-};
-
 export type BooleanCell = {
   boolean_value: boolean;
 };
@@ -1931,8 +1914,7 @@ export type CellType =
   | 'record_cell'
   | 'array_cell'
   | 'null_cell'
-  | 'sql_native_cell'
-  | 'big_number_cell';
+  | 'sql_native_cell';
 
 export type Cell =
   | CellWithStringCell
@@ -1944,8 +1926,7 @@ export type Cell =
   | CellWithRecordCell
   | CellWithArrayCell
   | CellWithNullCell
-  | CellWithSQLNativeCell
-  | CellWithBigNumberCell;
+  | CellWithSQLNativeCell;
 
 export type CellWithStringCell = {kind: 'string_cell'} & StringCell;
 
@@ -1966,8 +1947,6 @@ export type CellWithArrayCell = {kind: 'array_cell'} & ArrayCell;
 export type CellWithNullCell = {kind: 'null_cell'} & NullCell;
 
 export type CellWithSQLNativeCell = {kind: 'sql_native_cell'} & SQLNativeCell;
-
-export type CellWithBigNumberCell = {kind: 'big_number_cell'} & BigNumberCell;
 
 export type CompileModelRequest = {
   model_url: string;
@@ -2339,6 +2318,7 @@ export type NullLiteral = {};
 export type NumberCell = {
   number_value: number;
   subtype?: NumberSubtype;
+  string_value?: string;
 };
 
 export type NumberLiteral = {

--- a/packages/malloy-interfaces/thrift/malloy.thrift
+++ b/packages/malloy-interfaces/thrift/malloy.thrift
@@ -505,14 +505,9 @@ struct BooleanCell {
 struct NumberCell {
   1: required double number_value,
   2: optional NumberSubtype subtype,
-}
-
-// String representation for numbers that exceed JavaScript's Number.MAX_SAFE_INTEGER
-// or require precision beyond float64. Currently used for bigints (64-bit+ integers),
-// but designed to also support high-precision decimals in the future.
-struct BigNumberCell {
-  1: required string number_value,
-  2: optional NumberSubtype subtype,
+  // String representation for numbers that exceed JavaScript's Number.MAX_SAFE_INTEGER
+  // or require precision beyond float64. Used for bigints and future large decimals.
+  3: optional string string_value,
 }
 
 struct NullCell {}
@@ -553,7 +548,6 @@ union Cell {
   8: required ArrayCell array_cell,
   9: required NullCell null_cell,
   10: required SQLNativeCell sql_native_cell,
-  11: required BigNumberCell big_number_cell,
 }
 
 union Data {

--- a/packages/malloy-render/src/data_tree/cells/index.ts
+++ b/packages/malloy-render/src/data_tree/cells/index.ts
@@ -84,9 +84,7 @@ export const Cell = {
       }
       case 'null_cell':
         return new NullCell(cell, field, parent);
-      case 'number_cell':
-      // fallthrough
-      case 'big_number_cell': {
+      case 'number_cell': {
         if (field instanceof NumberField) {
           return new NumberCell(cell, field, parent);
         }

--- a/packages/malloy/src/api/util.ts
+++ b/packages/malloy/src/api/util.ts
@@ -112,14 +112,13 @@ export function mapData(data: QueryData, schema: Malloy.Schema): Malloy.Data {
       return {kind: 'boolean_cell', boolean_value: value};
     } else if (field.type.kind === 'number_type') {
       const subtype = field.type.subtype;
-      if (subtype === 'bigint') {
-        const stringValue = rowDataToSerializedBigint(value);
-        return {kind: 'big_number_cell', number_value: stringValue, subtype};
-      }
+      const stringValue =
+        subtype === 'bigint' ? rowDataToSerializedBigint(value) : undefined;
       return {
         kind: 'number_cell',
         number_value: rowDataToNumber(value),
         subtype,
+        string_value: stringValue,
       };
     } else if (field.type.kind === 'string_type') {
       if (typeof value !== 'string') {

--- a/packages/malloy/src/test/cellsToObject.ts
+++ b/packages/malloy/src/test/cellsToObject.ts
@@ -27,9 +27,11 @@ function cellToValue(cell: Malloy.Cell, fieldInfo: Malloy.FieldInfo): unknown {
     case 'string_cell':
       return cell.string_value;
     case 'number_cell':
+      // Return BigInt for bigint values (when string_value is present for precision)
+      if (cell.string_value !== undefined) {
+        return BigInt(cell.string_value);
+      }
       return cell.number_value;
-    case 'big_number_cell':
-      return BigInt(cell.number_value);
     case 'boolean_cell':
       return cell.boolean_value;
     case 'date_cell':


### PR DESCRIPTION
There is a piece of cruft in the thrift from the series of "big number" changes, I meant to remove it and forgot.

## Summary

- Remove separate `BigNumberCell` thrift struct and consolidate into `NumberCell` with optional `string_value` field
- Simplifies the data model while preserving bigint precision support
- Matches the existing `NumberLiteral` pattern which already uses `number_value` + optional `string_value`

## Changes

- **thrift**: Add `string_value` field to `NumberCell`, remove `BigNumberCell` struct and `big_number_cell` from Cell union
- **util.ts**: Always create `number_cell`, set `string_value` when subtype is `bigint`
- **renderer atomic.ts**: Simplify `NumberCell` class - read directly from cell instead of private fields
- **renderer index.ts**: Remove `big_number_cell` fallthrough case
- **test utilities**: Check `string_value !== undefined` instead of `cell.kind === 'big_number_cell'`

## Test plan

- [x] `npm run build` passes
- [x] `npm run test-duckdb` passes (2498 tests)
- [x] CI passes