### PR TITLE
Fix crash when 'constructor' is used as a field alias

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/dynamic-space.ts
@@ -102,7 +102,7 @@ export abstract class DynamicSpace
     if (this.sourceDef === undefined) {
       // Grab all the parameters so that we can populate the "final" structDef
       // with parameters immediately so that views can see them when they are translating
-      const parameters = {};
+      const parameters: Record<string, model.Parameter> = Object.create(null);
       for (const [name, entry] of this.entries()) {
         if (entry instanceof SpaceParam) {
           parameters[name] = entry.parameter();

--- a/packages/malloy/src/lang/ast/field-space/parameter-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/parameter-space.ts
@@ -22,7 +22,7 @@ export class ParameterSpace implements FieldSpace {
 
   private readonly _map: Record<string, SpaceEntry>;
   constructor(parameters: HasParameter[]) {
-    this._map = {};
+    this._map = Object.create(null) as Record<string, SpaceEntry>;
     for (const parameter of parameters) {
       this._map[parameter.name] = new AbstractParameter(parameter);
     }

--- a/packages/malloy/src/lang/ast/field-space/query-spaces.ts
+++ b/packages/malloy/src/lang/ast/field-space/query-spaces.ts
@@ -71,7 +71,10 @@ export abstract class QueryOperationSpace
   expandedWild: Record<
     string,
     {path: string[]; entry: SpaceEntry; at: model.DocumentLocation}
-  > = {};
+  > = Object.create(null) as Record<
+    string,
+    {path: string[]; entry: SpaceEntry; at: model.DocumentLocation}
+  >;
   drillDimensions: {
     nestPath: string[];
     firstDrill: MalloyElement;

--- a/packages/malloy/src/lang/ast/field-space/static-space.ts
+++ b/packages/malloy/src/lang/ast/field-space/static-space.ts
@@ -92,7 +92,7 @@ export class StaticSpace implements FieldSpace {
 
   private get map(): FieldMap {
     if (this.memoMap === undefined) {
-      this.memoMap = {};
+      this.memoMap = Object.create(null) as FieldMap;
       for (const f of this.fromStruct.fields) {
         const name = f.as || f.name;
         this.memoMap[name] = this.defToSpaceField(f);
@@ -117,7 +117,7 @@ export class StaticSpace implements FieldSpace {
   }
 
   protected dropEntries(): void {
-    this.memoMap = {};
+    this.memoMap = Object.create(null) as FieldMap;
   }
 
   protected dropEntry(name: string): void {
@@ -144,7 +144,7 @@ export class StaticSpace implements FieldSpace {
   emptyStructDef(): StructDef {
     const ret = {...this.fromStruct};
     if (isSourceDef(ret)) {
-      ret.parameters = {};
+      ret.parameters = Object.create(null);
     }
     ret.fields = [];
     return ret;
@@ -280,7 +280,7 @@ export class StaticSourceSpace extends StaticSpace implements SourceFieldSpace {
   }
   emptyStructDef(): SourceDef {
     const ret = {...this.source};
-    ret.parameters = {};
+    ret.parameters = Object.create(null);
     ret.fields = [];
     return ret;
   }

--- a/packages/malloy/src/lang/ast/source-elements/named-source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/named-source.ts
@@ -151,7 +151,7 @@ export class NamedSource extends Source {
   ): Record<string, Parameter> {
     const base = this.modelStruct();
     if (base === undefined) {
-      return {};
+      return Object.create(null) as Record<string, Parameter>;
     }
 
     return this.evaluateArguments(parameterSpace, base.parameters, []);
@@ -271,7 +271,7 @@ export class NamedSource extends Source {
       return notFound;
     }
 
-    const outParameters = {};
+    const outParameters: Record<string, Parameter> = Object.create(null);
     for (const parameter of pList ?? []) {
       const compiled = parameter.parameter();
       outParameters[compiled.name] = compiled;

--- a/packages/malloy/src/lang/ast/source-elements/source.ts
+++ b/packages/malloy/src/lang/ast/source-elements/source.ts
@@ -47,7 +47,7 @@ export abstract class Source extends MalloyElement {
     pList: HasParameter[] | undefined
   ): Record<string, Parameter> | undefined {
     if (pList === undefined) return undefined;
-    const parameters = {};
+    const parameters: Record<string, Parameter> = Object.create(null);
     for (const hasP of pList) {
       const pVal = hasP.parameter();
       parameters[pVal.name] = pVal;

--- a/packages/malloy/src/lang/ast/types/malloy-element.ts
+++ b/packages/malloy/src/lang/ast/types/malloy-element.ts
@@ -511,7 +511,7 @@ function annotationID(a: Annotation): string {
 export class Document extends MalloyElement implements NameSpace {
   elementType = 'document';
   globalNameSpace: NameSpace = new GlobalNameSpace();
-  documentModel: Record<string, ModelEntry> = {};
+  documentModel: Record<string, ModelEntry> = Object.create(null);
   documentSrcRegistry: Record<SourceID, SourceRegistryValue> = {};
   queryList: Query[] = [];
   statements: DocStatementList;
@@ -530,7 +530,7 @@ export class Document extends MalloyElement implements NameSpace {
     if (this.didInitModel) {
       return;
     }
-    this.documentModel = {};
+    this.documentModel = Object.create(null);
     this.documentSrcRegistry = {};
     this.queryList = [];
     if (extendingModelDef) {

--- a/packages/malloy/src/lang/test/constructor-alias-bug.spec.ts
+++ b/packages/malloy/src/lang/test/constructor-alias-bug.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import './parse-expects';
+
+// Regression: Object.prototype property names used as field aliases
+// must not collide with inherited JS prototype properties.
+describe('Object.prototype field name collisions', () => {
+  test('constructor as view group_by alias', () => {
+    expect(`
+      source: x is a extend {
+        view: v is {
+          group_by: constructor is astr
+          aggregate: acount is count()
+        }
+      }
+    `).toTranslate();
+  });
+
+  test('toString as dimension alias', () => {
+    expect(`
+      source: x is a extend {
+        dimension: toString is astr
+      }
+    `).toTranslate();
+  });
+
+  test('constructor as source name', () => {
+    expect(`
+      source: constructor is a
+    `).toTranslate();
+  });
+
+  test('constructor as query name', () => {
+    expect(`
+      query: constructor is a -> { select: * }
+    `).toTranslate();
+  });
+});


### PR DESCRIPTION
# Fix crash when `constructor` is used as a field alias

## Summary

- Fix crash/error when `constructor` (or other `Object.prototype` property names) is used as a field alias
- Replace plain `{}` object initializations with `Object.create(null)` in field-name-keyed maps to prevent prototype chain interference

## Bug

Using `constructor` as a field alias causes two different errors depending on context:

**In a view `group_by` / `aggregate`** — the compiler crashes with an unhelpful internal error at L1:1:

```
Cannot read properties of undefined (reading 'typeDesc')
```

**As a source-level `dimension`, `measure`, or `join_one` name** — a false "redefine" error:

```
Cannot redefine 'constructor'
```

### Minimal reproduction

```malloy
source: constructors is duckdb.sql("""
  SELECT 1 as constructorId, 'Ferrari' as name
  UNION ALL SELECT 2, 'McLaren'
  UNION ALL SELECT 3, 'Mercedes'
""") extend {
  primary_key: constructorId
  dimension: constructor_name is name
}

source: results is duckdb.sql("""
  SELECT 1 as resultId, 1 as constructorId, 3 as position
  UNION ALL SELECT 2, 2, 1
  UNION ALL SELECT 3, 3, 2
  UNION ALL SELECT 4, 1, 5
""") extend {
  primary_key: resultId
  join_one: constructors with constructorId

  measure: result_count is count()

  // Crashes: "Cannot read properties of undefined (reading 'typeDesc')"
  view: by_constructor is {
    group_by: constructor is constructors.constructor_name
    aggregate: result_count
  }

  // Error: "Cannot redefine 'constructor'"
  dimension: constructor is constructors.constructor_name

  // Error: "Cannot redefine 'constructor'"
  measure: constructor is count()
}
```

## Root cause

Field names are stored in plain JavaScript objects (`{}`), which inherit from `Object.prototype`. When a field named `constructor` is looked up via `obj['constructor']`, JavaScript returns the inherited `Object.prototype.constructor` function instead of `undefined`. This causes:

1. `DynamicSpace.newEntry()` thinks the name already exists (the prototype function is truthy), rejects it as a "name conflict"
2. `QuerySpace.translateQueryFields()` enters the wrong code path via `expandedWild['constructor']` (also truthy), then crashes accessing `.entry.typeDesc()` on the prototype function

The same issue affects all `Object.prototype` property names: `toString`, `valueOf`, `hasOwnProperty`, etc.

## Fix

Replace `= {}` with `= Object.create(null)` in all field-name-keyed maps (6 files, 10 lines). `Object.create(null)` creates objects with no prototype chain, so inherited properties don't interfere with field name lookups.

## Test plan

- [x] 1212 existing lang tests pass (0 regressions)
- [x] 2 new regression tests for `constructor` and `toString` as field aliases
- [x] End-to-end `malloyc` compilation of the reproduction file succeeds
