### PR TITLE
Bump DuckDB to 1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3734,31 +3734,31 @@
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.3-r.1.tgz",
-      "integrity": "sha512-/L6nywAWDnMptERJiO3npCu8XqWYGSo2prw6RvxERtjT9J95cnUP+WM6uNAm+Nw2uYDm8PvPO2kASC3Moh2bBA==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.4-r.1.tgz",
+      "integrity": "sha512-oqaH9DXTJNwyLkd2FgJwmSnWVqjB5irbESeTeNVMBnM03iRaNY545BhfBDumu1TnOV2koIdG1mNsmjgq/ZTIkA==",
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.4.3-r.1"
+        "@duckdb/node-bindings": "1.4.4-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.3-r.1.tgz",
-      "integrity": "sha512-I7rkYeNYDs9oV9AU076m9msrWb4wdVXapX1y2em8YkGItn4ehyp8q0KEJ2QZy45+PLqmkHt9b/QHlDo8xKnLZQ==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.4-r.1.tgz",
+      "integrity": "sha512-NFm0AMrK3kiVLQhgnGUEjX5c8Elm93dYePZ9BUCvvd0AVVTKEBeRhBp9afziuzP3Sl5+7XQ1TyaBLsZJKKBDBQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.4.3-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.4.3-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.4.3-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.4.3-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.4.3-r.1"
+        "@duckdb/node-bindings-darwin-arm64": "1.4.4-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.4.4-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.4.4-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.4.4-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.4.4-r.1"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.3-r.1.tgz",
-      "integrity": "sha512-2dShpy8HmdLwfRLPI+KZaJXN+wA68gOsuAh//Q1C/X0tQbd97WxHo8u7lZqMhaJMvGaInVAxR+KoFSfG2M5jwA==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.4-r.1.tgz",
+      "integrity": "sha512-/NtbkCgCAOJDxw41XvSGV/mxQAlsx+2xUvhIVUj6fxoOfTG4jTttRhuphwE3EXNoWzJOjZxCZ5LwhC/qb6ZwLg==",
       "cpu": [
         "arm64"
       ],
@@ -3769,9 +3769,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-a6DUVpDolavw1ojq/IBKoEViGzL1oMIP5xlPrqEW+znyDxp85/UfZzCXnH+BYTKgLWBwCUcqlneMtCh4osZ9lQ==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.4-r.1.tgz",
+      "integrity": "sha512-lzFRDrZwc1EoV513vmKufasiAQ2WlhEb0O6guRBarbvOKKVhRb8tQ5H7LPVTrIewjTI3XDgHrnK+vfh9L+xQcA==",
       "cpu": [
         "x64"
       ],
@@ -3782,9 +3782,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.3-r.1.tgz",
-      "integrity": "sha512-WQ/khu+KCEH34JxDAfa8IDCw0m5NUefpqT4izbH372OAAiY/858xrtcB8FYW0p9Yeb6P8dglHQ058FoLBQ7MhA==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.4-r.1.tgz",
+      "integrity": "sha512-wq92/EcTiOTRW1RSDOwjeLyMMXWwNVNwU21TQdfu3sgS86+Ih3raaK68leDgY5cWgf72We3J2W7HYz8GwxcMYw==",
       "cpu": [
         "arm64"
       ],
@@ -3795,9 +3795,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-GWZPi+eAsv2/6TQch+b6AgnPiVnXjhmT7l9gbZMZ17fDSIkKXSbWa9Y3dDJ8amDu/IJpwBMFVovfLHrELbMmlA==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.4-r.1.tgz",
+      "integrity": "sha512-fjYNc+t4/T7mhzZ57oJoIQaWvbYVvxhidcNNansQFiWnd6/JMLCULd4qnt8XI3Tt2BrZsraH690KSBIS3QPt0w==",
       "cpu": [
         "x64"
       ],
@@ -3808,9 +3808,9 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-7II6t8/0opHz6NFosrn5VSv3uMadtOhVRfBK+HzEvxTSkGEpu6DzQ91mPaiehuFctdB2upPza4dP3rCLYDdHeQ==",
+      "version": "1.4.4-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.4-r.1.tgz",
+      "integrity": "sha512-+J+MUYGvYWfX0balWToDIy3CBYg7hHI0KQUQ39+SniinXlMF8+puRW6ebyQ+AXrcrKkwuj4wzJuEBD0AdhHGtw==",
       "cpu": [
         "x64"
       ],
@@ -28527,7 +28527,7 @@
       "license": "MIT",
       "dependencies": {
         "@duckdb/duckdb-wasm": "1.33.1-dev13.0",
-        "@duckdb/node-api": "1.4.3-r.1",
+        "@duckdb/node-api": "1.4.4-r.1",
         "@malloydata/malloy": "0.0.349",
         "@motherduck/wasm-client": "^0.6.6",
         "apache-arrow": "^17.0.0",

--- a/packages/malloy-db-duckdb/package.json
+++ b/packages/malloy-db-duckdb/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "1.33.1-dev13.0",
-    "@duckdb/node-api": "1.4.3-r.1",
+    "@duckdb/node-api": "1.4.4-r.1",
     "@malloydata/malloy": "0.0.349",
     "@motherduck/wasm-client": "^0.6.6",
     "apache-arrow": "^17.0.0",

--- a/test/src/core/multi_connection.spec.ts
+++ b/test/src/core/multi_connection.spec.ts
@@ -26,7 +26,7 @@
 
 import * as malloy from '@malloydata/malloy';
 import {EmptyURLReader} from '@malloydata/malloy';
-import {DuckDBTestConnection, PostgresTestConnection} from '../runtimes';
+import {DuckDBROTestConnection, PostgresTestConnection} from '../runtimes';
 import {describeIfDatabaseAvailable} from '../util';
 
 const [, databases] = describeIfDatabaseAvailable(['duckdb', 'postgres']);
@@ -39,7 +39,7 @@ const describe =
     : globalThis.describe.skip;
 
 describe('Multi-connection', () => {
-  const ddbConnection = new DuckDBTestConnection(
+  const ddbConnection = new DuckDBROTestConnection(
     'duckdb',
     'test/data/duckdb/duckdb_test.db'
   );


### PR DESCRIPTION
Apparently #2681 is the result of something in the mssql/azure extensions requiring 1.4.4 of duckdub at minimum to work.

| _The mssql extension provides a DuckDB connector for Microsoft SQL Server using the native TDS protocol Support DuckDB version: 1.4.4 and later._
( from https://github.com/duckdb/community-extensions/blob/main/extensions/mssql/description.yml )
## Summary

- Bumps `@duckdb/node-api` from 1.4.3-r.1 to 1.4.4-r.1
- Fixes `multi_connection.spec.ts` to open the shared test DB in read-only mode. Update to 1.44 forces this for reasons which I did not feel like spending an hour to figure out, it's a good fix, the mystery is why it was needed.


## Test plan

- [x] `npm run test-duckdb` passes (2664 tests, 0 failures)
- [ ] CI green