### PR TITLE
Use slim Presto image in CI to reduce job time

### DIFF
--- a/.github/workflows/db-presto.yaml
+++ b/.github/workflows/db-presto.yaml
@@ -25,7 +25,7 @@ jobs:
           npm ci --loglevel error
           npm run build
           npm run build-duckdb-db
-          ./test/presto/presto_start.sh
+          ./test/presto/presto_start.sh --slim
           npm run ci-presto
           ./test/presto/presto_stop.sh
         env:

--- a/test/presto/Dockerfile.slim
+++ b/test/presto/Dockerfile.slim
@@ -1,0 +1,48 @@
+# Slim Presto image for Malloy CI testing
+#
+# This image is ~850MB vs ~9GB for the official prestodb/presto image.
+# It includes only what's needed to run Presto with the BigQuery connector.
+#
+# How this was created:
+# 1. The official prestodb/presto:0.287 image contains 42 connector plugins (~2GB)
+#    but we only need presto-bigquery (~36MB)
+# 2. We use eclipse-temurin as the base because:
+#    - Presto requires Java 11 (not newer - tested, Java 17 fails with classloading errors)
+#    - Presto requires full JDK (not JRE - needs com.sun.tools.attach classes)
+# 3. Python is required because the Presto launcher (bin/launcher) is a Python script
+#
+# To update when Presto version changes:
+# 1. Update the PRESTO_VERSION arg below
+# 2. Verify Java version compatibility (check: docker run --rm prestodb/presto:X.XXX java -version)
+# 3. Test locally: ./test/presto/presto_start.sh --slim && npm run ci-presto
+#
+# Size comparison (as of 0.287):
+#   Official image: 9.11 GB
+#   This slim image: ~850 MB
+
+ARG PRESTO_VERSION=0.287
+
+# Stage to reference the official Presto image
+FROM prestodb/presto:${PRESTO_VERSION} AS presto-official
+
+FROM eclipse-temurin:11-jdk-jammy
+
+# Install Python for the launcher script
+RUN apt-get update && apt-get install -y --no-install-recommends python3 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PRESTO_HOME=/opt/presto-server
+
+# Copy Presto server core
+COPY --from=presto-official /opt/presto-server/lib /opt/presto-server/lib
+COPY --from=presto-official /opt/presto-server/bin /opt/presto-server/bin
+COPY --from=presto-official /opt/presto-server/etc /opt/presto-server/etc
+
+# Copy only BigQuery plugin (the only connector we use for testing)
+COPY --from=presto-official /opt/presto-server/plugin/presto-bigquery /opt/presto-server/plugin/presto-bigquery
+
+EXPOSE 8080
+
+WORKDIR /opt/presto-server
+CMD ["./bin/launcher", "run"]

--- a/test/presto/presto_start.sh
+++ b/test/presto/presto_start.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRESTO_VERSION=0.287
+USE_SLIM=false
+
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --slim)
+      USE_SLIM=true
+      shift
+      ;;
+  esac
+done
+
 rm -rf .tmp
 mkdir .tmp
 
@@ -13,8 +27,22 @@ bigquery.project-id=advance-lacing-417917
 bigquery.credentials-key=$BQ_CREDENTIALS_KEY
 EOF
 
+# Select image
+if [ "$USE_SLIM" = true ]; then
+  PRESTO_IMAGE="presto-slim:${PRESTO_VERSION}"
+  # Build slim image if it doesn't exist
+  if ! docker image inspect "$PRESTO_IMAGE" > /dev/null 2>&1; then
+    echo "Building slim Presto image..."
+    docker build -f "$SCRIPT_DIR/Dockerfile.slim" \
+      --build-arg PRESTO_VERSION="$PRESTO_VERSION" \
+      -t "$PRESTO_IMAGE" "$SCRIPT_DIR"
+  fi
+else
+  PRESTO_IMAGE="prestodb/presto:${PRESTO_VERSION}"
+fi
+
 # run docker
-docker run -p ${PRESTO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-pesto.properties:/opt/presto-server/etc/catalog/bigquery.properties --name presto-malloy prestodb/presto:0.287
+docker run -p ${PRESTO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-pesto.properties:/opt/presto-server/etc/catalog/bigquery.properties --name presto-malloy "$PRESTO_IMAGE"
 
 # wait for server to start
 counter=0


### PR DESCRIPTION
## Summary
- Add slim Presto Docker image (~850MB vs 9GB official image)
- Add `--slim` flag to `presto_start.sh` to use the slim image
- Update CI to use `--slim` for faster builds

## Background
The Presto CI job was taking ~30 minutes, with ~24 minutes spent just downloading the 9GB official image. The official image includes 42 connector plugins, but we only need BigQuery.

The slim image includes:
- Eclipse Temurin Java 11 (same version as official)
- Presto server core (~77MB)
- BigQuery plugin only (~36MB)
- Python (for launcher script)

## Expected improvement
| Metric | Before | After |
|--------|--------|-------|
| Image size | 9.11 GB | ~850 MB |
| Image pull time | ~24 min | ~2-3 min |
| Total job time | ~30 min | ~8-10 min |

## Test plan
- [x] Built slim image locally
- [x] Ran `npm run ci-presto` against slim image - all 771 tests pass
- [x] CI runs with slim image