### PR TITLE
fix: clone filterList when extending source to prevent mutation

### DIFF
--- a/packages/malloy/src/lang/ast/source-elements/refined-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/refined-source.ts
@@ -168,7 +168,8 @@ export class RefinedSource extends Source {
     fs.addNotes(thisIncludeState.notes);
     const retStruct = fs.structDef();
 
-    const filterList = retStruct.filterList || [];
+    // Clone the filterList to avoid mutating the original source's filters
+    const filterList = retStruct.filterList ? [...retStruct.filterList] : [];
     let moreFilters = false;
     for (const filter of filters) {
       for (const el of filter.list) {


### PR DESCRIPTION
## Problem

When extending a source with a filter that references a joined field, the filter was incorrectly being added to the **original** source's `filterList`. This caused queries on the original source to fail at runtime with:

```
Unrecognized name: <join_alias>_0
```

### Root Cause

In `RefinedSource.withParameters()`, line 171 was:
```typescript
const filterList = retStruct.filterList || [];
```

When `retStruct.filterList` existed (inherited via shallow copy from the original source), this got a reference to the shared array. The subsequent `filterList.push()` then mutated the original source's `filterList`.

## Fix

Clone the array before pushing:
```typescript
const filterList = retStruct.filterList ? [...retStruct.filterList] : [];
```

## Tests

Added two translator tests in `source.spec.ts`:
1. Verify original source's filterList count unchanged after extending
2. Verify multiple extensions don't affect each other's filterLists

## Supersedes #2630

Same fix, but tests moved from `test/src/databases/all/` to translator test suite (`packages/malloy/src/lang/test/source.spec.ts`) so they run once rather than per-dialect.