### PR TITLE
Auto-generate GitHub Release notes on npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,8 @@ jobs:
       - db-snowflake
       - main
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,9 +60,8 @@ jobs:
           done
           # Make sure we're current
           git pull origin $BRANCH_NAME
-          # Tag current version
-          git tag v$VERSION
-          git push origin v$VERSION
+          # Create GitHub Release with auto-generated notes from PRs
+          gh release create v$VERSION --generate-notes --title "v$VERSION"
           # Bump version
           npx lerna version patch --exact --yes --no-push --no-git-tag-version
           # Fix up package-lock.json
@@ -75,3 +76,4 @@ jobs:
           CI: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BRANCH_NAME: main
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Replace manual `git tag` + `git push` with `gh release create --generate-notes`
- Automatically generates release notes from merged PR titles when publishing to npm
- Creates a GitHub Release entity visible on the Releases page

## Test plan
- [ ] Trigger the "npmjs.com Release" workflow manually
- [ ] Verify GitHub Release is created with auto-generated notes
- [ ] Check the Releases page shows the new release with PR summaries