### PR TITLE
Export MalloyConfig from top-level package index

### DIFF
--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -189,6 +189,7 @@ export {
   InMemoryModelCache,
   CacheManager,
   Manifest,
+  MalloyConfig,
 } from './api/foundation';
 export type {
   PreparedQuery,


### PR DESCRIPTION
## Summary
- `MalloyConfig` was exported from `api/foundation/index.ts` but missing from the top-level `src/index.ts` re-exports, making it inaccessible to package consumers via `import { MalloyConfig } from '@malloydata/malloy'`
- Adds `MalloyConfig` to the existing export block alongside `Manifest`

## Test plan
- [x] Verified `MalloyConfig` appears in `dist/index.d.ts` and `dist/index.js` after build
- [ ] CI passes