### PR TITLE
Strict persistence: BuildManifest carries strict flag

### DIFF
--- a/packages/malloy/src/api/CONTEXT.md
+++ b/packages/malloy/src/api/CONTEXT.md
@@ -168,7 +168,8 @@ const runtime = new Runtime({
 const result = await runtime.loadQuery(modelURL).run();
 
 // Pass empty manifest to get unsubstituted SQL
-const rawSQL = await runtime.loadQuery(modelURL, {buildManifest: {}}).getSQL();
+import {EMPTY_BUILD_MANIFEST} from '@malloydata/malloy';
+const rawSQL = await runtime.loadQuery(modelURL, {buildManifest: EMPTY_BUILD_MANIFEST}).getSQL();
 ```
 
 **Manifest can also be set after construction:**
@@ -183,7 +184,15 @@ runtime.buildManifest = manifest.buildManifest;
 | Class | Purpose |
 |-------|---------|
 | `MalloyConfig` | Loads `malloy-config.json` (connections + manifest path). Two construction modes: from URL (async `load()`) or from text (sync). |
-| `Manifest` | In-memory manifest store. `load(url)` reads via URLReader, `loadText(json)` parses directly. `update()` and `touch()` for builders, `activeEntries` for writing. The `buildManifest` getter returns a stable reference — mutations are visible to the Runtime without re-assignment. |
+| `Manifest` | In-memory manifest store. `load(url)` reads via URLReader, `loadText(json)` parses directly. `update()` and `touch()` for builders, `activeEntries` for writing. The `buildManifest` getter returns a stable `BuildManifest` reference (`{entries, strict}`) — mutations are visible to the Runtime without re-assignment. The `strict` flag is loaded from the manifest file and can be overridden via `manifest.strict = value`. |
+
+`MalloyConfig` is the standard entry point for both the CLI (`malloydata/malloy-cli`) and the VS Code extension. The config file determines connections, and the manifest is resolved relative to the config file's location:
+
+```
+<configDir>/<manifestPath>/malloy-manifest.json
+```
+
+`manifestPath` defaults to `"MANIFESTS"`. Calling `config.load()` reads both the config and the manifest in one step. The `Manifest` class can also be used standalone (e.g. in builder sketches), but in practice config and manifest are almost always tied — you read the config to find the manifest.
 
 ---
 

--- a/packages/malloy/src/api/foundation/config.ts
+++ b/packages/malloy/src/api/foundation/config.ts
@@ -31,12 +31,19 @@ export interface MalloyProjectConfig {
  * In-memory manifest store. Reads, updates, and serializes manifest data.
  *
  * Always valid — starts empty, call load() to populate from a file.
- * The internal BuildManifest object is stable: load() and update() mutate
- * the same object, so any reference obtained via `buildManifest` stays current.
+ * The BuildManifest object returned by `buildManifest` is stable: load()
+ * and update() mutate the same entries object, so any reference obtained
+ * via `buildManifest` stays current without re-assignment.
+ *
+ * The `strict` flag controls what happens when a persist source's BuildID
+ * is not found in the manifest. When strict, the compiler throws an error
+ * instead of falling through to inline SQL. The flag is loaded from the
+ * manifest file and can be overridden by the application before creating
+ * a Runtime.
  */
 export class Manifest {
   private readonly _urlReader?: URLReader;
-  private readonly _data: BuildManifest = {};
+  private readonly _manifest: BuildManifest = {entries: {}, strict: false};
   private readonly _touched = new Set<BuildID>();
 
   constructor(urlReader?: URLReader) {
@@ -50,11 +57,9 @@ export class Manifest {
    * is available, clears to empty.
    */
   async load(manifestRoot: URL): Promise<void> {
-    // Clear existing entries and touched set
-    for (const key of Object.keys(this._data)) {
-      delete this._data[key];
-    }
+    this._clearEntries();
     this._touched.clear();
+    this._manifest.strict = false;
 
     if (!this._urlReader) return;
 
@@ -72,8 +77,7 @@ export class Manifest {
       return;
     }
 
-    const loaded: BuildManifest = JSON.parse(contents);
-    Object.assign(this._data, loaded);
+    this._loadParsed(JSON.parse(contents));
   }
 
   /**
@@ -81,28 +85,38 @@ export class Manifest {
    * Replaces any existing data.
    */
   loadText(jsonText: string): void {
-    for (const key of Object.keys(this._data)) {
-      delete this._data[key];
-    }
+    this._clearEntries();
     this._touched.clear();
-    const loaded: BuildManifest = JSON.parse(jsonText);
-    Object.assign(this._data, loaded);
+    this._manifest.strict = false;
+    this._loadParsed(JSON.parse(jsonText));
   }
 
   /**
    * The live BuildManifest. This is a stable reference — load() and update()
    * mutate the same object, so passing this to a Runtime means the Runtime
-   * always sees current data.
+   * always sees current data including the strict flag.
    */
   get buildManifest(): BuildManifest {
-    return this._data;
+    return this._manifest;
+  }
+
+  /**
+   * Whether missing manifest entries should cause errors.
+   * Loaded from the manifest file; can be overridden by the application.
+   */
+  get strict(): boolean {
+    return this._manifest.strict ?? false;
+  }
+
+  set strict(value: boolean) {
+    this._manifest.strict = value;
   }
 
   /**
    * Add or replace a manifest entry. Also marks it as touched.
    */
   update(buildId: BuildID, entry: BuildManifestEntry): void {
-    this._data[buildId] = entry;
+    this._manifest.entries[buildId] = entry;
     this._touched.add(buildId);
   }
 
@@ -115,18 +129,50 @@ export class Manifest {
   }
 
   /**
-   * Returns only entries that were update()d or touch()ed.
-   * This is the manifest a builder should write — it reflects
-   * exactly what the current build references.
+   * Returns a BuildManifest with only entries that were update()d or touch()ed.
+   * This is the manifest a builder should write — it reflects exactly what the
+   * current build references. Preserves the strict flag.
    */
   get activeEntries(): BuildManifest {
-    const result: BuildManifest = {};
+    const entries: Record<BuildID, BuildManifestEntry> = {};
     for (const id of this._touched) {
-      if (this._data[id]) {
-        result[id] = this._data[id];
+      if (this._manifest.entries[id]) {
+        entries[id] = this._manifest.entries[id];
       }
     }
-    return result;
+    return {entries, strict: this._manifest.strict};
+  }
+
+  private _clearEntries(): void {
+    for (const key of Object.keys(this._manifest.entries)) {
+      delete this._manifest.entries[key];
+    }
+  }
+
+  private _loadParsed(parsed: Record<string, unknown>): void {
+    if (typeof parsed['strict'] === 'boolean') {
+      this._manifest.strict = parsed['strict'];
+    }
+    // New format: {entries: {...}, strict?: boolean}
+    // Old format: {buildId: {tableName}, ...} (flat record, no "entries" key)
+    let entries: Record<string, BuildManifestEntry>;
+    if (parsed['entries'] && typeof parsed['entries'] === 'object') {
+      entries = parsed['entries'] as Record<string, BuildManifestEntry>;
+    } else {
+      // Treat as old flat-record format: every key with a tableName is an entry
+      entries = {};
+      for (const [key, val] of Object.entries(parsed)) {
+        if (
+          key !== 'strict' &&
+          val &&
+          typeof val === 'object' &&
+          'tableName' in val
+        ) {
+          entries[key] = val as BuildManifestEntry;
+        }
+      }
+    }
+    Object.assign(this._manifest.entries, entries);
   }
 }
 

--- a/packages/malloy/src/api/foundation/index.ts
+++ b/packages/malloy/src/api/foundation/index.ts
@@ -13,6 +13,7 @@ export type {
   BuildNode,
   BuildGraph,
 } from './types';
+export {EMPTY_BUILD_MANIFEST} from './types';
 
 // URL readers and connection helpers
 export {

--- a/packages/malloy/src/api/foundation/runtime.ts
+++ b/packages/malloy/src/api/foundation/runtime.ts
@@ -824,20 +824,28 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
       };
 
       // Use manifest from options if provided, otherwise fall back to Runtime's manifest.
-      // Pass an empty {} in options to explicitly suppress manifest substitution.
+      // Pass EMPTY_BUILD_MANIFEST in options to explicitly suppress manifest substitution.
       const explicitManifest = mergedOptions.buildManifest !== undefined;
       let buildManifest =
         mergedOptions.buildManifest ?? this.runtime.buildManifest;
 
-      // If we have a manifest, compute connectionDigests for manifest lookups
+      // If we have a manifest with entries, compute connectionDigests for lookups.
       // TODO: This is inefficient - we call getBuildPlan just to find connection names.
       // Consider adding a listConnections() method to LookupConnection, or caching this.
       let connectionDigests: Record<string, string> | undefined;
+      if (
+        buildManifest &&
+        Object.keys(buildManifest.entries).length === 0 &&
+        !buildManifest.strict
+      ) {
+        // Empty non-strict manifest — nothing to substitute, skip persistence checks
+        buildManifest = undefined;
+      }
       if (buildManifest) {
         const modelTag = preparedQuery.model.tagParse({prefix: /^##! /}).tag;
         if (!modelTag.has('experimental', 'persistence')) {
           if (explicitManifest) {
-            // Explicitly passed manifest requires persistence support
+            // Explicitly passed non-empty manifest requires persistence support
             throw new Error(
               'Model must have ##! experimental.persistence to use buildManifest'
             );
@@ -864,7 +872,6 @@ export class QueryMaterializer extends FluentState<PreparedQuery> {
         defaultRowLimit: mergedOptions.defaultRowLimit,
         buildManifest,
         connectionDigests,
-        strictPersist: mergedOptions.strictPersist,
       };
 
       return preparedQuery.getPreparedResult({

--- a/packages/malloy/src/api/foundation/types.ts
+++ b/packages/malloy/src/api/foundation/types.ts
@@ -6,6 +6,19 @@
 import type {EventStream} from '../../runtime_types';
 import type {BuildManifest} from '../../model';
 
+/**
+ * An empty BuildManifest with no entries and strict mode off.
+ * Use this to explicitly suppress manifest substitution in a query:
+ *
+ *   runtime.loadQuery(url, {buildManifest: EMPTY_BUILD_MANIFEST}).getSQL()
+ *
+ * Frozen to prevent accidental mutation of the shared sentinel.
+ */
+export const EMPTY_BUILD_MANIFEST: BuildManifest = Object.freeze({
+  entries: Object.freeze({}),
+  strict: false,
+});
+
 export type {Taggable} from '../../taggable';
 
 export interface Loggable {
@@ -34,12 +47,10 @@ export interface CompileOptions {
 export interface CompileQueryOptions {
   eventStream?: EventStream;
   defaultRowLimit?: number;
-  /** Manifest of built tables (BuildID → entry) for persist substitution */
+  /** Manifest of built tables for persist source substitution */
   buildManifest?: BuildManifest;
   /** Map from connectionName to connectionDigest (from Connection.getDigest()) */
   connectionDigests?: Record<string, string>;
-  /** If true, throw when a persist source's BuildID is not in the manifest */
-  strictPersist?: boolean;
 }
 
 // =============================================================================

--- a/packages/malloy/src/connection/CONTEXT.md
+++ b/packages/malloy/src/connection/CONTEXT.md
@@ -57,7 +57,7 @@ The `is` field identifies the backend. Any property value can be a `{env: "VAR"}
 
 ## API Functions
 
-All exported from `@malloydata/malloy` and available as static methods on the `Malloy` class:
+### Public (exported from `@malloydata/malloy`)
 
 | Function | Purpose |
 |----------|---------|
@@ -65,23 +65,36 @@ All exported from `@malloydata/malloy` and available as static methods on the `M
 | `getRegisteredConnectionTypes()` | Returns all registered backend names |
 | `getConnectionTypeDisplayName(typeName)` | Returns human-readable display name |
 | `getConnectionProperties(typeName)` | Returns `ConnectionPropertyDefinition[]` for a backend |
-| `readConnectionsConfig(jsonText)` | Parse JSON config string, validate `is` fields |
-| `writeConnectionsConfig(config)` | Serialize config to JSON (2-space indent) |
-| `createConnectionsFromConfig(config)` | Returns `LookupConnection<Connection>` with lazy creation + caching |
 | `isValueRef(value)` | Type guard: is this a `{env: string}` reference? |
 | `resolveValue(vr)` | Resolve a `ValueRef` from `process.env` |
 
+### Internal (used by `MalloyConfig`, not re-exported)
+
+| Function | Purpose |
+|----------|---------|
+| `readConnectionsConfig(jsonText)` | Parse JSON config string, validate `is` fields |
+| `writeConnectionsConfig(config)` | Serialize config to JSON (2-space indent) |
+| `createConnectionsFromConfig(config)` | Returns `LookupConnection<Connection>` with lazy creation + caching |
+
 ### Usage Pattern
+
+The standard way to get connections is through `MalloyConfig`, which reads a `malloy-config.json` file and uses the registry internally:
 
 ```typescript
 import '@malloydata/malloy-connections';  // registers all backends
-import {Runtime, readConnectionsConfig, createConnectionsFromConfig} from '@malloydata/malloy';
+import {Runtime, MalloyConfig} from '@malloydata/malloy';
 
-const configText = fs.readFileSync('malloy-config.json', 'utf-8');
-const config = readConnectionsConfig(configText);
-const connections = createConnectionsFromConfig(config);
-const runtime = new Runtime({connections, urlReader});
+const config = new MalloyConfig(urlReader, configURL);
+await config.load();  // reads config JSON + manifest
+
+const runtime = new Runtime({
+  urlReader,
+  connections: config.connections,
+  buildManifest: config.manifest.buildManifest,
+});
 ```
+
+`MalloyConfig.connections` calls `createConnectionsFromConfig()` internally. Each access creates a fresh `LookupConnection` snapshot from the current `connectionMap`.
 
 ## Property Type System
 

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -265,5 +265,5 @@ export type {SQLSourceRequest} from './lang/translate-response';
 export {sqlKey} from './model/sql_block';
 export {annotationToTag, annotationToTaglines} from './annotation';
 export type {BuildGraph, BuildNode, BuildPlan} from './api/foundation';
-export {PersistSource} from './api/foundation';
+export {PersistSource, EMPTY_BUILD_MANIFEST} from './api/foundation';
 export {makeDigest} from './model';

--- a/packages/malloy/src/model/malloy_types.ts
+++ b/packages/malloy/src/model/malloy_types.ts
@@ -2008,12 +2008,10 @@ export interface PrepareResultOptions {
   defaultRowLimit?: number;
   isPartialQuery?: boolean; // Query is being used as a sql_block
   eventStream?: EventStream;
-  /** Manifest of built tables (BuildID → entry), the build cache */
+  /** Manifest of built tables for persist source substitution */
   buildManifest?: BuildManifest;
   /** Map from connectionName to connectionDigest (from Connection.getDigest()) */
   connectionDigests?: SafeRecord<string>;
-  /** If true, throw when a persist query's digest is not in the manifest */
-  strictPersist?: boolean;
 }
 
 type UTD =
@@ -2124,10 +2122,16 @@ export interface BuildManifestEntry {
 
 /**
  * Manifest of persisted build results (the build cache).
- * Maps BuildID → BuildManifestEntry. Used by compileQuery to substitute
- * persist sources with table references. Content-addressable: same SQL +
- * same connection digest = same BuildID regardless of which model produced it.
+ * Used by compileQuery to substitute persist sources with table references.
+ * Content-addressable: same SQL + same connection digest = same BuildID
+ * regardless of which model produced it.
+ *
+ * When `strict` is true, a missing entry for a persist source throws an error
+ * instead of falling through to inline SQL.
  */
-export type BuildManifest = Record<BuildID, BuildManifestEntry>;
+export interface BuildManifest {
+  entries: Record<BuildID, BuildManifestEntry>;
+  strict?: boolean;
+}
 
 // clang-format on

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -788,7 +788,7 @@ export class QueryQuery extends QueryField {
       case 'nest_source':
         return qs.structDef.pipeSQL;
       case 'query_source': {
-        const {buildManifest, connectionDigests, strictPersist} =
+        const {buildManifest, connectionDigests} =
           qs.prepareResultOptions ?? {};
 
         // Check manifest for this source
@@ -806,14 +806,14 @@ export class QueryQuery extends QueryField {
               false
             );
             const buildId = mkBuildID(connDigest, fullRet.sql!);
-            const entry = buildManifest[buildId];
+            const entry = buildManifest.entries[buildId];
 
             if (entry) {
               // Found in manifest - use persisted table
               return this.parent.dialect.quoteTablePath(entry.tableName);
             }
 
-            if (strictPersist) {
+            if (buildManifest.strict) {
               throw new Error(
                 `Persist source '${qs.structDef.sourceID}' not found in manifest (buildId: ${buildId})`
               );

--- a/packages/malloy/src/model/sql_compiled.ts
+++ b/packages/malloy/src/model/sql_compiled.ts
@@ -86,7 +86,7 @@ function expandPersistableSource(
   quoteTablePath: (path: string) => string,
   compileQuery: CompileQueryCallback
 ): string {
-  const {buildManifest, connectionDigests, strictPersist} = opts;
+  const {buildManifest, connectionDigests} = opts;
 
   // Try manifest lookup if we have the required info
   if (buildManifest && connectionDigests) {
@@ -95,7 +95,7 @@ function expandPersistableSource(
       // Get the SQL for this source to compute BuildID (no opts = full SQL)
       const sql = getSourceSQL(source, quoteTablePath, compileQuery);
       const buildId = mkBuildID(connDigest, sql);
-      const entry = buildManifest[buildId];
+      const entry = buildManifest.entries[buildId];
 
       if (entry) {
         // Found in manifest - substitute with subquery from persisted table
@@ -103,7 +103,7 @@ function expandPersistableSource(
       }
 
       // Not in manifest
-      if (strictPersist) {
+      if (buildManifest.strict) {
         throw new Error(
           `Persist source '${source.sourceID}' not found in manifest (buildId: ${buildId})`
         );

--- a/scripts/simple_builder/build.ts
+++ b/scripts/simple_builder/build.ts
@@ -152,7 +152,7 @@ export async function build(opts: BuildOptions): Promise<void> {
       validateTableName(tableName);
 
       // Already built — just mark it active in the manifest
-      if (manifest.buildManifest[buildId]) {
+      if (manifest.buildManifest.entries[buildId]) {
         manifest.touch(buildId);
         console.log(`  Exists: ${source.name} -> ${tableName}`);
         logEntries.push({action: 'exists', buildId, tableName, nameProvided});

--- a/scripts/simple_builder/test.ts
+++ b/scripts/simple_builder/test.ts
@@ -22,8 +22,8 @@ import * as path from 'path';
 import {build} from './build';
 import {gc} from './gc';
 import type {BuilderLog, GCLog, Log} from './log_types';
-import type {Connection} from '@malloydata/malloy';
-import {Runtime, Manifest} from '@malloydata/malloy';
+import type {Connection, BuildManifest} from '@malloydata/malloy';
+import {Runtime, Manifest, EMPTY_BUILD_MANIFEST} from '@malloydata/malloy';
 // eslint-disable-next-line n/no-extraneous-import
 import {DuckDBConnection} from '@malloydata/db-duckdb';
 
@@ -111,12 +111,14 @@ test('build v1 → build v2 → gc → gc', async () => {
       logDir: LOG_DIR,
     });
 
-    const manifest1 =
-      await readJSON<Record<string, {tableName: string}>>(MANIFEST_FILE);
-    const names1 = Object.values(manifest1).map(e => e.tableName);
+    const manifest1 = await readJSON<BuildManifest>(MANIFEST_FILE);
+    const names1 = Object.values(manifest1.entries).map(e => e.tableName);
     check(names1.includes('by_carrier'), 'manifest has by_carrier');
     check(names1.includes('by_origin'), 'manifest has by_origin');
-    check(Object.keys(manifest1).length === 2, 'manifest has 2 entries');
+    check(
+      Object.keys(manifest1.entries).length === 2,
+      'manifest has 2 entries'
+    );
 
     const sql1 = await readFile(SQL_FILE, 'utf-8');
     check(
@@ -148,13 +150,15 @@ test('build v1 → build v2 → gc → gc', async () => {
       logDir: LOG_DIR,
     });
 
-    const manifest2 =
-      await readJSON<Record<string, {tableName: string}>>(MANIFEST_FILE);
-    const names2 = Object.values(manifest2).map(e => e.tableName);
+    const manifest2 = await readJSON<BuildManifest>(MANIFEST_FILE);
+    const names2 = Object.values(manifest2.entries).map(e => e.tableName);
     check(names2.includes('by_carrier'), 'manifest still has by_carrier');
     check(names2.includes('by_destination'), 'manifest has by_destination');
     check(!names2.includes('by_origin'), 'manifest no longer has by_origin');
-    check(Object.keys(manifest2).length === 2, 'manifest has 2 entries');
+    check(
+      Object.keys(manifest2.entries).length === 2,
+      'manifest has 2 entries'
+    );
 
     const sql2 = await readFile(SQL_FILE, 'utf-8');
     check(
@@ -279,7 +283,9 @@ test('runtime queries with and without manifest', async () => {
 
     // Two query materializers: manifest from runtime, and explicitly empty
     const queryWithManifest = runtime.loadQuery(modelWithQuery);
-    const queryPlain = runtime.loadQuery(modelWithQuery, {buildManifest: {}});
+    const queryPlain = runtime.loadQuery(modelWithQuery, {
+      buildManifest: EMPTY_BUILD_MANIFEST,
+    });
 
     // ── SQL comparison ─────────────────────────────────────────────
     // The manifest SQL should reference the persisted table directly
@@ -298,7 +304,7 @@ test('runtime queries with and without manifest', async () => {
     console.log('\n=== Runtime: data comparison ===');
     const resultManifest = await runtime.loadQuery(modelWithQuery).run();
     const resultPlain = await runtime
-      .loadQuery(modelWithQuery, {buildManifest: {}})
+      .loadQuery(modelWithQuery, {buildManifest: EMPTY_BUILD_MANIFEST})
       .run();
 
     const dataPlain = resultPlain.data.toObject();

--- a/test/src/core/persist.spec.ts
+++ b/test/src/core/persist.spec.ts
@@ -6,7 +6,11 @@
 import {runtimeFor, testFileSpace, DuckDBROTestConnection} from '../runtimes';
 import {wrapTestModel} from '@malloydata/malloy/test';
 import type {BuildNode, BuildManifest} from '@malloydata/malloy';
-import {ConnectionRuntime, SingleConnectionRuntime} from '@malloydata/malloy';
+import {
+  ConnectionRuntime,
+  SingleConnectionRuntime,
+  EMPTY_BUILD_MANIFEST,
+} from '@malloydata/malloy';
 import {DuckDBConnection} from '@malloydata/db-duckdb';
 
 // Helper to extract all sourceIDs from a nested BuildNode array (recursive)
@@ -47,7 +51,7 @@ function findNode(nodes: BuildNode[][], pattern: string) {
 
 // Create empty manifest
 function createManifest(): BuildManifest {
-  return {};
+  return {entries: {}};
 }
 
 // Add entry to manifest
@@ -56,7 +60,7 @@ function addManifestEntry(
   buildId: string,
   tableName: string
 ) {
-  manifest[buildId] = {tableName};
+  manifest.entries[buildId] = {tableName};
 }
 
 // Connection digest (cached)
@@ -304,6 +308,7 @@ describe('source persistence', () => {
 
         const connectionDigest = await getDigest();
         const manifest = createManifest();
+        manifest.strict = true;
 
         const wrapper = Object.values(plan.sources).find(
           s => s.name === 'wrapper'
@@ -314,7 +319,6 @@ describe('source persistence', () => {
           wrapper.getSQL({
             buildManifest: manifest,
             connectionDigests: {[tstDB]: connectionDigest},
-            strictPersist: true,
           })
         ).toThrow(/not found in manifest/);
       });
@@ -1222,7 +1226,7 @@ describe('source persistence', () => {
       const wrapperBuildId = wrapper.makeBuildId(connectionDigest, wrapperSQL);
       addManifestEntry(manifest, wrapperBuildId, 'build_cache.wrapper_v1');
 
-      expect(Object.keys(manifest)).toHaveLength(2);
+      expect(Object.keys(manifest.entries)).toHaveLength(2);
       expect(carrierStatsBuildId).not.toBe(wrapperBuildId);
     });
   });
@@ -1463,7 +1467,7 @@ describe('source persistence', () => {
       expect(() => model.getBuildPlan()).toThrow('experimental.persistence');
     });
 
-    it('running query with buildManifest throws without experimental.persistence annotation', async () => {
+    it('running query with non-empty buildManifest throws without experimental.persistence annotation', async () => {
       const testModel = wrapTestModel(
         tstRuntime,
         `
@@ -1474,6 +1478,7 @@ describe('source persistence', () => {
       );
 
       const manifest = createManifest();
+      addManifestEntry(manifest, 'fake-build-id', 'some_table');
 
       await expect(
         testModel.model
@@ -1552,7 +1557,7 @@ describe('source persistence', () => {
 
       // Override with empty manifest — SQL should NOT reference the table
       const sqlWithoutManifest = await runtimeWithManifest
-        .loadQuery(modelCode, {buildManifest: {}})
+        .loadQuery(modelCode, {buildManifest: EMPTY_BUILD_MANIFEST})
         .getSQL();
       expect(sqlWithoutManifest).not.toMatch(/FROM\s+by_carrier\s/);
     });
@@ -1609,7 +1614,7 @@ describe('source persistence', () => {
         const resultManifest = await rwRuntime.loadQuery(modelCode).run();
         // Run without manifest (inlines the query)
         const resultPlain = await rwRuntime
-          .loadQuery(modelCode, {buildManifest: {}})
+          .loadQuery(modelCode, {buildManifest: EMPTY_BUILD_MANIFEST})
           .run();
 
         const dataManifest = resultManifest.data.toObject();
@@ -1680,6 +1685,80 @@ describe('source persistence', () => {
       // Now SQL SHOULD reference the table
       const sqlAfter = await runtime.loadQuery(modelCode).getSQL();
       expect(sqlAfter).toMatch(/FROM\s+by_carrier\s/);
+    });
+  });
+
+  describe('strict manifest', () => {
+    const strictModelCode = `${PERSIST_ANNOTATION}
+      source: flights is ${tstDB}.table('malloytest.flights')
+
+      #@ persist
+      source: by_carrier is flights -> {
+        group_by: carrier
+        aggregate: flight_count is count()
+      }
+
+      run: by_carrier -> { select: * }
+    `;
+
+    it('strict manifest throws when persist source is missing from manifest', async () => {
+      const manifest = createManifest();
+      manifest.strict = true;
+
+      const runtime = new SingleConnectionRuntime({
+        connection: tstRuntime.connection,
+        urlReader: testFileSpace,
+        buildManifest: manifest,
+      });
+
+      await expect(runtime.loadQuery(strictModelCode).getSQL()).rejects.toThrow(
+        'not found in manifest'
+      );
+    });
+
+    it('strict manifest succeeds when persist source is in manifest', async () => {
+      const {plan} = await getPersistPlan(`
+        source: flights is ${tstDB}.table('malloytest.flights')
+
+        #@ persist
+        source: by_carrier is flights -> {
+          group_by: carrier
+          aggregate: flight_count is count()
+        }
+      `);
+
+      const connectionDigest = await getDigest();
+      const source = Object.values(plan.sources)[0];
+      const sql = source.getSQL();
+      const buildId = source.makeBuildId(connectionDigest, sql);
+
+      const manifest = createManifest();
+      manifest.strict = true;
+      addManifestEntry(manifest, buildId, 'cached.by_carrier');
+
+      const runtime = new SingleConnectionRuntime({
+        connection: tstRuntime.connection,
+        urlReader: testFileSpace,
+        buildManifest: manifest,
+      });
+
+      const resultSQL = await runtime.loadQuery(strictModelCode).getSQL();
+      expect(resultSQL).toContain('cached.by_carrier');
+    });
+
+    it('non-strict manifest falls through when persist source is missing', async () => {
+      const manifest = createManifest();
+      // strict is undefined/false by default
+
+      const runtime = new SingleConnectionRuntime({
+        connection: tstRuntime.connection,
+        urlReader: testFileSpace,
+        buildManifest: manifest,
+      });
+
+      // Should not throw — falls through to inline SQL
+      const sql = await runtime.loadQuery(strictModelCode).getSQL();
+      expect(sql).toContain('COUNT(');
     });
   });
 });


### PR DESCRIPTION
## Summary

- `BuildManifest` changes from `Record<BuildID, BuildManifestEntry>` to an interface with `entries` and `strict`
- When `strict` is true in a manifest, missing entries throw instead of falling through to inline SQL
- The separate `strictPersist` option on `CompileQueryOptions` and `PrepareResultOptions` is removed — strictness is now a property of the manifest itself
- `EMPTY_BUILD_MANIFEST` constant exported for the suppress-substitution pattern
- Old-format manifest files (flat record without `entries` key) are auto-detected and loaded correctly

## Migration guide for builder clients

### BuildManifest type changed

**Before:**
```typescript
const manifest: BuildManifest = {};
manifest[buildId] = {tableName: 'my_table'};
```

**After:**
```typescript
const manifest: BuildManifest = {entries: {}};
manifest.entries[buildId] = {tableName: 'my_table'};
```

### Manifest file format changed

**Before (`malloy-manifest.json`):**
```json
{
  "abc123": {"tableName": "my_table"},
  "def456": {"tableName": "other_table"}
}
```

**After:**
```json
{
  "entries": {
    "abc123": {"tableName": "my_table"},
    "def456": {"tableName": "other_table"}
  },
  "strict": true
}
```

Old-format files are auto-detected and loaded correctly, so existing manifests keep working.

### Suppress-substitution pattern changed

**Before:**
```typescript
runtime.loadQuery(url, {buildManifest: {}}).getSQL()
```

**After:**
```typescript
import {EMPTY_BUILD_MANIFEST} from '@malloydata/malloy';
runtime.loadQuery(url, {buildManifest: EMPTY_BUILD_MANIFEST}).getSQL()
```

### strictPersist option removed

**Before:**
```typescript
source.getSQL({buildManifest: manifest, connectionDigests, strictPersist: true})
```

**After:** Set `strict` on the manifest itself:
```typescript
manifest.strict = true;
source.getSQL({buildManifest: manifest, connectionDigests})
```

Or if using the `Manifest` class:
```typescript
manifest.strict = true; // override what was loaded from file
// manifest.buildManifest now includes strict: true
```

### Using strict mode

The builder writes `"strict": true` in the manifest file. Any consumer (CLI, VSCode) that loads the manifest gets strict behavior automatically. To override:

```typescript
const config = new MalloyConfig(urlReader, configURL);
await config.load();
config.manifest.strict = false; // override file-loaded strictness
```

## Test plan

- [x] `npm run build -w @malloydata/malloy` — type-checks
- [x] `npx jest test/src/core/persist.spec.ts` — 52 tests pass (3 new strict mode tests)
- [x] `npx ts-node scripts/simple_builder/test.ts` — integration test passes
- [x] `npm run lint-fix` — clean
- [ ] CI full test suite