### PR TITLE
fix: handle DDL statements in Result.toJSON()

### DIFF
--- a/packages/malloy/src/malloy.ts
+++ b/packages/malloy/src/malloy.ts
@@ -1407,6 +1407,14 @@ export class PreparedResult implements Taggable {
   public get _sourceFilters(): FilterCondition[] {
     return this.inner.sourceFilters || [];
   }
+
+  /**
+   * @return Whether this result has a schema. DDL statements (INSTALL, LOAD,
+   * CREATE SECRET, etc.) do not return a schema.
+   */
+  public get hasSchema(): boolean {
+    return this.inner.structs.length > 0;
+  }
 }
 
 /**
@@ -3391,6 +3399,14 @@ export class Result extends PreparedResult {
   }
 
   public toJSON(): ResultJSON {
+    // DDL statements (INSTALL, LOAD, CREATE SECRET, etc.) don't have a schema,
+    // so we can't call this.data.toJSON() which requires resultExplore.
+    if (!this.hasSchema) {
+      return {
+        queryResult: this.inner,
+        modelDef: this._modelDef,
+      };
+    }
     // The result rows are converted to JSON separately because they
     // may contain un-serializable data types.
     return {


### PR DESCRIPTION
## Summary

- Add `hasSchema` getter to `PreparedResult` to check if result has a schema
- Update `Result.toJSON()` to handle schema-less results gracefully

DDL statements (INSTALL, LOAD, CREATE SECRET, etc.) don't return a result schema. Previously, calling `toJSON()` on these results would throw "Malformed query result" because `resultExplore` requires a non-empty `structs` array.

This fix allows consumers (like the VS Code extension) to safely call `toJSON()` on any result without needing to check internal implementation details.

Related: https://github.com/malloydata/malloy-vscode-extension/pull/717

## Test plan

- [ ] Run DDL statements in MalloySQL notebook (INSTALL, LOAD, CREATE SECRET)
- [ ] Verify `toJSON()` returns valid object without throwing
- [ ] Verify normal queries still work as expected