### PR TITLE
Restore optional "," separation in tag parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6126,9 +6126,9 @@
       "link": true
     },
     "node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.0.1.tgz",
-      "integrity": "sha512-/0QYBEOku2oDO7uNFUuVQxsUJ4FPe5mZOYFcWhOmv7dWIr5ujnUwaoGV+D75RgWEb8cuOPT3pS+Xl20u1mNrYA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.0.2.tgz",
+      "integrity": "sha512-gBEcset4Izv64g2sO9jQoiqupyVW9OKXp+ZP1T2+Wu1EGudceLHtcE4Rvn13dO1ntU5QrO0p8pggaa+Kq8t10Q==",
       "license": "MIT"
     },
     "node_modules/@malloydata/render": {
@@ -29816,7 +29816,7 @@
       "version": "0.0.341",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/motly-ts-parser": "^0.0.1",
+        "@malloydata/motly-ts-parser": "^0.0.2",
         "assert": "^2.0.0"
       },
       "devDependencies": {

--- a/packages/malloy-tag/package.json
+++ b/packages/malloy-tag/package.json
@@ -28,7 +28,7 @@
     "generate-flow": "ts-node ../../scripts/gen-flow.ts"
   },
   "dependencies": {
-    "@malloydata/motly-ts-parser": "^0.0.1",
+    "@malloydata/motly-ts-parser": "^0.0.2",
     "assert": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Issue

```
the tag parsing no longer supports comma-delimited parameters within annotations. Is that intended?

# big_value{comparison_field='margin_2025' comparison_label='vs. 2024' comparison_format='ppt'} works but

# big_value{comparison_field='margin_2025', comparison_label='vs. 2024' comparison_format='ppt'} does not
```

## Explanation

This was an undocumented feature which was discovered. When the tag parser was re-implemented, this feature was removed. After discussion with the user who discovered the feature, the decision was made to implement and document it.

## Summary
- Bump `@malloydata/motly-ts-parser` from 0.0.1 to 0.0.2 in `packages/malloy-tag`


## Test plan
- [x] `npm run build` — clean
- [x] `npm run test-duckdb` — 2694 passed