### PR TITLE
fix(render): fix chart and table rendering bugs

### DIFF
--- a/packages/malloy-render/.storybook/main.ts
+++ b/packages/malloy-render/.storybook/main.ts
@@ -66,6 +66,12 @@ const config: StorybookConfig = {
           'IS_STORYBOOK': true,
         },
       },
+      optimizeDeps: {
+        include: [
+          '@malloydata/malloy-tag',
+          '@malloydata/motly-ts-parser',
+        ],
+      },
       assetsInclude: ['/sb-preview/runtime.js'],
       plugins: [viteMalloyStoriesPlugin()],
     };

--- a/packages/malloy-render/src/component/chart/chart-layout-settings.ts
+++ b/packages/malloy-render/src/component/chart/chart-layout-settings.ts
@@ -222,15 +222,13 @@ export function getXAxisSettings({
   const maxStringSize = getTextWidthDOM(maxString, xLabelFontStyles);
   const ellipsesSize = getTextWidthDOM('...', xLabelFontStyles);
 
-  const X_AXIS_THRESHOLD = 0.35;
-  const plotHeight = chartHeight - 2 * xTitleOffset - xTitleSize - ellipsesSize;
+  const X_AXIS_THRESHOLD = xField.isTime() ? 0.45 : 0.35;
+  const plotHeight = chartHeight - xTitleOffset - xTitleSize;
 
   let labelHeight = Math.min(maxStringSize, X_AXIS_THRESHOLD * plotHeight);
   labelLimit = labelHeight;
-  if (labelHeight < maxStringSize) {
-    labelHeight += ellipsesSize;
-  }
-  xAxisHeight = labelHeight + xTitleOffset * 2 + xTitleSize + xLabelPadding;
+  // Vega handles ellipsis within labelLimit, so no extra space needed for truncated labels
+  xAxisHeight = labelHeight + xTitleOffset + xTitleSize + xLabelPadding;
 
   // TODO: improve this, this logic exists in more detail in generate vega spec. this is a hacky partial solution for now :/
   const uniqueValuesCt = xField.valueSet.size;
@@ -241,9 +239,10 @@ export function getXAxisSettings({
   // TODO: shouldn't yTitleSize and yAxisWidth be subtracted from this chartWidth?
   const xSpacePerLabel = chartWidth / recordsToFit;
   if (xSpacePerLabel > xAxisHeight || xSpacePerLabel > maxStringSize) {
+    // Labels fit horizontally
     labelAngle = 0;
-    // Remove label limit; our vega specs should use labelOverlap setting to hide overlapping labels
-    labelLimit = 0;
+    // Set label limit based on available space per label, with some padding
+    labelLimit = xSpacePerLabel > maxStringSize ? 0 : xSpacePerLabel - 4;
     labelAlign = undefined;
 
     const horizontalLabelHeight = getTextHeightDOM(
@@ -251,6 +250,37 @@ export function getXAxisSettings({
       xLabelFontStyles
     );
     xAxisHeight = horizontalLabelHeight + xTitleOffset * 2 + xTitleSize;
+  } else {
+    // Check if labels fit at -45° angle
+    // At -45°, effective width per label ≈ labelHeight * √2, and effective height ≈ maxStringSize * sin(45°)
+    const diagonalWidth = maxStringSize * Math.cos(Math.PI / 4);
+    const horizontalLabelHeight = getTextHeightDOM(
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZgy',
+      xLabelFontStyles
+    );
+    const diagonalHeight =
+      maxStringSize * Math.sin(Math.PI / 4) + horizontalLabelHeight;
+
+    if (
+      xSpacePerLabel > horizontalLabelHeight * 1.2 &&
+      diagonalHeight < xAxisHeight * 1.2
+    ) {
+      labelAngle = -45;
+      labelAlign = 'right';
+      // For temporal fields, use full label width since Vega's labelOverlap:'greedy'
+      // will hide labels that don't fit, rather than truncating all labels
+      labelLimit = xField.isTime()
+        ? maxStringSize
+        : Math.min(
+            maxStringSize,
+            (xSpacePerLabel / Math.cos(Math.PI / 4)) * 1.5
+          );
+
+      xAxisHeight = Math.min(diagonalHeight, xAxisHeight) +
+        xTitleOffset * 2 +
+        xTitleSize +
+        xLabelPadding;
+    }
   }
 
   const titleArea = xAxisHeight - (xLabelPadding + labelLimit);

--- a/packages/malloy-render/src/component/renderer/apply-renderer.tsx
+++ b/packages/malloy-render/src/component/renderer/apply-renderer.tsx
@@ -27,7 +27,7 @@ export function applyRenderer(props: RendererProps) {
   const plugin = field.getPlugins().at(0);
   if (plugin) {
     return {
-      renderAs,
+      renderAs: 'chart',
       renderValue: (
         <PluginRenderContainer
           plugin={plugin}

--- a/packages/malloy-render/src/component/table/table.css
+++ b/packages/malloy-render/src/component/table/table.css
@@ -24,8 +24,7 @@
 }
 
 .malloy-table.root {
-  width: fit-content;
-  max-width: 100%;
+  width: max-content;
   height: fit-content;
   max-height: 100%;
   position: relative;
@@ -33,7 +32,7 @@
   overflow-anchor: none;
   grid-template-columns: repeat(
     var(--total-header-size),
-    minmax(auto, max-content)
+    minmax(min-content, max-content)
   );
 }
 

--- a/packages/malloy-render/src/component/table/table.tsx
+++ b/packages/malloy-render/src/component/table/table.tsx
@@ -495,7 +495,7 @@ const MalloyTableRoot = (_props: {
           const maybeSize = tableCtx.store.columnWidths[key];
           if (shouldFillWidth) return maybeSize ? maybeSize + 'px' : 'auto';
           return `minmax(${
-            maybeSize ? maybeSize + 'px' : 'auto'
+            maybeSize ? maybeSize + 'px' : '64px'
           }, max-content)`;
         })
         .join(' ');

--- a/packages/malloy-render/src/component/tag-utils.ts
+++ b/packages/malloy-render/src/component/tag-utils.ts
@@ -46,13 +46,6 @@ export function convertLegacyToVizTag(tag: Tag): Tag {
 
   // Copy legacy tags into viz property
   if (legacyChartTag) {
-    const legacyTagObject = tag.tag(legacyChartTag);
-    // First set the legacy tag (clones it with correct parent), then set the value
-    if (legacyTagObject) {
-      return tag
-        .set(['viz'], legacyTagObject)
-        .set(['viz'], legacyTagToVizType(legacyChartTag));
-    }
     return tag.set(['viz'], legacyTagToVizType(legacyChartTag));
   }
 

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -716,7 +716,7 @@ export function generateBarChartVegaSpecV2(
         orient: 'bottom',
         scale: 'xscale',
         title: xField.name,
-        labelOverlap: 'greedy',
+        labelOverlap: xIsDateorTime ? ('greedy' as const) : false,
         labelSeparation: 4,
         ...chartSettings.xAxis,
         encode: {

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -179,6 +179,7 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
               name: 'Year',
               valueSet: yearValues,
               referenceId: '__synthetic_year__',
+              tag: {text: () => undefined, has: () => false},
               // Add minimal Field interface properties that might be used
               isTime: () => false,
               isDate: () => false,

--- a/packages/malloy-render/src/stories/bar_chart.stories.malloy
+++ b/packages/malloy-render/src/stories/bar_chart.stories.malloy
@@ -472,7 +472,7 @@ source: products is duckdb.table("static/data/products.parquet") extend {
 
 
   #(story)
-  view: indepenent_axis is {
+  view: independent_axis is {
     group_by: category
     aggregate: avg_retail is retail_price.avg()
     # bar_chart

--- a/packages/malloy-render/src/stories/scroll-override.stories.ts
+++ b/packages/malloy-render/src/stories/scroll-override.stories.ts
@@ -5,7 +5,7 @@ import {MalloyRenderer} from '../api/malloy-renderer';
 
 const meta: Meta = {
   title: 'Malloy Next/Scroll Override Test',
-  render: context => {
+  render: (_args, context) => {
     const mainContainer = document.createElement('div');
 
     const scrollContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- Fix Storybook Vite optimizeDeps for `malloy-tag` and `motly-ts-parser`
- Fix x-axis label truncation thresholds and angle logic for temporal axes
- Show all labels for categorical bar chart axes instead of greedy overlap
- Fix YoY line chart crash by adding `.tag` to synthetic year field
- Fix table sizing (`width: max-content`, `minmax(min-content, max-content)`)
- Fix table column fallback min-width from `auto` to `64px`
- Fix `renderAs` to always return `chart` for plugin fields
- Remove broken legacy tag cloning in `convertLegacyToVizTag`
- Fix typo `indepenent_axis` → `independent_axis` in stories

## Test plan
- [ ] `cd packages/malloy-render && npx tsc --noEmit` passes
- [ ] Storybook bar chart stories render correctly
- [ ] Table column sizing works properly with charts in cells
- [ ] YoY line chart stories don't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)