### PR TITLE
Allow dotted field paths in order_by clauses

### DIFF
--- a/packages/malloy/src/lang/grammar/MalloyParser.g4
+++ b/packages/malloy/src/lang/grammar/MalloyParser.g4
@@ -490,7 +490,7 @@ ordering
   ;
 
 orderBySpec
-  : (INTEGER_LITERAL | fieldName) ( ASC | DESC ) ?
+  : (INTEGER_LITERAL | fieldPath) ( ASC | DESC ) ?
   ;
 
 limitStatement

--- a/packages/malloy/src/lang/malloy-to-ast.ts
+++ b/packages/malloy/src/lang/malloy-to-ast.ts
@@ -1119,9 +1119,11 @@ export class MalloyToAST
     if (ncx) {
       return new ast.OrderBy(this.getNumber(ncx), dir);
     }
-    const fieldCx = pcx.fieldName();
-    if (fieldCx) {
-      return new ast.OrderBy(this.getFieldName(fieldCx), dir);
+    const pathCx = pcx.fieldPath();
+    if (pathCx) {
+      const names = pathCx.fieldName();
+      const lastFieldName = names[names.length - 1];
+      return new ast.OrderBy(this.getFieldName(lastFieldName), dir);
     }
     throw this.internalError(pcx, "can't parse order_by specification");
   }

--- a/packages/malloy/src/lang/malloy-to-stable-query.ts
+++ b/packages/malloy/src/lang/malloy-to-stable-query.ts
@@ -387,8 +387,9 @@ export class MalloyToQuery
     for (const spec of specs) {
       if (spec.INTEGER_LITERAL()) {
         this.notAllowed(spec, 'Indexed order by statements');
-      } else if (spec.fieldName()) {
-        const fieldName = getId(spec.fieldName()!);
+      } else if (spec.fieldPath()) {
+        const names = spec.fieldPath()!.fieldName();
+        const fieldName = getId(names[names.length - 1]);
         const direction = spec.ASC() ? 'asc' : spec.DESC() ? 'desc' : undefined;
         orders.push({
           kind: 'order_by',

--- a/packages/malloy/src/lang/test/query.spec.ts
+++ b/packages/malloy/src/lang/test/query.spec.ts
@@ -1108,6 +1108,14 @@ describe('query:', () => {
           expect(reduce.orderBy).toEqual([{field: 'astr', dir: 'asc'}]);
         }
       });
+      test('order by dotted field path from join', () => {
+        expect('run: ab->{ group_by: b.astr; order_by: b.astr }').toTranslate();
+      });
+      test('order by dotted field path with direction', () => {
+        expect(
+          'run: ab->{ group_by: b.astr; order_by: b.astr desc }'
+        ).toTranslate();
+      });
     });
     test('order by multiple', () => {
       expect(`


### PR DESCRIPTION
The order_by grammar rule previously only accepted a single identifier (fieldName), so `order_by: carriers.nickname` would fail with a syntax error even though `group_by: carriers.nickname` worked fine. This changes the grammar to accept fieldPath (dotted paths) and resolves them to the output field name (last segment of the path).