### PR TITLE
fix(render): render plain arrays as comma-separated strings in table cells

### DIFF
--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -50,7 +50,28 @@ export function applyRenderer(props: RendererProps) {
   } else {
     switch (renderAs) {
       case 'cell': {
-        if (dataColumn.isNumber()) {
+        if (dataColumn.isArray()) {
+          // Plain array (e.g., string[], number[]) - render as comma-separated values
+          // with proper formatting for each element type
+          const renderedElements = dataColumn.values.map(elementCell => {
+            if (elementCell.isNull()) {
+              return NULL_SYMBOL;
+            } else if (elementCell.isNumber()) {
+              return renderNumberCell(elementCell);
+            } else if (elementCell.isTime()) {
+              return renderTime({
+                dataColumn: elementCell,
+                tag: elementCell.field.tag,
+                customProps,
+              });
+            } else if (elementCell.isString()) {
+              return elementCell.value;
+            } else {
+              return String(elementCell.value);
+            }
+          });
+          renderValue = renderedElements.join(', ');
+        } else if (dataColumn.isNumber()) {
           renderValue = renderNumberCell(dataColumn);
         } else if (dataColumn.isString()) {
           renderValue = dataColumn.value;
@@ -99,12 +120,6 @@ export function applyRenderer(props: RendererProps) {
       case 'table': {
         if (dataColumn.isRecordOrRepeatedRecord()) {
           renderValue = <MalloyTable data={dataColumn} {...propsToPass} />;
-        } else if (dataColumn.isArray()) {
-          // Plain array (e.g., string[]) - render as cell with comma-separated values
-          const values = dataColumn.values.map(cell => cell.value);
-          renderValue = values.join(', ');
-          // Return 'cell' so it gets proper cell wrapper styling
-          return {renderAs: 'cell', renderValue};
         } else {
           throw new Error(
             `Malloy render: wrong data type passed to the table renderer for field ${field.name}`

--- a/packages/malloy-render/src/data_tree/utils.ts
+++ b/packages/malloy-render/src/data_tree/utils.ts
@@ -151,7 +151,10 @@ export function shouldRenderAs({
     return 'none';
   }
 
-  const isNest = field instanceof ArrayField || field instanceof RecordField;
+  // RepeatedRecordField and RecordField render as tables
+  // Plain ArrayField (e.g., string[], number[]) renders as cell with comma-separated values
+  const isNest =
+    field instanceof RepeatedRecordField || field instanceof RecordField;
 
   const result = !isNest ? 'cell' : 'table';
   return result;

--- a/packages/malloy-render/src/stories/tables.stories.malloy
+++ b/packages/malloy-render/src/stories/tables.stories.malloy
@@ -365,22 +365,29 @@ source: sparse_pivot is duckdb.sql(
   }
 }
 
-// Test rendering of plain string arrays (not struct arrays)
+// Test rendering of plain arrays (not struct arrays)
+// Tests string[], number[], date[], and arrays with null elements
 source: array_test is duckdb.sql("""
   SELECT
     'Movie 1' as title,
     ['Action', 'Comedy'] as genres,
-    ['Tom Hanks', 'Robin Wright'] as cast_names
+    ['Tom Hanks', 'Robin Wright'] as cast_names,
+    [85, 92, 78] as ratings,
+    [DATE '2020-01-15', DATE '2020-06-20'] as release_dates
   UNION ALL
   SELECT
     'Movie 2' as title,
     ['Drama'] as genres,
-    ['Brad Pitt'] as cast_names
+    ['Brad Pitt'] as cast_names,
+    [95] as ratings,
+    [DATE '2019-05-10'] as release_dates
   UNION ALL
   SELECT
     'Movie 3' as title,
     ['Action', 'Sci-Fi', 'Thriller'] as genres,
-    ['Keanu Reeves', 'Carrie-Anne Moss', 'Laurence Fishburne'] as cast_names
+    ['Keanu Reeves', 'Carrie-Anne Moss', 'Laurence Fishburne'] as cast_names,
+    [88, 91, 85, 90] as ratings,
+    [DATE '1999-03-31', DATE '2003-05-15', DATE '2021-12-22'] as release_dates
 """) extend {
   #(story) story="String Array Columns"
   view: string_array_column is {
@@ -391,5 +398,58 @@ source: array_test is duckdb.sql("""
   view: string_array_group_by is {
     group_by: genres
     aggregate: movie_count is count()
+  }
+
+  #(story) story="Number Array Columns"
+  view: number_array_column is {
+    select: title, ratings
+  }
+
+  #(story) story="Date Array Columns"
+  view: date_array_column is {
+    select: title, release_dates
+  }
+
+  #(story) story="Mixed Array Types"
+  view: mixed_array_types is {
+    select: title, genres, ratings, release_dates
+  }
+}
+
+// Test arrays with null elements
+source: array_null_test is duckdb.sql("""
+  SELECT
+    'Test 1' as name,
+    ['a', NULL, 'b'] as string_with_null,
+    [1, NULL, 3] as number_with_null,
+    [DATE '2020-01-01', NULL, DATE '2020-03-01'] as date_with_null
+  UNION ALL
+  SELECT
+    'Test 2' as name,
+    [NULL, 'only'] as string_with_null,
+    [NULL, 42, NULL] as number_with_null,
+    [NULL] as date_with_null
+""") extend {
+  #(story) story="Arrays With Null Elements"
+  view: arrays_with_nulls is {
+    select: name, string_with_null, number_with_null, date_with_null
+  }
+}
+
+// Test timestamp arrays
+source: array_timestamp_test is duckdb.sql("""
+  SELECT
+    'Event 1' as event_name,
+    [TIMESTAMP '2024-01-15 10:30:00', TIMESTAMP '2024-01-15 14:45:30'] as timestamps,
+    [TIMESTAMP '2024-06-01 09:00:00', NULL, TIMESTAMP '2024-06-03 17:30:00'] as timestamps_with_null
+  UNION ALL
+  SELECT
+    'Event 2' as event_name,
+    [TIMESTAMP '2023-12-31 23:59:59'] as timestamps,
+    [TIMESTAMP '2023-11-01 08:00:00', TIMESTAMP '2023-11-02 08:00:00'] as timestamps_with_null
+""") extend {
+  #(story) story="Timestamp Array Columns"
+  view: timestamp_array_column is {
+    select: event_name, timestamps, timestamps_with_null
   }
 }


### PR DESCRIPTION
- Fixes rendering of plain array types (e.g., `string[]`, `number[]`, `date[]`) in table cells
   - Previously, grouping by an array field would show a pink/red error square because `applyRenderer` only
    handled `RepeatedRecord` (array of structs) for the `'table'` render mode
   - Now plain arrays render as comma-separated values with proper element formatting and cell styling

   ## Changes

   - **Changed default `renderAs()` routing** in `utils.ts`: Plain `ArrayField` now defaults to `'cell'`
   while `RepeatedRecordField` and `RecordField` continue to default to `'table'`
   - **Added array handling in the `'cell'` case** of `applyRenderer()`:
     - Numbers use `renderNumberCell()` for proper formatting (currency, percent, etc.)
     - Dates/timestamps use `renderTime()` for proper date formatting
     - Null elements display as `∅` symbol
     - Values joined with comma separator
   - **Added comprehensive Storybook tests**:
     - String array columns and group-by
     - Number array columns
     - Date and timestamp array columns
     - Arrays with null elements (displays `∅`)
  
## Test plan

- [x] Storybook: `string_array_column` story renders arrays correctly
- [x] Storybook: `string_array_group_by` story renders grouped arrays correctly
- [x] VS Code: Tested with imdb dataset using:
  ```malloy
  view: by_genre is {
    group_by: genres
    aggregate: 
      title_count, 
      total_ratings
      percent_of_titles
  }
  ```

before, this query shows a red box if i run it: 
<img width="897" height="268" alt="errorArrayStrings" src="https://github.com/user-attachments/assets/50370e85-919f-40ee-bd10-136549b93396" />

After the fix (tested in vs code local build) - we can see the array of string values:
<img width="1258" height="307" alt="fixedArrayStrings" src="https://github.com/user-attachments/assets/653fa335-0efb-41c5-aaad-ec0504b02428" />
