### PR TITLE
Add custom types support to tag schema validation

### DIFF
--- a/packages/malloy-tag/docs/motly.md
+++ b/packages/malloy-tag/docs/motly.md
@@ -743,6 +743,60 @@ required: {
 
 This validates that `items` is an array where every element has `size` (number) and `color` (string). Errors include the array index in the path (e.g., `items.1.size`).
 
+### Custom Types
+
+Define reusable types in the `types` section and reference them by name:
+
+```motly
+types: {
+  personType: {
+    required: {
+      name = string
+      age = number
+    }
+  }
+}
+required: {
+  user = personType
+  manager = personType
+}
+```
+
+Custom type names cannot conflict with built-in types (string, number, etc.).
+
+#### Custom Type Arrays
+
+Use quoted `"typeName[]"` for arrays of custom types:
+
+```motly
+types: {
+  personType: {
+    required: { name = string age = number }
+  }
+}
+required: {
+  people = "personType[]"
+}
+```
+
+#### Recursive Types
+
+Custom types can reference themselves for recursive structures:
+
+```motly
+types: {
+  treeNode: {
+    required: { value = number }
+    optional: { children = "treeNode[]" }
+  }
+}
+required: {
+  root = treeNode
+}
+```
+
+This validates trees of arbitrary depth where each node has a `value` and optional `children`.
+
 ### Unknown Properties
 
 By default, properties not listed in `required` or `optional` cause validation errors. To allow extra properties, add `allowUnknown = @true`:


### PR DESCRIPTION
## Summary

Adds a `types` section to schemas for defining reusable, named types that can be referenced throughout the schema.

**Features:**
- Define types once, reference by name: `person = personType`
- Arrays of custom types: `people = "personType[]"`
- Recursive types for tree structures: `children = "treeNode[]"`
- Each type can have its own `allowUnknown` setting

**Example:**
```motly
types: {
  personType: {
    required: { name = string age = number }
  }
}
required: {
  user = personType
  friends = "personType[]"
}
```

**Recursive example:**
```motly
types: {
  treeNode: {
    required: { value = number }
    optional: { children = "treeNode[]" }
  }
}
required: { root = treeNode }
```

Includes a self-validating test: a meta-schema that describes valid schemas and validates itself.

## Test plan
- [x] 65 unit tests passing
- [x] Lint passes
- [x] Package builds

🤖 Generated with [Claude Code](https://claude.ai/code)