### PR TITLE
Add colon syntax for replacing properties in tag language

### DIFF
--- a/packages/malloy-tag/src/peggy/malloy-tag.peggy
+++ b/packages/malloy-tag/src/peggy/malloy-tag.peggy
@@ -54,7 +54,7 @@ tagEq
       return result;
     }
 
-// name = { properties }  or  name = ... { properties }
+// name = { properties }  or  name = ... { properties }  or  name: { properties }
 tagReplaceProperties
   = path:propName _ "=" _ dotty:"..."? _ props:properties {
       return {
@@ -62,6 +62,14 @@ tagReplaceProperties
         path,
         properties: props.statements,
         preserveValue: dotty !== null
+      };
+    }
+  / path:propName _ ":" _ props:properties {
+      return {
+        kind: 'replaceProperties',
+        path,
+        properties: props.statements,
+        preserveValue: false
       };
     }
 

--- a/packages/malloy-tag/src/tags.spec.ts
+++ b/packages/malloy-tag/src/tags.spec.ts
@@ -146,6 +146,9 @@ describe('tagParse to Tag', () => {
       },
     ],
     ['can remove.properties -...', {}],
+    // Colon syntax for replacing properties (same as name = { })
+    ['name: { prop }', {name: {properties: {prop: {}}}}],
+    ['name: { a=1 b=2 }', {name: {properties: {a: {eq: '1'}, b: {eq: '2'}}}}],
     // Multi-line input
     [
       'person {\n  name="ted"\n  age=42\n}',


### PR DESCRIPTION
## Summary

- Adds `name: { props }` as an alternative syntax for `name = { props }` (replace properties)
- Aligns tag language more closely with Malloy's syntax which uses `: {` for similar constructs

## Test plan

- [x] Added tests for the new colon syntax
- [x] All existing tests pass

---
🤖 Generated with [Claude Code](https://claude.ai/code)