### PR TITLE
refactor(render): consolidate cell rendering into shared utility

### DIFF
--- a/packages/malloy-render/src/component/cell-utils.ts
+++ b/packages/malloy-render/src/component/cell-utils.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Cell} from '../data_tree';
+import type {Tag} from '@malloydata/malloy-tag';
+import {NULL_SYMBOL} from '../util';
+import {renderNumberCell, renderDateTimeField} from './render-numeric-field';
+
+export interface RenderCellValueOptions {
+  /**
+   * Value to return for null cells.
+   * Defaults to NULL_SYMBOL ('∅').
+   */
+  nullValue?: string;
+  /**
+   * Override tag for formatting.
+   * Use this when rendering array elements - pass the array field's tag
+   * so formatting (currency, percent, etc.) is applied from the array definition.
+   * If not provided, uses the cell's own field tag.
+   */
+  tag?: Tag;
+}
+
+/**
+ * Render a Cell value to a formatted display string.
+ *
+ * Handles all cell types with appropriate formatting:
+ * - Numbers: uses renderNumberCell (handles bigint precision + formatting tags)
+ * - Dates: uses renderDateTimeField with isDate: true
+ * - Timestamps: uses renderDateTimeField with isDate: false
+ * - Strings: returns value directly
+ * - Booleans: returns 'true' or 'false'
+ * - Null: returns nullValue option (defaults to NULL_SYMBOL)
+ *
+ * @example
+ * // Basic usage (pivot headers, etc.)
+ * renderCellValue(cell)
+ *
+ * @example
+ * // Array elements - use array field's tag for formatting
+ * renderCellValue(elementCell, { tag: arrayField.tag })
+ *
+ * @example
+ * // Custom null display
+ * renderCellValue(cell, { nullValue: '' })
+ */
+export function renderCellValue(
+  cell: Cell,
+  options: RenderCellValueOptions = {}
+): string {
+  const {nullValue = NULL_SYMBOL, tag} = options;
+
+  if (cell.isNull()) {
+    return nullValue;
+  }
+
+  if (cell.isNumber()) {
+    return renderNumberCell(cell, tag);
+  }
+
+  if (cell.isDate()) {
+    return renderDateTimeField(
+      cell.field,
+      cell.value,
+      {
+        isDate: true,
+        timeframe: cell.timeframe,
+      },
+      tag
+    );
+  }
+
+  if (cell.isTimestamp()) {
+    return renderDateTimeField(
+      cell.field,
+      cell.value,
+      {
+        isDate: false,
+        timeframe: cell.timeframe,
+      },
+      tag
+    );
+  }
+
+  if (cell.isBoolean()) {
+    return String(cell.value);
+  }
+
+  if (cell.isString()) {
+    return cell.value;
+  }
+
+  // Fallback for any other types
+  return String(cell.value);
+}

--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -6,17 +6,16 @@
  */
 
 import type {JSXElement} from 'solid-js';
-import {renderNumberCell} from '@/component/render-numeric-field';
 import {renderLink} from '@/component/render-link';
 import MalloyTable from '@/component/table/table';
 import {renderList} from '@/component/render-list';
 import {renderImage} from '@/component/render-image';
 import {Dashboard} from '@/component/dashboard/dashboard';
-import {renderTime} from '@/component/render-time';
 import {LegacyChart} from '@/component/legacy-charts/legacy_chart';
 import {NULL_SYMBOL} from '@/util';
 import type {RendererProps} from '@/component/types';
 import {PluginRenderContainer} from '@/component/renderer/plugin-render-container';
+import {renderCellValue} from '@/component/cell-utils';
 
 export function applyRenderer(props: RendererProps) {
   const {dataColumn, customProps = {}} = props;
@@ -52,34 +51,14 @@ export function applyRenderer(props: RendererProps) {
       case 'cell': {
         if (dataColumn.isArray()) {
           // Plain array (e.g., string[], number[]) - render as comma-separated values
-          // with proper formatting for each element type
-          const renderedElements = dataColumn.values.map(elementCell => {
-            if (elementCell.isNull()) {
-              return NULL_SYMBOL;
-            } else if (elementCell.isNumber()) {
-              return renderNumberCell(elementCell);
-            } else if (elementCell.isTime()) {
-              return renderTime({
-                dataColumn: elementCell,
-                tag: elementCell.field.tag,
-                customProps,
-              });
-            } else if (elementCell.isString()) {
-              return elementCell.value;
-            } else {
-              return String(elementCell.value);
-            }
-          });
+          // Use the array field's tag for formatting (currency, percent, etc.)
+          const arrayTag = field.tag;
+          const renderedElements = dataColumn.values.map(elementCell =>
+            renderCellValue(elementCell, {tag: arrayTag})
+          );
           renderValue = renderedElements.join(', ');
-        } else if (dataColumn.isNumber()) {
-          renderValue = renderNumberCell(dataColumn);
-        } else if (dataColumn.isString()) {
-          renderValue = dataColumn.value;
-        } else if (field.isTime()) {
-          renderValue = renderTime(props);
         } else {
-          // try to force to string
-          renderValue = String(dataColumn.value);
+          renderValue = renderCellValue(dataColumn);
         }
         break;
       }

--- a/packages/malloy-render/src/component/table/pivot-header.tsx
+++ b/packages/malloy-render/src/component/table/pivot-header.tsx
@@ -4,9 +4,9 @@
  */
 
 import {For} from 'solid-js';
-import type {Cell, Field} from '../../data_tree';
+import type {Field} from '../../data_tree';
 import type {PivotConfig, PivotedField} from './pivot-utils';
-import {renderNumberCell, renderDateTimeField} from '../render-numeric-field';
+import {renderCellValue} from '../cell-utils';
 
 /**
  * Info about a sibling field (non-pivot field at same depth as pivot).
@@ -15,45 +15,6 @@ export type SiblingFieldInfo = {
   field: Field;
   startColumn: number;
   endColumn: number;
-};
-
-/**
- * Renders a cell value for display in pivot dimension headers.
- * Uses proper formatting based on cell type and field tags.
- */
-const renderPivotDimensionValue = (cell: Cell): string => {
-  if (cell.isNull()) {
-    return '';
-  }
-
-  // Number cells: use renderNumberCell which handles bigint and formatting tags
-  if (cell.isNumber()) {
-    return renderNumberCell(cell);
-  }
-
-  // Date cells: use renderDateTimeField with date options
-  if (cell.isDate()) {
-    return renderDateTimeField(cell.field, cell.value, {
-      isDate: true,
-      timeframe: cell.timeframe,
-    });
-  }
-
-  // Timestamp cells: use renderDateTimeField with timestamp options
-  if (cell.isTimestamp()) {
-    return renderDateTimeField(cell.field, cell.value, {
-      isDate: false,
-      timeframe: cell.timeframe,
-    });
-  }
-
-  // Boolean: display as true/false
-  if (cell.isBoolean()) {
-    return String(cell.value);
-  }
-
-  // String and other types: use value directly
-  return String(cell.value);
 };
 
 /**
@@ -70,7 +31,7 @@ const PivotDimensionHeaderRow = (props: {
     const parts: string[] = [];
     for (const dimValue of pf.values) {
       if (dimValue && !dimValue.isNull()) {
-        parts.push(renderPivotDimensionValue(dimValue));
+        parts.push(renderCellValue(dimValue, {nullValue: ''}));
       }
     }
     return parts.join(', ') || '';


### PR DESCRIPTION
## Summary

- Create `cell-utils.ts` with `renderCellValue()` function for unified cell formatting
- Add `tagOverride` parameter to render-numeric-field functions to support array element formatting  
- Refactor `apply-renderer.tsx` to use `renderCellValue`, simplifying array and cell handling
- Refactor `pivot-header.tsx` to use `renderCellValue`, removing duplicate logic
- Fix `malloy-to-json.ts` script URL handling and readline close behavior

## Details

This consolidates duplicate cell rendering logic from pivot headers and array rendering into a shared utility. The new `renderCellValue()` function handles all cell types (number, string, boolean, date, timestamp) with proper formatting.

The `tagOverride` parameter enables array elements to inherit formatting tags (like `# currency`) from their parent array field, which will be used once translator annotation bugs are fixed in a follow-up PR.

## Test plan

- [x] Build passes
- [x] Existing storybook stories render correctly
- [x] Pivot tables format dimension values properly
- [x] Array columns render as comma-separated values