### PR TITLE
Cache QueryModel at the Model level

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint-fix": "gts fix",
     "test": "echo 'npm run test' not supported, see test/README.md for details ; exit 1",
     "test-publisher": "MALLOY_DATABASE=publisher jest",
-    "test-duckdb": "MALLOY_DATABASE=duckdb JEST_SILENT_REPORTER_SHOW_PATHS=true jest --reporters jest-silent-reporter summary",
+    "test-duckdb": "MALLOY_DATABASE=duckdb JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects malloy-core malloy-render db-all db-duckdb db-duckdb-core --reporters jest-silent-reporter summary",
     "ci-core": "JEST_SILENT_REPORTER_SHOW_PATHS=true jest --reporters --selectProjects malloy-core malloy-render --reporters jest-silent-reporter summary --runInBand",
     "ci-bigquery": "MALLOY_DATABASE=bigquery JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects db-all db-bigquery --reporters jest-silent-reporter summary",
     "ci-duckdb-wasm": "MALLOY_DATABASE=duckdb_wasm JEST_SILENT_REPORTER_SHOW_PATHS=true jest --selectProjects db-all db-duckdb --reporters jest-silent-reporter summary --runInBand",

--- a/packages/malloy/src/lang/ast/types/document-compile-result.ts
+++ b/packages/malloy/src/lang/ast/types/document-compile-result.ts
@@ -28,4 +28,5 @@ import type {ModelDataRequest} from '../../translate-response';
 export interface DocumentCompileResult {
   modelDef: ModelDef;
   needs: ModelDataRequest;
+  modelWasModified: boolean;
 }

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -510,6 +510,7 @@ export class Document extends MalloyElement implements NameSpace {
   queryList: Query[] = [];
   statements: DocStatementList;
   didInitModel = false;
+  modelWasModified = false;
   annotation: Annotation = {};
   experiments = new Tag({});
 
@@ -565,6 +566,7 @@ export class Document extends MalloyElement implements NameSpace {
         queryList: this.queryList,
       },
       needs,
+      modelWasModified: this.modelWasModified,
     };
     return ret;
   }
@@ -630,6 +632,11 @@ export class Document extends MalloyElement implements NameSpace {
     }
     if (isSourceDef(ent.entry)) {
       this.checkExperimentalDialect(this, ent.entry.dialect);
+    }
+
+    // Track if the model was modified after initialization
+    if (this.didInitModel) {
+      this.modelWasModified = true;
     }
 
     this.documentModel[str] = ent;

--- a/packages/malloy/src/lang/parse-malloy.ts
+++ b/packages/malloy/src/lang/parse-malloy.ts
@@ -567,6 +567,7 @@ class TranslateStep implements TranslationStep {
         modelDef: pretranslate,
         final: true,
         fromSources: that.getDependencies(),
+        modelWasModified: false,
       };
     }
 
@@ -606,6 +607,7 @@ class TranslateStep implements TranslationStep {
           };
         } else {
           that.modelDef = docCompile.modelDef;
+          that.modelWasModified = docCompile.modelWasModified;
         }
       } else {
         that.root.logError(
@@ -630,6 +632,7 @@ class TranslateStep implements TranslationStep {
           imports: [...that.imports],
         },
         fromSources: that.getDependencies(),
+        modelWasModified: that.modelWasModified,
         ...that.problemResponse(),
         final: true,
       };
@@ -643,6 +646,7 @@ export abstract class MalloyTranslation {
   childTranslators: Map<string, MalloyTranslation>;
   sqlSources: SQLSourceDef[] = [];
   modelDef: ModelDef;
+  modelWasModified = false;
   imports: ImportLocation[] = [];
   compilerFlags = new Tag();
 

--- a/packages/malloy/src/lang/test/model-was-modified.spec.ts
+++ b/packages/malloy/src/lang/test/model-was-modified.spec.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {TestTranslator} from './test-translator';
+import './parse-expects';
+
+/**
+ * Tests for the modelWasModified flag in the translator output.
+ *
+ * The translator outputs:
+ * 1. A ModelDef (the compiled model with sources, queries, exports)
+ * 2. A queryList (unnamed queries from `run:` statements)
+ * 3. modelWasModified flag - true if the model was modified during translation
+ *
+ * The modelWasModified flag is used by the Model caching system to determine
+ * if we can reuse the input model's cached QueryModel, or if we need to
+ * create a new Model with the updated ModelDef.
+ */
+describe('modelWasModified flag', () => {
+  describe('should be false when only running queries', () => {
+    test('run query against existing source', () => {
+      const tt = new TestTranslator('run: a -> { group_by: astr }');
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(false);
+      // Query should be in queryList
+      expect(result.modelDef?.queryList.length).toBe(1);
+    });
+
+    test('run query with filter against existing source', () => {
+      const tt = new TestTranslator(
+        "run: a -> { where: astr = 'x' group_by: astr }"
+      );
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(false);
+    });
+
+    test('run query using existing view', () => {
+      const tt = new TestTranslator('run: ab -> aturtle');
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(false);
+    });
+
+    test('run multiple queries', () => {
+      const tt = new TestTranslator(`
+        run: a -> { group_by: astr }
+        run: ab -> { aggregate: acount }
+      `);
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(false);
+      expect(result.modelDef?.queryList.length).toBe(2);
+    });
+
+    test('run query with pipeline', () => {
+      const tt = new TestTranslator(`
+        run: a -> { group_by: astr; aggregate: c is count() }
+             -> { where: c > 10 select: * }
+      `);
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(false);
+    });
+  });
+
+  describe('should be true when adding new definitions', () => {
+    test('define new source', () => {
+      const tt = new TestTranslator(`
+        source: new_source is a extend {
+          dimension: new_dim is concat(astr, 'x')
+        }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(true);
+      expect(result.modelDef?.contents['new_source']).toBeDefined();
+    });
+
+    test('define named query', () => {
+      const tt = new TestTranslator(`
+        query: my_query is a -> { group_by: astr }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(true);
+      expect(result.modelDef?.contents['my_query']).toBeDefined();
+    });
+
+    test('define source then run query', () => {
+      const tt = new TestTranslator(`
+        source: new_source is a
+        run: new_source -> { group_by: astr }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(true);
+    });
+
+    test('extend existing source', () => {
+      const tt = new TestTranslator(`
+        source: extended_a is a extend {
+          measure: my_count is count()
+        }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef).toBeDefined();
+      expect(result.modelWasModified).toBe(true);
+    });
+  });
+
+  describe('queryList population', () => {
+    test('run statements populate queryList', () => {
+      const tt = new TestTranslator(`
+        run: a -> { group_by: astr }
+        run: ab -> { aggregate: acount }
+      `);
+      const result = tt.translate();
+      expect(result.modelDef?.queryList.length).toBe(2);
+    });
+
+    test('named queries do not populate queryList', () => {
+      const tt = new TestTranslator(`
+        query: q1 is a -> { group_by: astr }
+        query: q2 is ab -> { aggregate: acount }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef?.queryList.length).toBe(0);
+      expect(result.modelDef?.contents['q1']).toBeDefined();
+      expect(result.modelDef?.contents['q2']).toBeDefined();
+    });
+
+    test('mixed named and run queries', () => {
+      const tt = new TestTranslator(`
+        query: named_q is a -> { group_by: astr }
+        run: ab -> { aggregate: acount }
+      `);
+      expect(tt).toTranslate();
+      const result = tt.translate();
+      expect(result.modelDef?.queryList.length).toBe(1);
+      expect(result.modelDef?.contents['named_q']).toBeDefined();
+      expect(result.modelWasModified).toBe(true); // named query adds to model
+    });
+  });
+});

--- a/packages/malloy/src/lang/translate-response.ts
+++ b/packages/malloy/src/lang/translate-response.ts
@@ -122,6 +122,7 @@ interface TranslatedResponseData
     FinalResponse {
   modelDef: ModelDef;
   fromSources: string[];
+  modelWasModified: boolean;
 }
 
 interface TablePath

--- a/packages/malloy/src/model/constant_expression_compiler.ts
+++ b/packages/malloy/src/model/constant_expression_compiler.ts
@@ -110,11 +110,13 @@ class ConstantQueryStruct extends QueryStruct {
       dialect: dialect.name,
     };
 
-    // Create a minimal model interface that only provides eventStream
-    const minimalModel: ModelRootInterface = {eventStream};
+    // Create minimal model with empty structs map
+    const minimalModel: ModelRootInterface = {
+      structs: new Map(),
+    };
 
-    // Create minimal prepare result options
-    const minimalPrepareOptions: PrepareResultOptions = {};
+    // Create minimal prepare result options with eventStream
+    const minimalPrepareOptions: PrepareResultOptions = {eventStream};
 
     // Call parent constructor with minimal requirements
     super(
@@ -126,9 +128,6 @@ class ConstantQueryStruct extends QueryStruct {
 
     this.dialect = dialect;
     this._constantArguments = parameters;
-    if (eventStream) {
-      this.model.eventStream = eventStream;
-    }
   }
 
   /**

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -30,17 +30,10 @@ import {QueryQuery} from './query_query';
 import {FieldInstanceField} from './field_instance';
 import {QueryModelImpl} from './query_model_impl';
 
-// We have a circular dependency issue, and this is the minimal
-// dependency injection needed to get around it. Ideally, we would
-// like to avoid this, and I think a thoughtful pass through
-// FieldInstance and QueryField might eliminate the need for this.
 function getLookupFun(
   mri: ModelRootInterface
 ): (name: string) => QueryStruct | undefined {
-  if (mri instanceof QueryModelImpl) {
-    return (name: string) => mri.structs.get(name);
-  }
-  return () => undefined;
+  return (name: string) => mri.structs.get(name);
 }
 
 FieldInstanceField.registerExpressionCompiler(exprToSQL);

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -23,6 +23,7 @@
  */
 
 import type * as Malloy from '@malloydata/malloy-interfaces';
+import type {EventStream} from '../runtime_types';
 
 // clang-format off
 
@@ -1904,6 +1905,7 @@ export interface PrepareResultOptions {
   materializedTablePrefix?: string;
   defaultRowLimit?: number;
   isPartialQuery?: boolean; // Query is being used as a sql_block
+  eventStream?: EventStream;
 }
 
 type UTD =

--- a/packages/malloy/src/model/query_model_impl.ts
+++ b/packages/malloy/src/model/query_model_impl.ts
@@ -20,7 +20,6 @@ import type {
 import {isSourceDef, getIdentifier, isAtomic} from './malloy_types';
 import {StageWriter} from './stage_writer';
 import {StandardSQLDialect, type Dialect} from '../dialect';
-import type {EventStream} from '../runtime_types';
 import {
   buildQueryMaterializationSpec,
   shouldMaterialize,
@@ -31,11 +30,8 @@ import {QueryStruct, isScalarField} from './query_node';
 import type {QueryModel, QueryResults} from './query_model_contract';
 import {rowDataToNumber} from '../api/row_data_utils';
 
-export function makeQueryModel(
-  modelDef: ModelDef | undefined,
-  eventStream?: EventStream
-): QueryModel {
-  return new QueryModelImpl(modelDef, eventStream);
+export function makeQueryModel(modelDef: ModelDef | undefined): QueryModel {
+  return new QueryModelImpl(modelDef);
 }
 
 export class QueryModelImpl implements QueryModel, ModelRootInterface {
@@ -43,10 +39,7 @@ export class QueryModelImpl implements QueryModel, ModelRootInterface {
   // dialect: Dialect = new PostgresDialect();
   modelDef: ModelDef | undefined = undefined;
   structs = new Map<string, QueryStruct>();
-  constructor(
-    modelDef: ModelDef | undefined,
-    readonly eventStream?: EventStream
-  ) {
+  constructor(modelDef: ModelDef | undefined) {
     if (modelDef) {
       this.loadModelFromDef(modelDef);
     }

--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -251,12 +251,9 @@ export interface ParentQueryStruct {
   struct: QueryStruct;
 }
 
-/*
- * So that we don't have to includeQueryModel. Put properties
- * of query model which are needed in here.
- */
+// Interface for model - provides struct lookup capability
 export interface ModelRootInterface {
-  eventStream?: EventStream;
+  structs: Map<string, QueryStruct>;
 }
 
 export interface ParentQueryModel {
@@ -292,8 +289,6 @@ export class QueryStruct {
     parent: ParentQueryStruct | ParentQueryModel,
     readonly prepareResultOptions: PrepareResultOptions
   ) {
-    this.setParent(parent);
-
     if ('model' in parent) {
       this.model = parent.model;
       this.pathAliasMap = new Map<string, string>();
@@ -303,6 +298,7 @@ export class QueryStruct {
         throw new Error('All root StructDefs should be a baseTable');
       }
     } else {
+      this.parent = parent.struct;
       this.model = this.getModel();
       this.pathAliasMap = this.root().pathAliasMap;
       this.connectionName = this.root().connectionName;
@@ -627,18 +623,7 @@ export class QueryStruct {
   }
 
   get eventStream(): EventStream | undefined {
-    return this.getModel().eventStream;
-  }
-
-  setParent(parent: ParentQueryStruct | ParentQueryModel) {
-    if ('struct' in parent) {
-      this.parent = parent.struct;
-    }
-    if ('model' in parent) {
-      this.model = parent.model;
-    } else {
-      this.model = this.getModel();
-    }
+    return this.prepareResultOptions?.eventStream;
   }
 
   /** makes a new queryable field object from a fieldDef */

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -171,7 +171,7 @@ export class QueryQuery extends QueryField {
           fields: [...sourceDef.fields, ...firstStage.extendSource],
         },
         parentStruct.sourceArguments,
-        parent.parent ? {struct: parent} : {model: parent.model},
+        parent.parent ? {struct: parent} : {model: parent.getModel()},
         parent.prepareResultOptions
       );
       turtleWithFilters = {
@@ -2088,13 +2088,13 @@ export class QueryQuery extends QueryField {
       };
       pipeline.shift();
       for (const transform of pipeline) {
-        const parent = this.parent.parent
+        const parentArg = this.parent.parent
           ? {struct: this.parent.parent}
           : {model: this.parent.getModel()};
         const s = new QueryStruct(
           structDef,
           undefined,
-          parent,
+          parentArg,
           this.parent.prepareResultOptions
         );
         const q = QueryQuery.makeQuery(


### PR DESCRIPTION
## Overview

There is a `Model` object in the API which ends up getting re-computed a lot because of how the API grew over time. With persistence work, the "loaded state" of a model will be expensive to compute so we needed to tweak the API.

Withe AI help managed to figure out how to do that and keep the API the same.

This work is in support of #2644

## Summary

- Cache `QueryModel` at the `Model` level to avoid recreating it on every `PreparedQuery.getPreparedResult()` call
- Track model modifications via `modelWasModified` flag to know when cache can be reused
- Move `eventStream` to `PrepareResultOptions` to avoid concurrency issues with shared QueryModel

## Breaking Change

Removed unused `eventStream` parameter from `ModelMaterializer.search()` - it was never passed to the underlying implementation.

## Test plan

- [x] All existing tests pass (2504)
- [x] New tests for `modelWasModified` tracking
- [x] No circularity issues (dependencies.spec.ts)