### PR TITLE
add support for complex boolean logic within addWhere and addHaving

### DIFF
--- a/packages/malloy-interfaces/src/types.ts
+++ b/packages/malloy-interfaces/src/types.ts
@@ -658,6 +658,19 @@ export const MALLOY_INTERFACE_TYPES: Record<string, MalloyInterfaceType> = {
         'optional': false,
         'array': false,
       },
+      'conjunction': {
+        'type': 'Conjunction',
+        'optional': true,
+        'array': false,
+      },
+    },
+  },
+  'Conjunction': {
+    'type': 'enum',
+    'name': 'Conjunction',
+    'values': {
+      'and': 1,
+      'or': 2,
     },
   },
   'FilterStringApplication': {
@@ -2144,7 +2157,10 @@ export type FilterExpressionType = {
 
 export type FilterOperation = {
   filter: Filter;
+  conjunction?: Conjunction;
 };
+
+export type Conjunction = 'and' | 'or';
 
 export type FilterStringApplication = {
   expression: Expression;

--- a/packages/malloy-query-builder/src/query-ast.spec.ts
+++ b/packages/malloy-query-builder/src/query-ast.spec.ts
@@ -648,6 +648,657 @@ describe('query builder', () => {
       }`,
     });
   });
+  describe('addWhere with conjunction', () => {
+    test('add multiple wheres with AND conjunction', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('carrier', 'WN');
+        segment.addWhere('carrier', 'AA', 'and');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'AA',
+                  },
+                  conjunction: 'and',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              carrier ~ f\`WN\`
+              and carrier ~ f\`AA\`
+          }`,
+      });
+    });
+    test('add multiple wheres with OR conjunction', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('carrier', 'WN');
+        segment.addWhere('carrier', 'AA', 'or');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'AA',
+                  },
+                  conjunction: 'or',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              carrier ~ f\`WN\`
+              or carrier ~ f\`AA\`
+          }`,
+      });
+    });
+    test('add multiple wheres with mixed AND and OR conjunctions', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('carrier', 'WN');
+        segment.addWhere('carrier', 'AA', 'and');
+        segment.addWhere('carrier', 'DL', 'or');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'AA',
+                  },
+                  conjunction: 'and',
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'DL',
+                  },
+                  conjunction: 'or',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              carrier ~ f\`WN\`
+              and carrier ~ f\`AA\`
+              or carrier ~ f\`DL\`
+          }`,
+      });
+    });
+    test('add where with path and AND conjunction', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('state', ['origin'], 'TX');
+        segment.addWhere('state', ['origin'], 'CA', 'and');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'state',
+                      path: ['origin'],
+                    },
+                    filter: 'TX',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'state',
+                      path: ['origin'],
+                    },
+                    filter: 'CA',
+                  },
+                  conjunction: 'and',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              origin.state ~ f\`TX\`
+              and origin.state ~ f\`CA\`
+          }`,
+      });
+    });
+    test('add where with ParsedFilter and AND conjunction', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('carrier', {
+          kind: 'string',
+          parsed: {operator: '=', values: ['WN']},
+        });
+        segment.addWhere(
+          'carrier',
+          {
+            kind: 'string',
+            parsed: {operator: '=', values: ['AA']},
+          },
+          'and'
+        );
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'AA',
+                  },
+                  conjunction: 'and',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              carrier ~ f\`WN\`
+              and carrier ~ f\`AA\`
+          }`,
+      });
+    });
+    test('first where with conjunction should ignore conjunction (no previous filter)', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        q.getOrAddDefaultSegment().addWhere('carrier', 'WN', 'and');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                  conjunction: 'and',
+                },
+              ],
+            },
+          },
+        },
+        malloy: 'run: flights -> { where: carrier ~ f`WN` }',
+      });
+    });
+    test('default conjunction (no parameter) uses comma separator', () => {
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addWhere('carrier', 'WN');
+        segment.addWhere('carrier', 'AA');
+      }).toModifyQuery({
+        model: flights_model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'WN',
+                  },
+                },
+                {
+                  kind: 'where',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'carrier',
+                    },
+                    filter: 'AA',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            where:
+              carrier ~ f\`WN\`,
+              carrier ~ f\`AA\`
+          }`,
+      });
+    });
+  });
+  describe('addHaving with conjunction', () => {
+    test('add multiple havings with AND conjunction', () => {
+      const model: Malloy.ModelInfo = {
+        entries: [
+          {
+            kind: 'source',
+            name: 'flights',
+            schema: {
+              fields: [
+                {
+                  kind: 'measure',
+                  name: 'flight_count',
+                  type: {kind: 'number_type'},
+                },
+                {
+                  kind: 'measure',
+                  name: 'total_distance',
+                  type: {kind: 'number_type'},
+                },
+              ],
+            },
+          },
+        ],
+        anonymous_queries: [],
+      };
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addHaving('flight_count', '> 100');
+        segment.addHaving('total_distance', '> 1000', 'and');
+      }).toModifyQuery({
+        model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'having',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'flight_count',
+                    },
+                    filter: '> 100',
+                  },
+                },
+                {
+                  kind: 'having',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'total_distance',
+                    },
+                    filter: '> 1000',
+                  },
+                  conjunction: 'and',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            having:
+              flight_count ~ f\`> 100\`
+              and total_distance ~ f\`> 1000\`
+          }`,
+      });
+    });
+    test('add multiple havings with OR conjunction', () => {
+      const model: Malloy.ModelInfo = {
+        entries: [
+          {
+            kind: 'source',
+            name: 'flights',
+            schema: {
+              fields: [
+                {
+                  kind: 'measure',
+                  name: 'flight_count',
+                  type: {kind: 'number_type'},
+                },
+                {
+                  kind: 'measure',
+                  name: 'total_distance',
+                  type: {kind: 'number_type'},
+                },
+              ],
+            },
+          },
+        ],
+        anonymous_queries: [],
+      };
+      const from: Malloy.Query = {
+        definition: {
+          kind: 'arrow',
+          source: {
+            kind: 'source_reference',
+            name: 'flights',
+          },
+          view: {
+            kind: 'segment',
+            operations: [],
+          },
+        },
+      };
+      expect((q: ASTQuery) => {
+        const segment = q.getOrAddDefaultSegment();
+        segment.addHaving('flight_count', '> 100');
+        segment.addHaving('total_distance', '> 1000', 'or');
+      }).toModifyQuery({
+        model,
+        from,
+        to: {
+          definition: {
+            kind: 'arrow',
+            source: {
+              kind: 'source_reference',
+              name: 'flights',
+            },
+            view: {
+              kind: 'segment',
+              operations: [
+                {
+                  kind: 'having',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'flight_count',
+                    },
+                    filter: '> 100',
+                  },
+                },
+                {
+                  kind: 'having',
+                  filter: {
+                    kind: 'filter_string',
+                    expression: {
+                      kind: 'field_reference',
+                      name: 'total_distance',
+                    },
+                    filter: '> 1000',
+                  },
+                  conjunction: 'or',
+                },
+              ],
+            },
+          },
+        },
+        malloy: dedent`
+          run: flights -> {
+            having:
+              flight_count ~ f\`> 100\`
+              or total_distance ~ f\`> 1000\`
+          }`,
+      });
+    });
+  });
   test('add some drills', () => {
     const from: Malloy.Query = {
       definition: {

--- a/packages/malloy-query-builder/src/query-ast.ts
+++ b/packages/malloy-query-builder/src/query-ast.ts
@@ -31,14 +31,14 @@ type NonOptionalASTNode<T> = T extends undefined ? never : ASTNode<T>;
 type LiteralOrNode<T> = T extends string
   ? T
   : T extends number
-    ? T
-    : T extends string[]
-      ? T
-      : T extends boolean
-        ? T
-        : undefined extends T
-          ? NonOptionalASTNode<T> | undefined
-          : ASTNode<T>;
+  ? T
+  : T extends string[]
+  ? T
+  : T extends boolean
+  ? T
+  : undefined extends T
+  ? NonOptionalASTNode<T> | undefined
+  : ASTNode<T>;
 
 abstract class ASTNode<T> {
   /**
@@ -2916,6 +2916,16 @@ export class ASTSegmentViewDefinition
   public addWhere(name: string, filterString: string): ASTWhereViewOperation;
   public addWhere(
     name: string,
+    filter: ParsedFilter,
+    conjunction: Malloy.Conjunction
+  ): ASTWhereViewOperation;
+  public addWhere(
+    name: string,
+    filterString: string,
+    conjunction: Malloy.Conjunction
+  ): ASTWhereViewOperation;
+  public addWhere(
+    name: string,
     path: string[],
     filter: ParsedFilter
   ): ASTWhereViewOperation;
@@ -2926,11 +2936,41 @@ export class ASTSegmentViewDefinition
   ): ASTWhereViewOperation;
   public addWhere(
     name: string,
+    path: string[],
+    filter: ParsedFilter,
+    conjunction: Malloy.Conjunction
+  ): ASTWhereViewOperation;
+  public addWhere(
+    name: string,
+    path: string[],
+    filterString: string,
+    conjunction: Malloy.Conjunction
+  ): ASTWhereViewOperation;
+  public addWhere(
+    name: string,
     arg2: string[] | string | ParsedFilter,
-    arg3?: string | ParsedFilter
+    arg3?: string | ParsedFilter | Malloy.Conjunction,
+    arg4?: Malloy.Conjunction
   ): ASTWhereViewOperation {
     const path = Array.isArray(arg2) ? arg2 : [];
-    const filter = arg3 === undefined ? (arg2 as string | ParsedFilter) : arg3;
+    let filter: string | ParsedFilter;
+    let conjunction: Malloy.Conjunction | undefined;
+
+    if (Array.isArray(arg2)) {
+      // Path was provided
+      filter = arg3 as string | ParsedFilter;
+      conjunction = arg4;
+    } else {
+      // No path provided
+      if (arg3 === 'and' || arg3 === 'or') {
+        filter = arg2 as string | ParsedFilter;
+        conjunction = arg3;
+      } else {
+        filter = arg2 as string | ParsedFilter;
+        conjunction = undefined;
+      }
+    }
+
     const filterString =
       typeof filter === 'string' ? filter : serializeFilter(filter);
     const schema = this.getInputSchema();
@@ -2949,6 +2989,7 @@ export class ASTSegmentViewDefinition
         },
         filter: filterString,
       },
+      conjunction,
     });
     this.addOperation(item);
     return item;
@@ -2956,6 +2997,16 @@ export class ASTSegmentViewDefinition
 
   public addHaving(name: string, filter: ParsedFilter): ASTHavingViewOperation;
   public addHaving(name: string, filterString: string): ASTHavingViewOperation;
+  public addHaving(
+    name: string,
+    filter: ParsedFilter,
+    conjunction: Malloy.Conjunction
+  ): ASTHavingViewOperation;
+  public addHaving(
+    name: string,
+    filterString: string,
+    conjunction: Malloy.Conjunction
+  ): ASTHavingViewOperation;
   public addHaving(
     name: string,
     path: string[],
@@ -2968,11 +3019,41 @@ export class ASTSegmentViewDefinition
   ): ASTHavingViewOperation;
   public addHaving(
     name: string,
+    path: string[],
+    filter: ParsedFilter,
+    conjunction: Malloy.Conjunction
+  ): ASTHavingViewOperation;
+  public addHaving(
+    name: string,
+    path: string[],
+    filterString: string,
+    conjunction: Malloy.Conjunction
+  ): ASTHavingViewOperation;
+  public addHaving(
+    name: string,
     arg2: string[] | string | ParsedFilter,
-    arg3?: string | ParsedFilter
+    arg3?: string | ParsedFilter | Malloy.Conjunction,
+    arg4?: Malloy.Conjunction
   ): ASTHavingViewOperation {
     const path = Array.isArray(arg2) ? arg2 : [];
-    const filter = arg3 === undefined ? (arg2 as string | ParsedFilter) : arg3;
+    let filter: string | ParsedFilter;
+    let conjunction: Malloy.Conjunction | undefined;
+
+    if (Array.isArray(arg2)) {
+      // Path was provided
+      filter = arg3 as string | ParsedFilter;
+      conjunction = arg4;
+    } else {
+      // No path provided
+      if (arg3 === 'and' || arg3 === 'or') {
+        filter = arg2 as string | ParsedFilter;
+        conjunction = arg3;
+      } else {
+        filter = arg2 as string | ParsedFilter;
+        conjunction = undefined;
+      }
+    }
+
     const filterString =
       typeof filter === 'string' ? filter : serializeFilter(filter);
     const schema = this.getInputSchema();
@@ -2991,6 +3072,7 @@ export class ASTSegmentViewDefinition
         },
         filter: filterString,
       },
+      conjunction,
     });
     this.addOperation(item);
     return item;


### PR DESCRIPTION
## Problem

The `addWhere` and `addHaving` functions in `malloy-query-builder` couldn't express complex boolean logic (AND/OR) between filter conditions **across different fields**. All filters were joined with commas, limiting the ability to build queries with OR conditions or explicit AND groupings.

**Note:** The existing `ClauseChain` in `malloy-filter` only supports AND/OR operators within a single field's filter expression (e.g., `carrier ~ f'WN and AA'`). It cannot combine conditions across different fields like `flight_count > 100 AND total_distance > 1000`.

## Solution

Extended the `addWhere` and `addHaving` functions to accept an optional `conjunction` parameter (`'and'` | `'or'`) that specifies how the current filter connects to the previous one, enabling boolean logic across multiple fields.

## Changes

### `packages/malloy-interfaces/src/types.ts`

- Added `Conjunction` type (`'and'` | `'or'`)
- Added optional `conjunction` property to `FilterOperation` type

### `packages/malloy-interfaces/src/to_malloy.ts`

- Created `formatFilterBlock` function to handle per-item conjunction operators
- Updated serialization for `where` and `having` clauses to output `and`/`or` instead of comma when conjunction is specified

### `packages/malloy-query-builder/src/query-ast.ts`

- Extended `addWhere` function overloads to accept optional `conjunction` parameter
- Extended `addHaving` function similarly for consistency

## Usage Example

```javascript
const segment = query.getOrAddDefaultSegment();
segment.addWhere('carrier', 'WN');
segment.addWhere('carrier', 'AA', 'and');
segment.addWhere('carrier', 'DL', 'or');
```

Generates:

```malloy
run: flights -> {
  where:
    carrier ~ f`WN`
    and carrier ~ f`AA`
    or carrier ~ f`DL`
}
```

## ClauseChain vs Conjunction Parameter

| Feature       | ClauseChain (existing)          | Conjunction (this PR)                  |
| ------------- | ------------------------------- | -------------------------------------- |
| Scope         | Single field                    | Multiple fields                        |
| Where applied | Inside filter string            | Between filter operations              |
| Example       | `carrier ~ f'WN and AA'`        | `carrier ~ f'WN'` and `origin ~ f'TX'` |
| Use case      | Same field, multiple conditions | Different fields, boolean logic        |

## Combined Usage

The two approaches are complementary. You can use ClauseChain's complex within-field logic inside each `addWhere` call, and then use the conjunction parameter to connect those filters across fields:

```javascript
segment.addWhere('carrier', '(WN; AA) | DL'); // Complex within-field logic
segment.addWhere('origin', 'TX, CA', 'and'); // Connected via AND
```

## Limitations

Cross-field grouped logic with parentheses is **not supported**:

```
(country = 'US' AND age = '10') OR (state = 'CA' OR color = 'white')
```

This would require a filter tree builder, which is beyond the scope of this PR.

## Key Design Decisions

- The conjunction relates to the **current** filter being added (how it connects to the previous filter)
- First filter's conjunction is ignored (no previous filter to connect to)
- Without a conjunction parameter, the default comma separator is used (backward compatible)
- Prevents broken queries (no trailing operators like `where: field ~ f'value' and`)

## Tests

Added comprehensive tests in `packages/malloy-query-builder/src/query-ast.spec.ts`:

- Multiple wheres with AND conjunction
- Multiple wheres with OR conjunction
- Mixed AND and OR conjunctions
- Where with path and conjunction
- Where with ParsedFilter and conjunction
- First where with conjunction (verifies conjunction is ignored)
- Default behavior (comma separator when no conjunction)
- Having with AND/OR conjunctions

All existing tests continue to pass.
