### PR TITLE
Add secret property type and env-based secret resolution

### DIFF
--- a/packages/malloy-db-duckdb/src/index.ts
+++ b/packages/malloy-db-duckdb/src/index.ts
@@ -62,7 +62,7 @@ registerConnectionType('duckdb', {
     {
       name: 'motherDuckToken',
       displayName: 'MotherDuck Token',
-      type: 'password',
+      type: 'secret',
       optional: true,
     },
     {

--- a/packages/malloy/src/connection/registry.spec.ts
+++ b/packages/malloy/src/connection/registry.spec.ts
@@ -10,6 +10,7 @@ import {
   readConnectionsConfig,
   writeConnectionsConfig,
   createConnectionsFromConfig,
+  resolveSecret,
 } from './registry';
 import type {ConnectionConfig, Connection} from './types';
 
@@ -48,6 +49,25 @@ describe('connection registry', () => {
       factory: (config: ConnectionConfig) =>
         mockConnection(config.name, config),
       properties: [],
+    });
+    registerConnectionType('secretdb', {
+      factory: (config: ConnectionConfig) =>
+        mockConnection(config.name, config),
+      properties: [
+        {name: 'host', displayName: 'Host', type: 'string', optional: true},
+        {
+          name: 'password',
+          displayName: 'Password',
+          type: 'password',
+          optional: true,
+        },
+        {
+          name: 'token',
+          displayName: 'Token',
+          type: 'secret',
+          optional: true,
+        },
+      ],
     });
   });
 
@@ -201,5 +221,123 @@ describe('connection registry', () => {
     const conn1 = await lookup.lookupConnection('mydb');
     const conn2 = await lookup.lookupConnection('mydb');
     expect(conn1).toBe(conn2);
+  });
+
+  describe('resolveSecret', () => {
+    test('passes through plain strings', () => {
+      expect(resolveSecret('my-token')).toBe('my-token');
+    });
+
+    test('resolves env references', () => {
+      process.env['TEST_SECRET_VALUE'] = 'from-env';
+      try {
+        expect(resolveSecret({env: 'TEST_SECRET_VALUE'})).toBe('from-env');
+      } finally {
+        delete process.env['TEST_SECRET_VALUE'];
+      }
+    });
+
+    test('returns undefined for missing env var', () => {
+      delete process.env['NONEXISTENT_SECRET_VAR'];
+      expect(resolveSecret({env: 'NONEXISTENT_SECRET_VAR'})).toBeUndefined();
+    });
+
+    test('returns undefined for non-string/non-object values', () => {
+      expect(resolveSecret(42)).toBeUndefined();
+      expect(resolveSecret(true)).toBeUndefined();
+      expect(resolveSecret(null)).toBeUndefined();
+      expect(resolveSecret(undefined)).toBeUndefined();
+    });
+
+    test('returns undefined for unrecognized object shapes', () => {
+      expect(resolveSecret({vault: 'path/to/secret'})).toBeUndefined();
+    });
+  });
+
+  describe('secret resolution in createConnectionsFromConfig', () => {
+    test('resolves password env reference', async () => {
+      process.env['TEST_DB_PASSWORD'] = 'secret-pw';
+      try {
+        const config = {
+          connections: {
+            mydb: {is: 'secretdb', password: {env: 'TEST_DB_PASSWORD'}},
+          },
+        };
+        const lookup = createConnectionsFromConfig(config);
+        const conn = (await lookup.lookupConnection('mydb')) as unknown as {
+          _config: ConnectionConfig;
+        };
+        expect(conn._config['password']).toBe('secret-pw');
+      } finally {
+        delete process.env['TEST_DB_PASSWORD'];
+      }
+    });
+
+    test('resolves secret env reference', async () => {
+      process.env['TEST_API_TOKEN'] = 'my-token';
+      try {
+        const config = {
+          connections: {
+            mydb: {is: 'secretdb', token: {env: 'TEST_API_TOKEN'}},
+          },
+        };
+        const lookup = createConnectionsFromConfig(config);
+        const conn = (await lookup.lookupConnection('mydb')) as unknown as {
+          _config: ConnectionConfig;
+        };
+        expect(conn._config['token']).toBe('my-token');
+      } finally {
+        delete process.env['TEST_API_TOKEN'];
+      }
+    });
+
+    test('passes through plain string for sensitive fields', async () => {
+      const config = {
+        connections: {
+          mydb: {is: 'secretdb', password: 'plain-pw', token: 'plain-tok'},
+        },
+      };
+      const lookup = createConnectionsFromConfig(config);
+      const conn = (await lookup.lookupConnection('mydb')) as unknown as {
+        _config: ConnectionConfig;
+      };
+      expect(conn._config['password']).toBe('plain-pw');
+      expect(conn._config['token']).toBe('plain-tok');
+    });
+
+    test('omits sensitive field when env var is missing', async () => {
+      delete process.env['MISSING_VAR'];
+      const config = {
+        connections: {
+          mydb: {is: 'secretdb', password: {env: 'MISSING_VAR'}},
+        },
+      };
+      const lookup = createConnectionsFromConfig(config);
+      const conn = (await lookup.lookupConnection('mydb')) as unknown as {
+        _config: ConnectionConfig;
+      };
+      expect(conn._config['password']).toBeUndefined();
+    });
+
+    test('does not resolve env references on non-sensitive fields', async () => {
+      process.env['TEST_HOST_VAR'] = 'resolved-host';
+      try {
+        const config = {
+          connections: {
+            mydb: {
+              is: 'secretdb' as const,
+              host: {env: 'TEST_HOST_VAR'} as unknown as string,
+            },
+          },
+        };
+        const lookup = createConnectionsFromConfig(config);
+        const conn = (await lookup.lookupConnection('mydb')) as unknown as {
+          _config: ConnectionConfig;
+        };
+        expect(conn._config['host']).toBeUndefined();
+      } finally {
+        delete process.env['TEST_HOST_VAR'];
+      }
+    });
   });
 });

--- a/packages/malloy/src/connection/registry.ts
+++ b/packages/malloy/src/connection/registry.ts
@@ -18,6 +18,7 @@ export type ConnectionPropertyType =
   | 'number'
   | 'boolean'
   | 'password'
+  | 'secret'
   | 'file'
   | 'text';
 
@@ -44,11 +45,30 @@ export interface ConnectionTypeDef {
 }
 
 /**
+ * A sensitive value in a config file. Either a plain string (already resolved)
+ * or an environment variable reference.
+ */
+export type SecretValue = string | {env: string};
+
+/**
+ * Resolve a sensitive value. Plain strings pass through, {env: "X"} looks up
+ * process.env["X"], anything else returns undefined.
+ */
+export function resolveSecret(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (value !== null && typeof value === 'object' && 'env' in value) {
+    const envName = (value as {env: unknown}).env;
+    if (typeof envName === 'string') return process.env[envName];
+  }
+  return undefined;
+}
+
+/**
  * A single connection entry in a JSON config.
  */
 export interface ConnectionConfigEntry {
   is: string;
-  [key: string]: string | number | boolean | undefined;
+  [key: string]: string | number | boolean | SecretValue | undefined;
 }
 
 /**
@@ -160,11 +180,24 @@ export function createConnectionsFromConfig(
         );
       }
 
+      const sensitiveProps = new Set(
+        typeDef.properties
+          .filter(p => p.type === 'password' || p.type === 'secret')
+          .map(p => p.name)
+      );
+
       const connConfig: ConnectionConfig = {name: connectionName};
       for (const [key, value] of Object.entries(entry)) {
         if (key === 'is') continue;
         if (value !== undefined) {
-          connConfig[key] = value;
+          if (sensitiveProps.has(key)) {
+            const resolved = resolveSecret(value);
+            if (resolved !== undefined) {
+              connConfig[key] = resolved;
+            }
+          } else if (typeof value !== 'object') {
+            connConfig[key] = value;
+          }
         }
       }
 

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -244,6 +244,7 @@ export {
   readConnectionsConfig,
   writeConnectionsConfig,
   createConnectionsFromConfig,
+  resolveSecret,
 } from './connection/registry';
 export type {
   ConnectionTypeFactory,
@@ -252,6 +253,7 @@ export type {
   ConnectionTypeDef,
   ConnectionConfigEntry,
   ConnectionsConfig,
+  SecretValue,
 } from './connection/registry';
 export {toAsyncGenerator} from './connection_utils';
 export {modelDefToModelInfo, sourceDefToSourceInfo} from './to_stable';


### PR DESCRIPTION
## Summary
- Add `secret` as a new connection property type, semantically distinct from `password` (tokens/API keys vs credentials/passphrases)
- Both `password` and `secret` fields in `malloy-config.json` now support `{"env": "VAR_NAME"}` references, resolved automatically by `createConnectionsFromConfig()`
- Change `motherDuckToken` from `password` to `secret`
- Export `resolveSecret()` and `SecretValue` type from `@malloydata/malloy`

## Test plan
- [x] 10 new tests in `registry.spec.ts` covering `resolveSecret` and secret resolution in `createConnectionsFromConfig`
- [x] All existing registry tests pass
- [x] `npm run test-duckdb` passes (2704 tests)
- [ ] CI full suite