### PR TITLE
Make docker start scripts smart about existing containers

### DIFF
--- a/test/mysql/mysql_start.sh
+++ b/test/mysql/mysql_start.sh
@@ -7,20 +7,37 @@ mkdir .tmp
 # run docker
 SCRIPTDIR=$(cd $(dirname $0); pwd)
 DATADIR=$(dirname $SCRIPTDIR)/data/mysql
-docker run -p 3306:3306 -d -v $DATADIR:/init_data --name mysql-malloy -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:8.4.2
+CONTAINER_NAME="mysql-malloy"
+
+# Check for existing container
+if docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1; then
+  if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
+    echo "$CONTAINER_NAME is already running"
+    exit 0
+  fi
+  echo "Restarting existing $CONTAINER_NAME container..."
+  docker start "$CONTAINER_NAME"
+  while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "mysqld: ready for connections"; do
+    sleep 2
+  done
+  echo "MySQL running on port 3306"
+  exit 0
+fi
+
+docker run -p 3306:3306 -d -v $DATADIR:/init_data --name "$CONTAINER_NAME" -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -d mysql:8.4.2
 
 # wait for server to start
 counter=0
 echo -n Starting Docker ...
-while ! docker logs mysql-malloy 2>&1 | grep -q "mysqld: ready for connections"
+while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "mysqld: ready for connections"
 do
   sleep 10
   counter=$((counter+1))
   # if doesn't start after 2 minutes, output logs and kill process
   if [ $counter -eq 120 ]
   then
-    docker logs mysql-malloy >& ./.tmp/mysql-malloy.logs
-    docker rm -f mysql-malloy
+    docker logs "$CONTAINER_NAME" >& ./.tmp/mysql-malloy.logs
+    docker rm -f "$CONTAINER_NAME"
     echo "MySQL did not start successfully, check .tmp/mysql-malloy.logs"
     exit 1
     break
@@ -31,8 +48,8 @@ done
 # load the test data.
 echo
 echo Loading Test Data
-docker exec mysql-malloy cp /init_data/malloytest.mysql.gz /tmp
-docker exec mysql-malloy gunzip /tmp/malloytest.mysql.gz
-docker exec mysql-malloy mysql -P3306 -h127.0.0.1 -uroot -e 'drop database if exists malloytest; create database malloytest; use malloytest; source /tmp/malloytest.mysql;'
+docker exec "$CONTAINER_NAME" cp /init_data/malloytest.mysql.gz /tmp
+docker exec "$CONTAINER_NAME" gunzip /tmp/malloytest.mysql.gz
+docker exec "$CONTAINER_NAME" mysql -P3306 -h127.0.0.1 -uroot -e 'drop database if exists malloytest; create database malloytest; use malloytest; source /tmp/malloytest.mysql;'
 
 echo "MySQL running on port 3306"

--- a/test/presto/presto_start.sh
+++ b/test/presto/presto_start.sh
@@ -41,20 +41,37 @@ else
   PRESTO_IMAGE="prestodb/presto:${PRESTO_VERSION}"
 fi
 
+CONTAINER_NAME="presto-malloy"
+
+# Check for existing container
+if docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1; then
+  if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
+    echo "$CONTAINER_NAME is already running"
+    exit 0
+  fi
+  echo "Restarting existing $CONTAINER_NAME container..."
+  docker start "$CONTAINER_NAME"
+  while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "SERVER STARTED"; do
+    sleep 1
+  done
+  echo "Presto running on port 8080"
+  exit 0
+fi
+
 # run docker
-docker run -p ${PRESTO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-pesto.properties:/opt/presto-server/etc/catalog/bigquery.properties --name presto-malloy "$PRESTO_IMAGE"
+docker run -p ${PRESTO_PORT:-8080}:8080 -d -v ./.tmp/bigquery-pesto.properties:/opt/presto-server/etc/catalog/bigquery.properties --name "$CONTAINER_NAME" "$PRESTO_IMAGE"
 
 # wait for server to start
 counter=0
-while ! docker logs presto-malloy 2>&1 | grep -q "SERVER STARTED"
+while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "SERVER STARTED"
 do
   sleep 1
   counter=$((counter+1))
   # if doesn't start after 2 minutes, output logs and kill process
   if [ $counter -eq 120 ]
   then
-    docker logs presto-malloy >& ./.tmp/presto-malloy.logs
-    docker rm -f presto-malloy
+    docker logs "$CONTAINER_NAME" >& ./.tmp/presto-malloy.logs
+    docker rm -f "$CONTAINER_NAME"
     echo "Presto did not start successfully, check .tmp/presto-malloy.logs"
     exit 1
     break

--- a/test/trino/trino_start.sh
+++ b/test/trino/trino_start.sh
@@ -19,20 +19,37 @@ bigquery.credentials-key=$BQ_CREDENTIALS_KEY
 bigquery.arrow-serialization.enabled=false
 EOF
 
+CONTAINER_NAME="trino-malloy"
+
+# Check for existing container
+if docker container inspect "$CONTAINER_NAME" > /dev/null 2>&1; then
+  if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
+    echo "$CONTAINER_NAME is already running"
+    exit 0
+  fi
+  echo "Restarting existing $CONTAINER_NAME container..."
+  docker start "$CONTAINER_NAME"
+  while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "SERVER STARTED"; do
+    sleep 1
+  done
+  echo "Trino running on port localhost:8080"
+  exit 0
+fi
+
 # run docker
-docker run -p ${TRINO_PORT:-8080}:8080 -d -e TZ=UTC -v ./.tmp/bigquery-trino.properties:/etc/trino/catalog/bigquery.properties --name trino-malloy trinodb/trino
+docker run -p ${TRINO_PORT:-8080}:8080 -d -e TZ=UTC -v ./.tmp/bigquery-trino.properties:/etc/trino/catalog/bigquery.properties --name "$CONTAINER_NAME" trinodb/trino
 
 # wait for server to start
 counter=0
-while ! docker logs trino-malloy 2>&1 | grep -q "SERVER STARTED"
+while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -q "SERVER STARTED"
 do
   sleep 1
   counter=$((counter+1))
   # if doesn't start after 2 minutes, output logs and kill process
   if [ $counter -eq 300 ]
   then
-    docker logs trino-malloy >& ./.tmp/trino-malloy.logs
-    docker rm -f trino-malloy
+    docker logs "$CONTAINER_NAME" >& ./.tmp/trino-malloy.logs
+    docker rm -f "$CONTAINER_NAME"
     echo "Trino did not start successfully, check .tmp/trino-malloy.logs"
     exit 1
     break


### PR DESCRIPTION
## Summary
- Start scripts now detect existing containers instead of blindly running `docker run`
- If the container is already running, prints a message and exits
- If the container exists but is stopped, restarts it and waits for ready — skipping the data load step
- If no container exists, proceeds with the existing create + load flow as before

Also replaced hardcoded container names with `$CONTAINER_NAME` variable throughout each script.

## Test plan
Tested all four scripts (postgres, mysql, trino, presto) in all three conditions:
- [x] No container → creates and loads data as before
- [x] Container already running → prints "already running", exits 0
- [x] Container stopped → restarts without reloading data, waits for ready