### PR TITLE
Add setupSQL support to all connection dialects and fix digests

### DIFF
--- a/packages/malloy-db-bigquery/src/index.ts
+++ b/packages/malloy-db-bigquery/src/index.ts
@@ -69,5 +69,12 @@ registerConnectionType('bigquery', {
       type: 'string',
       optional: true,
     },
+    {
+      name: 'setupSQL',
+      displayName: 'Setup SQL',
+      type: 'text',
+      optional: true,
+      description: 'SQL statements to run when the connection is established',
+    },
   ],
 });

--- a/packages/malloy-db-duckdb/src/duckdb_common.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_common.ts
@@ -62,6 +62,7 @@ export abstract class DuckDBCommon
 {
   protected isMotherDuck = false;
   protected motherDuckToken: string | undefined;
+  protected setupSQL: string | undefined;
 
   private readonly dialect = new DuckDBDialect();
   static DEFAULT_QUERY_OPTIONS: DuckDBQueryOptions = {

--- a/packages/malloy-db-duckdb/src/index.ts
+++ b/packages/malloy-db-duckdb/src/index.ts
@@ -70,5 +70,12 @@ registerConnectionType('duckdb', {
       type: 'boolean',
       optional: true,
     },
+    {
+      name: 'setupSQL',
+      displayName: 'Setup SQL',
+      type: 'text',
+      optional: true,
+      description: 'SQL statements to run when the connection is established',
+    },
   ],
 });

--- a/packages/malloy-db-mysql/src/index.ts
+++ b/packages/malloy-db-mysql/src/index.ts
@@ -21,6 +21,8 @@ registerConnectionType('mysql', {
       user: typeof config['user'] === 'string' ? config['user'] : undefined,
       password:
         typeof config['password'] === 'string' ? config['password'] : undefined,
+      setupSQL:
+        typeof config['setupSQL'] === 'string' ? config['setupSQL'] : undefined,
     });
   },
   properties: [
@@ -39,6 +41,13 @@ registerConnectionType('mysql', {
       displayName: 'Password',
       type: 'password',
       optional: true,
+    },
+    {
+      name: 'setupSQL',
+      displayName: 'Setup SQL',
+      type: 'text',
+      optional: true,
+      description: 'SQL statements to run when the connection is established',
     },
   ],
 });

--- a/packages/malloy-db-mysql/src/mysql_setup.spec.ts
+++ b/packages/malloy-db-mysql/src/mysql_setup.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {MySQLConnection, MySQLExecutor} from '.';
+import crypto from 'crypto';
+
+const config = MySQLExecutor.getConnectionOptionsFromEnv();
+const describeMySQL = config.user ? describe : describe.skip;
+
+describeMySQL('setupSQL', () => {
+  const uid = crypto.randomBytes(4).toString('hex');
+  const connections: MySQLConnection[] = [];
+
+  function makeConn(name: string, setupSQL: string): MySQLConnection {
+    const conn = new MySQLConnection(name, {...config, setupSQL});
+    connections.push(conn);
+    return conn;
+  }
+
+  afterAll(async () => {
+    await Promise.all(connections.map(c => c.close()));
+  });
+
+  it('runs a single setup statement', async () => {
+    const varName = `@setup_single_${uid}`;
+    const conn = makeConn('mysql', `SET ${varName} = 42`);
+    const result = await conn.runSQL(`SELECT ${varName} AS v`);
+    expect(result.rows[0]['v']).toBe(42);
+  });
+
+  it('runs multiple semicolon-newline-separated statements', async () => {
+    const varA = `@setup_a_${uid}`;
+    const varB = `@setup_b_${uid}`;
+    const conn = makeConn(
+      'mysql',
+      [`SET ${varA} = 10`, `SET ${varB} = 20`].join(';\n')
+    );
+    const result = await conn.runSQL(`SELECT ${varA} + ${varB} AS v`);
+    expect(result.rows[0]['v']).toBe(30);
+  });
+
+  it('handles multi-line statements', async () => {
+    const varName = `@setup_ml_${uid}`;
+    const conn = makeConn('mysql', `SET\n  ${varName} = 99`);
+    const result = await conn.runSQL(`SELECT ${varName} AS v`);
+    expect(result.rows[0]['v']).toBe(99);
+  });
+});

--- a/packages/malloy-db-postgres/src/index.ts
+++ b/packages/malloy-db-postgres/src/index.ts
@@ -56,5 +56,12 @@ registerConnectionType('postgres', {
       type: 'string',
       optional: true,
     },
+    {
+      name: 'setupSQL',
+      displayName: 'Setup SQL',
+      type: 'text',
+      optional: true,
+      description: 'SQL statements to run when the connection is established',
+    },
   ],
 });

--- a/packages/malloy-db-snowflake/src/index.ts
+++ b/packages/malloy-db-snowflake/src/index.ts
@@ -30,14 +30,17 @@ import {SnowflakeConnection} from './snowflake_connection';
 
 registerConnectionType('snowflake', {
   factory: (config: ConnectionConfig) => {
-    const {name, ...props} = config;
+    const {name, setupSQL, ...props} = config;
     // ConnectionConfig values are trusted to match ConnectionOptions fields
     // because the property definitions below declare matching names/types.
     // The double cast bridges Malloy's generic config to snowflake-sdk's
     // external typed interface — unavoidable without enumerating every
     // ConnectionOptions field.
     const connOptions = props as unknown as ConnectionOptions;
-    return new SnowflakeConnection(name, {connOptions});
+    return new SnowflakeConnection(name, {
+      connOptions,
+      setupSQL: typeof setupSQL === 'string' ? setupSQL : undefined,
+    });
   },
   properties: [
     {name: 'account', displayName: 'Account', type: 'string'},
@@ -78,6 +81,13 @@ registerConnectionType('snowflake', {
       displayName: 'Timeout (ms)',
       type: 'number',
       optional: true,
+    },
+    {
+      name: 'setupSQL',
+      displayName: 'Setup SQL',
+      type: 'text',
+      optional: true,
+      description: 'SQL statements to run when the connection is established',
     },
   ],
 });

--- a/packages/malloy-db-snowflake/src/snowflake_setup.spec.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_setup.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as malloy from '@malloydata/malloy';
+import {SnowflakeConnection} from './snowflake_connection';
+import {SnowflakeExecutor} from './snowflake_executor';
+import crypto from 'crypto';
+
+describe('setupSQL', () => {
+  const connOptions =
+    SnowflakeExecutor.getConnectionOptionsFromEnv() ||
+    SnowflakeExecutor.getConnectionOptionsFromToml();
+  const uid = crypto.randomBytes(4).toString('hex');
+  const connections: SnowflakeConnection[] = [];
+
+  function makeConn(name: string, setupSQL: string): SnowflakeConnection {
+    const conn = new SnowflakeConnection(name, {connOptions, setupSQL});
+    connections.push(conn);
+    return conn;
+  }
+
+  afterAll(async () => {
+    await Promise.all(connections.map(c => c.close()));
+  });
+
+  it('runs a single setup statement', async () => {
+    const conn = makeConn(
+      'snowflake_setup_single',
+      `SET setup_test_${uid} = 42`
+    );
+    const result = await conn.runSQL(`SELECT $setup_test_${uid} AS V`);
+    expect(malloy.API.rowDataToNumber(result.rows[0]['V'])).toBe(42);
+  });
+
+  it('runs multiple semicolon-newline-separated statements', async () => {
+    const conn = makeConn(
+      'snowflake_setup_multi',
+      [`SET setup_a_${uid} = 10`, `SET setup_b_${uid} = 20`].join(';\n')
+    );
+    const result = await conn.runSQL(
+      `SELECT $setup_a_${uid} + $setup_b_${uid} AS V`
+    );
+    expect(malloy.API.rowDataToNumber(result.rows[0]['V'])).toBe(30);
+  });
+
+  it('handles multi-line statements', async () => {
+    const conn = makeConn(
+      'snowflake_setup_multiline',
+      `SET\n  setup_ml_${uid} = 99`
+    );
+    const result = await conn.runSQL(`SELECT $setup_ml_${uid} AS V`);
+    expect(malloy.API.rowDataToNumber(result.rows[0]['V'])).toBe(99);
+  });
+});

--- a/packages/malloy-db-trino/src/index.ts
+++ b/packages/malloy-db-trino/src/index.ts
@@ -54,6 +54,8 @@ function configToTrinoConfig(config: ConnectionConfig): {
       user: typeof config['user'] === 'string' ? config['user'] : undefined,
       password:
         typeof config['password'] === 'string' ? config['password'] : undefined,
+      setupSQL:
+        typeof config['setupSQL'] === 'string' ? config['setupSQL'] : undefined,
     },
   };
 }
@@ -65,6 +67,13 @@ const trinoProperties: ConnectionPropertyDefinition[] = [
   {name: 'schema', displayName: 'Schema', type: 'string', optional: true},
   {name: 'user', displayName: 'User', type: 'string', optional: true},
   {name: 'password', displayName: 'Password', type: 'password', optional: true},
+  {
+    name: 'setupSQL',
+    displayName: 'Setup SQL',
+    type: 'text',
+    optional: true,
+    description: 'SQL statements to run when the connection is established',
+  },
 ];
 
 registerConnectionType('trino', {

--- a/packages/malloy-db-trino/src/presto_setup.spec.ts
+++ b/packages/malloy-db-trino/src/presto_setup.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {PrestoConnection} from './trino_connection';
+import {TrinoExecutor} from './trino_executor';
+
+describe('presto setupSQL', () => {
+  const config = TrinoExecutor.getConnectionOptionsFromEnv('presto');
+  if (!config) {
+    it('skips — no PRESTO_HOST configured', () => {});
+    return;
+  }
+  const connections: PrestoConnection[] = [];
+
+  function makeConn(name: string, setupSQL: string): PrestoConnection {
+    const conn = new PrestoConnection(name, undefined, {...config, setupSQL});
+    connections.push(conn);
+    return conn;
+  }
+
+  afterAll(async () => {
+    await Promise.all(connections.map(c => c.close()));
+  });
+
+  // Note: the Presto HTTP client does not carry session state between
+  // queries, so SET SESSION effects don't persist.  These tests verify
+  // that the setupSQL mechanism itself works (statements execute before
+  // the first real query, and bad SQL is rejected).
+
+  it('runs a single setup statement', async () => {
+    const conn = makeConn(
+      'presto',
+      "SET SESSION query_max_execution_time = '30m'"
+    );
+    const result = await conn.runSQL('SELECT 1 AS v');
+    expect(result.rows[0]['v']).toBe(1);
+  });
+
+  it('runs multiple semicolon-newline-separated statements', async () => {
+    const conn = makeConn(
+      'presto',
+      [
+        "SET SESSION query_max_execution_time = '25m'",
+        "SET SESSION query_max_run_time = '25m'",
+      ].join(';\n')
+    );
+    const result = await conn.runSQL('SELECT 1 AS v');
+    expect(result.rows[0]['v']).toBe(1);
+  });
+
+  it('handles multi-line statements', async () => {
+    const conn = makeConn(
+      'presto',
+      "SET SESSION\n  query_max_execution_time = '20m'"
+    );
+    const result = await conn.runSQL('SELECT 1 AS v');
+    expect(result.rows[0]['v']).toBe(1);
+  });
+
+  it('rejects bad setup SQL', async () => {
+    const conn = makeConn('presto', 'THIS IS NOT VALID SQL');
+    await expect(conn.runSQL('SELECT 1 AS v')).rejects.toThrow();
+  });
+});

--- a/packages/malloy-db-trino/src/trino_setup.spec.ts
+++ b/packages/malloy-db-trino/src/trino_setup.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {TrinoConnection} from './trino_connection';
+import {TrinoExecutor} from './trino_executor';
+import crypto from 'crypto';
+
+describe('setupSQL', () => {
+  const config = TrinoExecutor.getConnectionOptionsFromEnv('trino');
+  if (!config) {
+    it('skips — no TRINO_SERVER configured', () => {});
+    return;
+  }
+  const uid = crypto.randomBytes(4).toString('hex');
+  const connections: TrinoConnection[] = [];
+
+  function makeConn(name: string, setupSQL: string): TrinoConnection {
+    const conn = new TrinoConnection(name, undefined, {...config, setupSQL});
+    connections.push(conn);
+    return conn;
+  }
+
+  afterAll(async () => {
+    await Promise.all(connections.map(c => c.close()));
+  });
+
+  it('runs a single setup statement', async () => {
+    const schema = `setup_single_${uid}`;
+    const conn = makeConn(
+      'trino',
+      `CREATE SCHEMA IF NOT EXISTS memory.${schema}`
+    );
+    const result = await conn.runSQL(
+      `SELECT schema_name FROM memory.information_schema.schemata WHERE schema_name = '${schema}'`
+    );
+    expect(result.rows.length).toBe(1);
+    // cleanup
+    await conn.runSQL(`DROP SCHEMA IF EXISTS memory.${schema}`);
+  });
+
+  it('runs multiple semicolon-newline-separated statements', async () => {
+    const schema = `setup_multi_${uid}`;
+    const table = `${schema}.test_tbl`;
+    const conn = makeConn(
+      'trino',
+      [
+        `CREATE SCHEMA IF NOT EXISTS memory.${schema}`,
+        `CREATE TABLE IF NOT EXISTS memory.${table} (v INTEGER)`,
+      ].join(';\n')
+    );
+    const result = await conn.runSQL(
+      `SELECT table_name FROM memory.information_schema.tables WHERE table_schema = '${schema}' AND table_name = 'test_tbl'`
+    );
+    expect(result.rows.length).toBe(1);
+    // cleanup
+    await conn.runSQL(`DROP TABLE IF EXISTS memory.${table}`);
+    await conn.runSQL(`DROP SCHEMA IF EXISTS memory.${schema}`);
+  });
+
+  it('handles multi-line statements', async () => {
+    const schema = `setup_ml_${uid}`;
+    const conn = makeConn(
+      'trino',
+      `CREATE SCHEMA IF NOT EXISTS\n  memory.${schema}`
+    );
+    const result = await conn.runSQL(
+      `SELECT schema_name FROM memory.information_schema.schemata WHERE schema_name = '${schema}'`
+    );
+    expect(result.rows.length).toBe(1);
+    // cleanup
+    await conn.runSQL(`DROP SCHEMA IF EXISTS memory.${schema}`);
+  });
+});

--- a/packages/malloy/src/connection/registry.ts
+++ b/packages/malloy/src/connection/registry.ts
@@ -18,7 +18,8 @@ export type ConnectionPropertyType =
   | 'number'
   | 'boolean'
   | 'password'
-  | 'file';
+  | 'file'
+  | 'text';
 
 /**
  * Describes a single configuration property for a connection type.


### PR DESCRIPTION
Add a new type to the connection registry config called "text" for multi line text, and added a `setupSQL` option which every connection uses to hold commands which are run when connections are established.

Includes tests for each connection type.