### PR TITLE
Add toObject() method to Tag class

### DIFF
--- a/packages/malloy-tag/src/tags.spec.ts
+++ b/packages/malloy-tag/src/tags.spec.ts
@@ -575,3 +575,92 @@ function idempotent(tag: Tag) {
   clone.prefix = tag.prefix;
   expect(clone.toString()).toBe(str);
 }
+
+describe('toObject', () => {
+  test('bare tag becomes true', () => {
+    const {tag} = parseTag('hidden');
+    expect(tag.toObject()).toEqual({hidden: true});
+  });
+
+  test('string value becomes string', () => {
+    const {tag} = parseTag('color=blue');
+    expect(tag.toObject()).toEqual({color: 'blue'});
+  });
+
+  test('numeric value becomes number', () => {
+    const {tag} = parseTag('size=10');
+    expect(tag.toObject()).toEqual({size: 10});
+  });
+
+  test('float value becomes number', () => {
+    const {tag} = parseTag('ratio=3.14');
+    expect(tag.toObject()).toEqual({ratio: 3.14});
+  });
+
+  test('properties only becomes nested object', () => {
+    const {tag} = parseTag('box { width=100 height=200 }');
+    expect(tag.toObject()).toEqual({box: {width: 100, height: 200}});
+  });
+
+  test('value and properties uses = key', () => {
+    const {tag} = parseTag('link="http://example.com" { target=_blank }');
+    expect(tag.toObject()).toEqual({
+      link: {'=': 'http://example.com', 'target': '_blank'},
+    });
+  });
+
+  test('array of simple values', () => {
+    const {tag} = parseTag('items=[a, b, c]');
+    expect(tag.toObject()).toEqual({items: ['a', 'b', 'c']});
+  });
+
+  test('array of numeric values', () => {
+    const {tag} = parseTag('nums=[1, 2, 3]');
+    expect(tag.toObject()).toEqual({nums: [1, 2, 3]});
+  });
+
+  test('array with properties on elements', () => {
+    const {tag} = parseTag('items=[a { x=1 }, b { y=2 }]');
+    expect(tag.toObject()).toEqual({
+      items: [
+        {'=': 'a', 'x': 1},
+        {'=': 'b', 'y': 2},
+      ],
+    });
+  });
+
+  test('complex nested structure', () => {
+    const {tag} = parseTag('# hidden color=blue size=10 box { width=100 }');
+    expect(tag.toObject()).toEqual({
+      hidden: true,
+      color: 'blue',
+      size: 10,
+      box: {width: 100},
+    });
+  });
+
+  test('deleted properties are excluded', () => {
+    const {tag} = parseTag('a b -a');
+    expect(tag.toObject()).toEqual({b: true});
+  });
+
+  test('empty tag returns empty object', () => {
+    const {tag} = parseTag('');
+    expect(tag.toObject()).toEqual({});
+  });
+
+  test('deeply nested properties', () => {
+    const {tag} = parseTag('a.b.c=1');
+    expect(tag.toObject()).toEqual({a: {b: {c: 1}}});
+  });
+
+  test('array of objects (dictionaries)', () => {
+    const {tag} = parseTag('items=[{name=alice age=30}, {name=bob age=25}]');
+    expect(tag.toObject()).toEqual({
+      items: [
+        {name: 'alice', age: 30},
+        {name: 'bob', age: 25},
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `toObject()` method to the `Tag` class for users who want to work with tag data as plain JavaScript objects without using the Tag API methods
- Converts tag structures to natural JS objects with these rules:
  - Bare tags → `true`
  - Value-only tags → the value directly (strings or numbers)
  - Properties-only tags → nested objects
  - Tags with both value and properties → `'='` key for value, properties spread on object
  - Arrays → JavaScript arrays
  - Numeric strings → actual numbers

## Example

```javascript
// Tag: # hidden color=blue box { width=100 }
tag.toObject()
// Returns: { hidden: true, color: 'blue', box: { width: 100 } }
```

## Test plan

- [x] Unit tests for all conversion cases added to `tags.spec.ts`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)