### PR TITLE
Add render tag validation and unread tag detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@malloydata/db-bigquery": "*",
         "@malloydata/db-mysql": "*",
         "@malloydata/malloy": "*",
-        "@malloydata/motly-ts-parser": "^0.5.0",
+        "@malloydata/motly-ts-parser": "^0.6.0",
         "@malloydata/render": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.0.3",
@@ -6220,10 +6220,9 @@
       "link": true
     },
     "node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.5.0.tgz",
-      "integrity": "sha512-OmsunGe6YbYrK++si/6eC0dPrE/mQH/QdkemHD/ywIaulfw+y/uYA13vYpMFhHm0aSqFWg9vuz3JlH89cjVVxw==",
-      "dev": true,
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.6.0.tgz",
+      "integrity": "sha512-mqqbLph3ATVIpclLY4Pofj54fLR9quumv/AdKkENl0u2/VUplfQuqwJRmisniDL620+UXOb0bRywkIwxBxtELw==",
       "license": "MIT"
     },
     "node_modules/@malloydata/render": {
@@ -30137,7 +30136,7 @@
       "version": "0.0.352",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/motly-ts-parser": "^0.4.0",
+        "@malloydata/motly-ts-parser": "^0.6.0",
         "assert": "^2.0.0"
       },
       "devDependencies": {
@@ -30147,12 +30146,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "packages/malloy-tag/node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.4.0.tgz",
-      "integrity": "sha512-n/+P4bCxhQzenae6eYNJFKy5j4eD400A0/NSTE8Ro3wJWJvkwvnIP98ieBNpmnn18NhBv7hn9CnpYtPTaJIDEA==",
-      "license": "MIT"
     },
     "packages/malloy-tag/node_modules/glob": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@malloydata/db-bigquery": "*",
     "@malloydata/db-mysql": "*",
     "@malloydata/malloy": "*",
-    "@malloydata/motly-ts-parser": "^0.5.0",
+    "@malloydata/motly-ts-parser": "^0.6.0",
     "@malloydata/render": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.0.3",

--- a/packages/malloy-render/.storybook/malloy-stories-indexer.ts
+++ b/packages/malloy-render/.storybook/malloy-stories-indexer.ts
@@ -144,6 +144,9 @@ export function viteMalloyStoriesPlugin(): PluginOption {
           import {MalloyRenderer} from '../api/malloy-renderer';
           import {DummyPluginFactory} from '@/plugins/dummy-plugin';
           import {DummyDOMPluginFactory} from '@/plugins/dummy-dom-plugin';
+          import {addons} from '@storybook/preview-api';
+
+          const RENDERER_LOGS_EVENT = 'malloy/renderer-logs/logs';
 
           const meta = {
             title: "Malloy Next/${modelStoriesMeta.componentName}",
@@ -189,6 +192,12 @@ export function viteMalloyStoriesPlugin(): PluginOption {
               console.log('tag', tag, tag?.toString());
               console.groupEnd();
               viz.render(targetElement);
+
+              viz.onReady(() => {
+                const logs = viz.getLogs();
+                const channel = addons.getChannel();
+                channel.emit(RENDERER_LOGS_EVENT, logs);
+              });
 
               return parent;
             },

--- a/packages/malloy-render/.storybook/manager.ts
+++ b/packages/malloy-render/.storybook/manager.ts
@@ -1,15 +1,25 @@
-import {addons} from '@storybook/manager-api';
+import React from 'react';
+import {addons, types} from '@storybook/manager-api';
 import theme from './theme';
+import {RendererLogsPanel, ADDON_ID, PANEL_ID} from './renderer-logs-panel';
+
+addons.register(ADDON_ID, () => {
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title: 'Renderer Logs',
+    render: ({active}) => React.createElement(RendererLogsPanel, {active}),
+  });
+});
 
 addons.setConfig({
   theme,
   isFullscreen: false,
   showNav: true,
-  showPanel: false,
+  showPanel: true,
   panelPosition: 'bottom',
   enableShortcuts: true,
   showToolbar: false,
-  selectedPanel: undefined,
+  selectedPanel: PANEL_ID,
   initialActive: 'sidebar',
   sidebar: {},
   toolbar: {},

--- a/packages/malloy-render/.storybook/renderer-logs-panel.ts
+++ b/packages/malloy-render/.storybook/renderer-logs-panel.ts
@@ -1,0 +1,67 @@
+import React, {useState} from 'react';
+import {useChannel} from '@storybook/manager-api';
+import {AddonPanel} from '@storybook/components';
+
+export const ADDON_ID = 'malloy/renderer-logs';
+export const PANEL_ID = `${ADDON_ID}/panel`;
+export const EVENT_ID = `${ADDON_ID}/logs`;
+
+interface LogMessage {
+  severity: string;
+  message: string;
+}
+
+const h = React.createElement;
+
+function LogsContent() {
+  const [logs, setLogs] = useState<LogMessage[]>([]);
+
+  useChannel({
+    [EVENT_ID]: (newLogs: LogMessage[]) => {
+      setLogs(newLogs);
+    },
+  });
+
+  if (logs.length === 0) {
+    return h(
+      'div',
+      {
+        style: {
+          padding: '12px',
+          color: '#888',
+          fontFamily: 'monospace',
+          fontSize: '12px',
+        },
+      },
+      'No renderer logs.'
+    );
+  }
+
+  return h(
+    'div',
+    {style: {padding: '8px', fontFamily: 'monospace', fontSize: '12px'}},
+    logs.map((log, i) =>
+      h(
+        'div',
+        {
+          key: i,
+          style: {
+            padding: '4px 8px',
+            color: log.severity === 'error' ? '#c62828' : '#f57f17',
+            borderBottom: '1px solid #eee',
+          },
+        },
+        h(
+          'span',
+          {style: {marginRight: '6px'}},
+          log.severity === 'error' ? '\u274c' : '\u26a0\ufe0f'
+        ),
+        log.message
+      )
+    )
+  );
+}
+
+export function RendererLogsPanel(props: {active?: boolean}) {
+  return h(AddonPanel, {active: props.active ?? false}, h(LogsContent));
+}

--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -84,6 +84,191 @@ The table uses CSS Grid with subgrid. Layout is calculated in `table-layout.ts`:
 ### Testing
 Use Storybook (`npm run storybook`) to test visual changes. Stories are in `src/stories/*.stories.malloy`.
 
+## Plugin System
+
+Render plugins are the mechanism for adding new visualization types to the renderer. Each plugin is a factory that matches fields based on their tags and data type, then creates an instance that renders the visualization.
+
+### Plugin Architecture
+
+A plugin has two parts:
+
+1. **`RenderPluginFactory`** — Registered globally. Decides whether a field should use this plugin (`matches()`) and creates instances (`create()`).
+2. **`RenderPluginInstance`** — Created per-field. Handles rendering, data processing, and metadata.
+
+```
+RenderPluginFactory.matches(field, tag, fieldType)
+  → true: RenderPluginFactory.create(field) → RenderPluginInstance
+  → false: skip this plugin
+```
+
+### Writing a Plugin
+
+#### 1. Create the Factory
+
+```typescript
+import type {RenderPluginFactory, RenderPluginInstance, RenderProps} from '@/api/plugin-types';
+import type {Field, FieldType} from '@/data_tree';
+import type {Tag} from '@malloydata/malloy-tag';
+
+export const MyPluginFactory: RenderPluginFactory = {
+  name: 'my_plugin',
+
+  matches: (field: Field, fieldTag: Tag, fieldType: FieldType): boolean => {
+    // Check if the field's tag requests this plugin
+    return fieldTag.has('my_plugin');
+  },
+
+  create: (field: Field): RenderPluginInstance => {
+    // Validate field structure — throw if the data shape is wrong
+    if (!field.isNest()) {
+      throw new Error('My Plugin: field must be a nested query');
+    }
+
+    return {
+      name: 'my_plugin',
+      field,
+      renderMode: 'solidjs',     // or 'dom' for raw DOM rendering
+      sizingStrategy: 'fixed',   // or 'fill' to expand to container
+
+      renderComponent: (props: RenderProps): JSXElement => {
+        // Render the visualization
+        return <div>...</div>;
+      },
+
+      getMetadata: () => ({ /* plugin-specific metadata */ }),
+    };
+  },
+};
+```
+
+#### 2. Register the Plugin
+
+Plugins are registered when creating a `MalloyRenderer`:
+
+```typescript
+import {MalloyRenderer} from '@malloydata/render';
+
+const renderer = new MalloyRenderer({
+  plugins: [MyPluginFactory],
+});
+```
+
+### Plugin Lifecycle
+
+```
+setResult()
+  → RenderFieldMetadata constructed
+    → For each field in schema:
+      → factory.matches(field, tag, fieldType)  — can the plugin handle this?
+      → factory.create(field)                   — create instance (may throw)
+      → validateFieldTags(field)                — semantic tag validation
+render(element)
+  → Solid.js mounts component tree
+    → plugin.beforeRender(metadata, options)    — pre-render setup (e.g. generate Vega spec)
+    → plugin.processData(field, cell)           — process data rows
+    → plugin.renderComponent(props)             — produce UI
+  → onReady fires when rendering is visually complete
+getLogs()
+  → Returns all collected warnings and errors
+```
+
+### Error Handling: Renderable vs Loggable
+
+Plugins produce two kinds of errors. The distinction is simple: **can the component still produce output?**
+
+#### Renderable Errors (throw in `matches()` or `create()`)
+
+The component **cannot render** — the data is fundamentally incompatible. Throw an error and the `ErrorPlugin` will replace the visualization with an error message in its place.
+
+Use for:
+- Missing required fields (e.g. bar chart has no x dimension)
+- Wrong data shape (e.g. chart tag on a scalar field that isn't a nested query)
+- Too many/few dimensions for the chart type
+
+```typescript
+matches: (field, fieldTag, fieldType) => {
+  const hasTag = fieldTag.has('my_chart');
+  if (hasTag && fieldType !== FieldType.RepeatedRecord) {
+    // Can't render — show error where the chart would be
+    throw new Error('My Chart: field must be a nested query');
+  }
+  return hasTag;
+},
+```
+
+#### Loggable Errors (via `logCollector`)
+
+The component **can still render** but a tag was wrong, ignored, or didn't do what the author intended. The visualization degrades gracefully (falls back to defaults). The log tells the author what to fix.
+
+Use for:
+- Invalid enum values (e.g. `# currency=yen` — unknown code, ignored)
+- Tags on wrong field types (e.g. `# link` on a number — ignored)
+- Misspelled tag properties (detected automatically via unread tag tracking)
+- Invalid combinations (e.g. `# big_value` with `group_by` fields)
+
+Loggable validation is centralized in `RenderFieldMetadata.validateFieldTags()` in `render-field-metadata.ts`, not in individual plugins. This keeps validation consistent and runs during `setResult()`, before rendering.
+
+### Tag Validation
+
+Tag validation runs in `validateFieldTags()` during `setResult()`. To add new validations:
+
+```typescript
+// In render-field-metadata.ts, inside validateFieldTags():
+
+// 1. Tag on wrong field type
+if (tag.has('my_tag') && fieldType !== FieldType.String) {
+  log.error(
+    `Tag 'my_tag' on field '${field.name}' requires a string field, but field is ${fieldType}`,
+    tag.tag('my_tag')  // pass the tag for source location
+  );
+}
+
+// 2. Invalid enum value
+const modeVal = tag.text('my_tag', 'mode');
+if (modeVal !== undefined) {
+  const validModes = ['a', 'b', 'c'];
+  if (!validModes.includes(modeVal)) {
+    log.error(
+      `Invalid my_tag mode '${modeVal}' on field '${field.name}'. Valid modes: ${validModes.join(', ')}`,
+      tag.tag('my_tag')
+    );
+  }
+}
+```
+
+Always pass the relevant `Tag` object as the second argument to `log.error()` / `log.warn()` — it carries source location information that helps the author find the problem in their Malloy source.
+
+### Unread Tag Detection
+
+Tags track whether they've been accessed. After rendering completes, any tag property that was never read by any plugin or the renderer is reported as a warning — this catches misspellings and unknown tag names automatically.
+
+The lifecycle:
+1. `setResult()` — validation reads tags (marking them as read)
+2. `render()` — plugins and components read tags during rendering
+3. `onReady` fires — `collectUnreadTagWarnings()` walks all tags and warns about unread ones
+4. `getLogs()` — returns all collected messages
+
+Because chart rendering may be deferred (waiting for container resize), `collectUnreadTagWarnings()` runs in the `onReady` callback, not synchronously after `render()`. Consumers should use `onReady` to get complete logs:
+
+```typescript
+viz.render(element);
+viz.onReady(() => {
+  const logs = viz.getLogs();
+  // logs now includes both semantic errors and unread tag warnings
+});
+```
+
+### Rendering Modes
+
+Plugins can render in two modes:
+
+- **`solidjs`** — Return a `JSXElement` from `renderComponent()`. Used by built-in chart and table plugins.
+- **`dom`** — Implement `renderToDOM(container, props)` for direct DOM manipulation. Useful for third-party libraries that need a DOM node. Optionally implement `cleanup(container)`.
+
+### Core Viz Plugins
+
+Plugins that implement `CoreVizPluginMethods` (settings schema, serialization to/from tags) get additional integration with the settings UI. See `CoreVizPluginInstance` in `plugin-types.ts`.
+
 ## Important Notes
 
 - Rendering is **separate from query execution** - it only processes results

--- a/packages/malloy-render/src/api/malloy-viz.tsx
+++ b/packages/malloy-render/src/api/malloy-viz.tsx
@@ -16,6 +16,7 @@ import type {MalloyRenderProps} from '@/component/render';
 import type * as Malloy from '@malloydata/malloy-interfaces';
 import {RenderFieldMetadata} from '@/render-field-metadata';
 import {ErrorPlugin} from '@/plugins/error/error-plugin';
+import {RenderLogCollector} from '@/component/render-log-collector';
 
 export class MalloyViz {
   private disposeFn: (() => void) | null = null;
@@ -23,6 +24,9 @@ export class MalloyViz {
   private result: Malloy.Result | null = null;
   private metadata: RenderFieldMetadata | null = null;
   private pluginRegistry: RenderPluginFactory[];
+  private logCollector = new RenderLogCollector();
+  private readyCallbacks: (() => void)[] = [];
+  private isReady = false;
 
   constructor(
     private options: MalloyRendererOptions,
@@ -141,7 +145,8 @@ export class MalloyViz {
         (error, _factory, _field, plugins) => {
           const errorPlugin = ErrorPlugin.create(error.message);
           plugins.push(errorPlugin);
-        }
+        },
+        this.logCollector
       );
     }
   }
@@ -160,6 +165,7 @@ export class MalloyViz {
     this.targetElement = nextTargetElement;
 
     // Prepare the props for DOMRender
+    this.isReady = false;
     const props: MalloyRenderProps = {
       result: this.result,
       element: this.targetElement,
@@ -173,6 +179,7 @@ export class MalloyViz {
       scrollEl: this.options.scrollEl,
       renderFieldMetadata: this.metadata,
       useVegaInterpreter: this.options.useVegaInterpreter,
+      onReady: () => this.handleReady(),
     };
 
     // Render the SolidJS component to the target element
@@ -205,5 +212,49 @@ export class MalloyViz {
 
     const plugins = this.metadata.getPluginsForField(fieldKey);
     return plugins?.at(0) ?? null;
+  }
+
+  /**
+   * Register a callback to be called when the render is complete.
+   * If the render is already complete, the callback is called immediately.
+   * Unread tag warnings are collected once the render is ready,
+   * so `getLogs()` should be called from the onReady callback
+   * to include unread tag warnings.
+   */
+  onReady(callback: () => void): void {
+    if (this.isReady) {
+      callback();
+    } else {
+      this.readyCallbacks.push(callback);
+    }
+  }
+
+  /**
+   * Get log messages from the most recent render pass.
+   * Includes warnings for unread (unknown) tags and semantic errors.
+   * For complete results including unread tag warnings,
+   * call this from an `onReady` callback.
+   */
+  getLogs(): Malloy.LogMessage[] {
+    return this.logCollector.getLogs();
+  }
+
+  private handleReady(): void {
+    this.isReady = true;
+    this.collectUnreadTagWarnings();
+    for (const cb of this.readyCallbacks) {
+      cb();
+    }
+    this.readyCallbacks = [];
+  }
+
+  /**
+   * Walk all field tags and collect warnings for unread properties.
+   */
+  private collectUnreadTagWarnings(): void {
+    if (!this.metadata) return;
+    for (const field of this.metadata.getAllFields()) {
+      this.logCollector.collectUnreadTags(field.tag, field.name);
+    }
   }
 }

--- a/packages/malloy-render/src/api/plugin-types.ts
+++ b/packages/malloy-render/src/api/plugin-types.ts
@@ -32,6 +32,15 @@ interface BaseRenderPluginInstance<TMetadata = unknown> {
     options: GetResultMetadataOptions
   ): void;
   getStyleOverrides?(): Record<string, string>;
+
+  /**
+   * Declare tag paths this plugin reads during render or interaction.
+   * Each entry is a path of tag property names, e.g. ['viz', 'title'].
+   * The framework marks these as read at registration time so they
+   * don't produce false-positive "unknown tag" warnings when the
+   * component hasn't rendered yet (e.g. virtualized off-screen).
+   */
+  getDeclaredTagPaths?(): string[][];
 }
 
 export interface SolidJSRenderPluginInstance<TMetadata = unknown>

--- a/packages/malloy-render/src/component/render-log-collector.ts
+++ b/packages/malloy-render/src/component/render-log-collector.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Tag} from '@malloydata/malloy-tag';
+import type * as Malloy from '@malloydata/malloy-interfaces';
+
+const NO_LOCATION = {
+  url: '',
+  range: {
+    start: {line: 0, character: 0},
+    end: {line: 0, character: 0},
+  },
+};
+
+function getLocation(tag?: Tag): {url: string; range: Malloy.DocumentRange} {
+  return tag?.location ?? NO_LOCATION;
+}
+
+/**
+ * Collects LogMessages during rendering.
+ * Semantic validation logs are added during setResult().
+ * Unread tag warnings are added when onReady fires after render completes.
+ */
+export class RenderLogCollector {
+  private logs: Malloy.LogMessage[] = [];
+
+  reset(): void {
+    this.logs = [];
+  }
+
+  warn(message: string, tag?: Tag): void {
+    this.add('warn', message, tag);
+  }
+
+  error(message: string, tag?: Tag): void {
+    this.add('error', message, tag);
+  }
+
+  private add(severity: Malloy.LogSeverity, message: string, tag?: Tag): void {
+    const {url, range} = tag ? getLocation(tag) : getLocation();
+    this.logs.push({
+      url,
+      range,
+      severity,
+      message,
+    });
+  }
+
+  /**
+   * Walk a tag tree and generate warnings for any unread properties.
+   * Call this after rendering is complete.
+   */
+  collectUnreadTags(tag: Tag, fieldName: string): void {
+    const unread = tag.getUnreadProperties();
+    for (const path of unread) {
+      const pathStr = path.join('.');
+      // Don't use tag.find() here — it would mark the unread tag as read,
+      // making this method non-idempotent. Use the tag itself for location.
+      this.warn(`Unknown render tag '${pathStr}' on field '${fieldName}'`, tag);
+    }
+  }
+
+  getLogs(): Malloy.LogMessage[] {
+    return [...this.logs];
+  }
+}

--- a/packages/malloy-render/src/component/render.tsx
+++ b/packages/malloy-render/src/component/render.tsx
@@ -10,6 +10,7 @@ import type {Accessor, Setter} from 'solid-js';
 import {
   Show,
   createContext,
+  createEffect,
   createMemo,
   createSignal,
   useContext,
@@ -48,6 +49,7 @@ export type MalloyRenderProps = {
   dashboardConfig?: Partial<DashboardConfig>;
   renderFieldMetadata: RenderFieldMetadata;
   useVegaInterpreter?: boolean;
+  onReady?: () => void;
 };
 
 const ConfigContext = createContext<{
@@ -115,6 +117,7 @@ export function MalloyRender(props: MalloyRenderProps) {
             vegaConfigOverride={props.vegaConfigOverride}
             renderFieldMetadata={props.renderFieldMetadata}
             useVegaInterpreter={props.useVegaInterpreter}
+            onReady={props.onReady}
           />
         </ConfigContext.Provider>
       </Show>
@@ -127,6 +130,7 @@ export function MalloyRenderInner(props: {
   result: Malloy.Result;
   element: HTMLElement;
   scrollEl?: HTMLElement;
+  onReady?: () => void;
   vegaConfigOverride?: VegaConfigHandler;
   renderFieldMetadata: RenderFieldMetadata;
   useVegaInterpreter?: boolean;
@@ -248,6 +252,16 @@ export function MalloyRenderInner(props: {
     }
     return false;
   };
+
+  let readyFired = false;
+  createEffect(() => {
+    if (showRendering() && !readyFired) {
+      readyFired = true;
+      // Defer so that <Show> children mount and read their tags
+      // before onReady collects unread tag warnings.
+      queueMicrotask(() => props.onReady?.());
+    }
+  });
 
   return (
     <div

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
@@ -260,8 +260,37 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
             .slice(0, maxSeries)
             .map(entry => entry[0]);
         },
+
+        getDeclaredTagPaths: () => BAR_CHART_TAG_PATHS,
       };
 
       return pluginInstance;
     },
   };
+
+/**
+ * Tag paths read by the bar chart plugin during render/interaction.
+ * Declared so the framework can mark them as read at registration
+ * time, preventing false-positive unread-tag warnings.
+ */
+const BAR_CHART_TAG_PATHS: string[][] = [
+  // viz sub-properties read by chart.tsx and spec generators
+  ['viz', 'title'],
+  ['viz', 'subtitle'],
+  ['viz', 'mode'],
+  ['viz', 'size'],
+  ['viz', 'stack'],
+  ['viz', 'disable_embedded'],
+  ['viz', 'disableEmbedded'],
+  // Channel settings
+  ['viz', 'x'],
+  ['viz', 'x', 'independent'],
+  ['viz', 'x', 'limit'],
+  ['viz', 'y'],
+  ['viz', 'y', 'independent'],
+  ['viz', 'series'],
+  ['viz', 'series', 'independent'],
+  ['viz', 'series', 'limit'],
+  // Legacy tag equivalents (read by convertLegacyToVizTag)
+  ['bar_chart'],
+];

--- a/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
+++ b/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
@@ -172,8 +172,25 @@ export const BigValuePluginFactory: RenderPluginFactory<BigValuePluginInstance> 
         settingsToTag: (s: Record<string, unknown>) => {
           return bigValueSettingsToTag(s as unknown as BigValueSettings);
         },
+
+        getDeclaredTagPaths: () => BIG_VALUE_TAG_PATHS,
       };
 
       return pluginInstance;
     },
   };
+
+/**
+ * Tag paths read by the big value plugin during render.
+ */
+const BIG_VALUE_TAG_PATHS: string[][] = [
+  ['big_value', 'size'],
+  ['big_value', 'neutral_threshold'],
+  ['big_value', 'comparison_field'],
+  ['big_value', 'comparison_label'],
+  ['big_value', 'comparison_format'],
+  ['big_value', 'down_is_good'],
+  ['big_value', 'sparkline'],
+  ['label'],
+  ['description'],
+];

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -304,10 +304,33 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
             .slice(0, maxSeries)
             .map(entry => entry[0]);
         },
+
+        getDeclaredTagPaths: () => LINE_CHART_TAG_PATHS,
       };
 
       return pluginInstance;
     },
   };
+
+/**
+ * Tag paths read by the line chart plugin during render/interaction.
+ */
+const LINE_CHART_TAG_PATHS: string[][] = [
+  ['viz', 'title'],
+  ['viz', 'subtitle'],
+  ['viz', 'mode'],
+  ['viz', 'size'],
+  ['viz', 'zero_baseline'],
+  ['viz', 'disableEmbedded'],
+  ['viz', 'disable_embedded'],
+  ['viz', 'x'],
+  ['viz', 'x', 'independent'],
+  ['viz', 'y'],
+  ['viz', 'y', 'independent'],
+  ['viz', 'series'],
+  ['viz', 'series', 'independent'],
+  ['viz', 'series', 'limit'],
+  ['line_chart'],
+];
 
 export type {LineChartPluginInstance};

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -1,5 +1,5 @@
 import {tagFromAnnotations} from '@/util';
-import {type Field, RootField, getFieldType} from '@/data_tree';
+import {type Field, RootField, getFieldType, FieldType} from '@/data_tree';
 import type {
   RenderPluginFactory,
   RenderPluginInstance,
@@ -8,6 +8,7 @@ import type {
   RenderFieldRegistryEntry,
   RenderFieldRegistry,
 } from '@/registry/types';
+import {RenderLogCollector} from '@/component/render-log-collector';
 
 import type * as Malloy from '@malloydata/malloy-interfaces';
 
@@ -21,13 +22,16 @@ export type OnPluginCreateError = (
 export class RenderFieldMetadata {
   private registry: RenderFieldRegistry;
   private rootField: RootField;
+  readonly logCollector: RenderLogCollector;
 
   constructor(
     result: Malloy.Result,
     private pluginRegistry: RenderPluginFactory[] = [],
     private pluginOptions: Record<string, unknown> = {},
-    private onPluginCreateError?: OnPluginCreateError
+    private onPluginCreateError?: OnPluginCreateError,
+    logCollector?: RenderLogCollector
   ) {
+    this.logCollector = logCollector ?? new RenderLogCollector();
     this.registry = new Map();
 
     // Create the root field with all its metadata
@@ -109,6 +113,14 @@ export class RenderFieldMetadata {
       renderFieldEntry.renderProperties.errors = vizProperties.errors;
 
       this.registry.set(fieldKey, renderFieldEntry);
+
+      // Run semantic validation on this field's tags
+      this.validateFieldTags(field);
+
+      // Mark tags declared by plugins + built-in renderers as read
+      // so they don't produce false-positive "unknown tag" warnings
+      // when components haven't rendered yet (e.g. virtualized).
+      this.markDeclaredTags(field, plugins);
     }
     // Recurse for nested fields
     if (field.isNest()) {
@@ -155,4 +167,314 @@ export class RenderFieldMetadata {
   getFieldEntry(fieldKey: string): RenderFieldRegistryEntry | undefined {
     return this.registry.get(fieldKey);
   }
+
+  /**
+   * Validate tag/field type compatibility and tag values.
+   * Called during registerFields for each field.
+   */
+  private validateFieldTags(field: Field): void {
+    const tag = field.tag;
+    const fieldType = getFieldType(field);
+    const log = this.logCollector;
+
+    // --- Renderer tags on wrong field types ---
+
+    const nestOnly = [
+      'viz',
+      'bar_chart',
+      'line_chart',
+      'list',
+      'list_detail',
+      'pivot',
+      'dashboard',
+      'transpose',
+      'table',
+    ];
+    const nestTypes = [FieldType.RepeatedRecord, FieldType.Record];
+    for (const tagName of nestOnly) {
+      if (tag.has(tagName) && !nestTypes.includes(fieldType)) {
+        log.error(
+          `Tag '${tagName}' on field '${field.name}' requires a nested query, but field is ${fieldType}`,
+          tag.tag(tagName)
+        );
+      }
+    }
+
+    if (tag.has('link') && fieldType !== FieldType.String) {
+      log.error(
+        `Tag 'link' on field '${field.name}' requires a string field, but field is ${fieldType}`,
+        tag.tag('link')
+      );
+    }
+
+    if (tag.has('image') && fieldType !== FieldType.String) {
+      log.error(
+        `Tag 'image' on field '${field.name}' requires a string field, but field is ${fieldType}`,
+        tag.tag('image')
+      );
+    }
+
+    const numericOnly = ['number', 'currency', 'percent', 'duration'];
+    for (const tagName of numericOnly) {
+      if (
+        tag.has(tagName) &&
+        fieldType !== FieldType.Number &&
+        fieldType !== FieldType.Array &&
+        // number tag is also valid on date/timestamp for format strings
+        !(
+          tagName === 'number' &&
+          (fieldType === FieldType.Date || fieldType === FieldType.Timestamp)
+        )
+      ) {
+        log.error(
+          `Tag '${tagName}' on field '${field.name}' requires a numeric field, but field is ${fieldType}`,
+          tag.tag(tagName)
+        );
+      }
+    }
+
+    // --- Invalid enum values ---
+
+    const vizType = tag.text('viz');
+    if (vizType !== undefined) {
+      const validVizTypes = ['bar', 'line', 'table', 'dashboard'];
+      if (!validVizTypes.includes(vizType)) {
+        log.error(
+          `Invalid viz type '${vizType}' on field '${field.name}'. Valid types: ${validVizTypes.join(', ')}`,
+          tag.tag('viz')
+        );
+      }
+    }
+
+    const sizeVal = tag.text('size');
+    if (sizeVal !== undefined) {
+      const validSizes = ['fill', 'spark', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+      // Only validate if it's a string preset, not a custom { width, height }
+      if (!validSizes.includes(sizeVal) && !tag.tag('size')?.has('width')) {
+        log.warn(
+          `Unknown size '${sizeVal}' on field '${field.name}'. Valid presets: ${validSizes.join(', ')}`,
+          tag.tag('size')
+        );
+      }
+    }
+
+    if (tag.has('currency')) {
+      const currencyVal = tag.text('currency');
+      if (currencyVal !== undefined) {
+        const validCodes = ['usd', 'eur', 'gbp', 'euro', 'pound'];
+        // Extract the currency code prefix for shorthand like "usd2m"
+        const codeMatch = currencyVal.match(/^(euro|pound|usd|eur|gbp)/i);
+        if (!codeMatch) {
+          log.error(
+            `Unknown currency '${currencyVal}' on field '${field.name}'. Valid codes: ${validCodes.join(', ')}`,
+            tag.tag('currency')
+          );
+        }
+      }
+    }
+
+    if (tag.has('duration')) {
+      const durationVal = tag.text('duration');
+      if (durationVal !== undefined) {
+        const validUnits = [
+          'nanoseconds',
+          'microseconds',
+          'milliseconds',
+          'seconds',
+          'minutes',
+          'hours',
+          'days',
+        ];
+        if (!validUnits.includes(durationVal)) {
+          log.error(
+            `Unknown duration unit '${durationVal}' on field '${field.name}'. Valid units: ${validUnits.join(', ')}`,
+            tag.tag('duration')
+          );
+        }
+      }
+    }
+
+    // --- Chart field references ---
+    if (field.isNest()) {
+      const vizTag = tag.tag('viz');
+      if (vizTag) {
+        const childNames = new Set(field.fields.map(f => f.name));
+        for (const channelName of ['x', 'y', 'series'] as const) {
+          const refArray = vizTag.textArray(channelName);
+          const refs = refArray ?? [];
+          const singleRef = vizTag.text(channelName);
+          if (singleRef && !refArray) refs.push(singleRef);
+          for (const ref of refs) {
+            if (!childNames.has(ref)) {
+              log.error(
+                `Chart field reference '${ref}' for '${channelName}' on '${field.name}' does not match any field. Available fields: ${[...childNames].join(', ')}`,
+                vizTag.tag(channelName)
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // --- Column width named sizes ---
+    const columnTag = tag.tag('column');
+    if (columnTag) {
+      const widthText = columnTag.text('width');
+      if (widthText !== undefined) {
+        const validWidthNames = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+        const numericWidth = columnTag.numeric('width');
+        if (
+          numericWidth === undefined &&
+          !validWidthNames.includes(widthText)
+        ) {
+          log.warn(
+            `Unknown column width '${widthText}' on field '${field.name}'. Valid presets: ${validWidthNames.join(', ')}`,
+            columnTag.tag('width')
+          );
+        }
+      }
+
+      const wordBreakVal = columnTag.text('word_break');
+      if (wordBreakVal !== undefined && wordBreakVal !== 'break_all') {
+        log.error(
+          `Unknown column word_break '${wordBreakVal}' on field '${field.name}'. Valid values: break_all`,
+          columnTag.tag('word_break')
+        );
+      }
+    }
+
+    // --- Chart mode ---
+    if (field.isNest()) {
+      const vizTag = tag.tag('viz');
+      if (vizTag) {
+        const modeVal = vizTag.text('mode');
+        if (modeVal !== undefined) {
+          const validModes = ['normal', 'yoy'];
+          if (!validModes.includes(modeVal)) {
+            log.error(
+              `Invalid chart mode '${modeVal}' on field '${field.name}'. Valid modes: ${validModes.join(', ')}`,
+              vizTag.tag('mode')
+            );
+          }
+        }
+      }
+    }
+
+    // --- Big value enum properties ---
+    const bigValueTag = tag.tag('big_value');
+    if (bigValueTag) {
+      const bvSize = bigValueTag.text('size');
+      if (bvSize !== undefined) {
+        const validBvSizes = ['sm', 'md', 'lg'];
+        if (!validBvSizes.includes(bvSize)) {
+          log.error(
+            `Invalid big_value size '${bvSize}' on field '${field.name}'. Valid sizes: ${validBvSizes.join(', ')}`,
+            bigValueTag.tag('size')
+          );
+        }
+      }
+
+      const compFormat = bigValueTag.text('comparison_format');
+      if (compFormat !== undefined) {
+        const validFormats = ['pct', 'ppt'];
+        if (!validFormats.includes(compFormat)) {
+          log.error(
+            `Invalid big_value comparison_format '${compFormat}' on field '${field.name}'. Valid formats: ${validFormats.join(', ')}`,
+            bigValueTag.tag('comparison_format')
+          );
+        }
+      }
+    }
+
+    // --- Number verbose properties ---
+    const numberTag = tag.tag('number');
+    if (numberTag) {
+      const scaleVal = numberTag.text('scale');
+      if (scaleVal !== undefined) {
+        const validScales = ['k', 'm', 'b', 't', 'q', 'auto'];
+        if (!validScales.includes(scaleVal)) {
+          log.error(
+            `Invalid number scale '${scaleVal}' on field '${field.name}'. Valid scales: ${validScales.join(', ')}`,
+            numberTag.tag('scale')
+          );
+        }
+      }
+
+      const suffixVal = numberTag.text('suffix');
+      if (suffixVal !== undefined) {
+        const validSuffixes = [
+          'letter',
+          'lower',
+          'word',
+          'short',
+          'finance',
+          'scientific',
+          'none',
+        ];
+        if (!validSuffixes.includes(suffixVal)) {
+          log.error(
+            `Invalid number suffix '${suffixVal}' on field '${field.name}'. Valid suffixes: ${validSuffixes.join(', ')}`,
+            numberTag.tag('suffix')
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Mark tag paths declared by plugins and built-in renderers as read.
+   * This prevents false-positive "unknown tag" warnings for tags that
+   * are consumed at render time or interaction time but may not have
+   * been read yet (e.g. virtualized charts, hover tooltips).
+   */
+  private markDeclaredTags(
+    field: Field,
+    plugins: RenderPluginInstance[]
+  ): void {
+    const tag = field.tag;
+
+    // Mark tags declared by plugins
+    for (const plugin of plugins) {
+      if (plugin.getDeclaredTagPaths) {
+        for (const path of plugin.getDeclaredTagPaths()) {
+          tag.find(path);
+        }
+      }
+    }
+
+    // Mark tags for built-in (non-plugin) renderers
+    for (const path of BUILTIN_RENDERER_TAGS) {
+      tag.find(path);
+    }
+  }
 }
+
+/**
+ * Tag paths consumed by built-in renderers that aren't part of the
+ * plugin system. These are read at render time by component code
+ * (render-link, render-image, duration formatter, etc.), by
+ * legacy chart delegation (apply-renderer), or by parent chart
+ * plugins that inspect child field tags.
+ */
+const BUILTIN_RENDERER_TAGS: string[][] = [
+  // render-link.tsx
+  ['link', 'field'],
+  ['link', 'url_template'],
+  // render-image.tsx
+  ['image', 'height'],
+  ['image', 'width'],
+  ['image', 'alt'],
+  ['image', 'alt', 'field'],
+  // duration formatter (util.ts)
+  ['duration', 'terse'],
+  // legacy chart renderers (apply-renderer.tsx)
+  ['scatter_chart'],
+  ['shape_map'],
+  ['segment_map'],
+  // Embedded channel tags on child fields (read by parent chart plugins)
+  ['x'],
+  ['y'],
+  ['series'],
+  // Custom tooltip tag on child fields (read by chart tooltip code)
+  ['tooltip'],
+];

--- a/packages/malloy-tag/package.json
+++ b/packages/malloy-tag/package.json
@@ -29,7 +29,7 @@
     "generate-flow": "node ../../scripts/femto-build.js flow"
   },
   "dependencies": {
-    "@malloydata/motly-ts-parser": "^0.4.0",
+    "@malloydata/motly-ts-parser": "^0.6.0",
     "assert": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/malloy-tag/src/index.ts
+++ b/packages/malloy-tag/src/index.ts
@@ -6,4 +6,5 @@
  */
 export * from './tags';
 export {parseTag, TagParser} from './parser';
+export type {SourceOrigin} from './parser';
 export * as ParseUtil from './util';

--- a/packages/malloy-tag/src/parser.ts
+++ b/packages/malloy-tag/src/parser.ts
@@ -3,10 +3,24 @@
  * SPDX-License-Identifier: MIT
  */
 
-import type {MOTLYError, MOTLYPropertyValue} from '@malloydata/motly-ts-parser';
+import type {
+  MOTLYError,
+  MOTLYLocation,
+  MOTLYPropertyValue,
+} from '@malloydata/motly-ts-parser';
 import {MOTLYSession, isRef, isEnvRef} from '@malloydata/motly-ts-parser';
 import {Tag, RefTag} from './tags';
-import type {TagParse, TagError} from './tags';
+import type {TagParse, TagError, TagLocation} from './tags';
+
+/**
+ * Where a MOTLY fragment came from in the host source.
+ * Used to resolve MOTLY-relative positions to absolute source locations.
+ */
+export interface SourceOrigin {
+  url: string;
+  startLine: number;
+  startColumn: number;
+}
 
 /**
  * Strip the Malloy tag prefix (e.g., "# " or "#(docs) ") from source.
@@ -35,19 +49,58 @@ function mapMOTLYError(error: MOTLYError): TagError {
 }
 
 /**
+ * Resolve a MOTLYLocation to a TagLocation using the source origin map.
+ */
+function resolveLocation(
+  loc: MOTLYLocation,
+  origins: Map<number, SourceOrigin>
+): TagLocation | undefined {
+  const origin = origins.get(loc.parseId);
+  if (!origin) return undefined;
+
+  return {
+    url: origin.url,
+    range: {
+      start: {
+        line: origin.startLine + loc.begin.line,
+        character:
+          loc.begin.line === 0
+            ? origin.startColumn + loc.begin.column
+            : loc.begin.column,
+      },
+      end: {
+        line: origin.startLine + loc.end.line,
+        character:
+          loc.end.line === 0
+            ? origin.startColumn + loc.end.column
+            : loc.end.column,
+      },
+    },
+  };
+}
+
+/**
  * Convert a MOTLYPropertyValue (node or ref) into a Tag tree with parent links.
  * Env references (@env.NAME) are resolved from process.env during hydration.
  */
-function hydrate(pv: MOTLYPropertyValue, parent?: Tag): Tag {
+function hydrate(
+  pv: MOTLYPropertyValue,
+  parent?: Tag,
+  origins?: Map<number, SourceOrigin>
+): Tag {
   if (isRef(pv)) {
     return new RefTag(pv.linkUps, pv.linkTo, parent);
   }
 
   const tag = new Tag({}, parent);
 
+  if (pv.location && origins) {
+    tag.location = resolveLocation(pv.location, origins);
+  }
+
   if (pv.eq !== undefined) {
     if (Array.isArray(pv.eq)) {
-      tag.eq = pv.eq.map(el => hydrate(el, tag));
+      tag.eq = pv.eq.map(el => hydrate(el, tag, origins));
     } else if (isEnvRef(pv.eq)) {
       const envVal = process.env[pv.eq.env];
       if (envVal !== undefined) {
@@ -63,7 +116,7 @@ function hydrate(pv: MOTLYPropertyValue, parent?: Tag): Tag {
   if (pv.properties !== undefined) {
     tag.properties = {};
     for (const [key, val] of Object.entries(pv.properties)) {
-      tag.properties[key] = hydrate(val, tag);
+      tag.properties[key] = hydrate(val, tag, origins);
     }
   }
 
@@ -80,23 +133,33 @@ function hydrate(pv: MOTLYPropertyValue, parent?: Tag): Tag {
  */
 export class TagParser {
   private session: MOTLYSession;
+  private origins = new Map<number, SourceOrigin>();
 
   constructor() {
     this.session = new MOTLYSession();
   }
 
-  parse(source: string): TagParse {
+  parse(source: string, origin?: SourceOrigin): TagParse {
     const stripped = stripPrefix(source);
-    const errors = this.session.parse(stripped);
+    const {parseId, errors} = this.session.parse(stripped);
+    if (origin) {
+      // Adjust column for the stripped prefix
+      const prefixLen = source.length - stripped.length;
+      this.origins.set(parseId, {
+        url: origin.url,
+        startLine: origin.startLine,
+        startColumn: origin.startColumn + prefixLen,
+      });
+    }
     const tagErrors = errors.map(mapMOTLYError);
     const value = this.session.getValue();
-    return {tag: hydrate(value), log: tagErrors};
+    return {tag: hydrate(value, undefined, this.origins), log: tagErrors};
   }
 
   finish(): Tag {
     const value = this.session.getValue();
     this.session.dispose();
-    return hydrate(value);
+    return hydrate(value, undefined, this.origins);
   }
 }
 

--- a/packages/malloy-tag/src/tags.spec.ts
+++ b/packages/malloy-tag/src/tags.spec.ts
@@ -23,7 +23,8 @@
 
 import type {TagDict} from './tags';
 import {Tag, RefTag, interfaceFromDict} from './tags';
-import {parseTag} from './parser';
+import {parseTag, TagParser} from './parser';
+import type {SourceOrigin} from './parser';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -821,5 +822,210 @@ describe('References (RefTag)', () => {
       // After cloning, the reference should still resolve
       expect(cloned.text('target')).toBe('hello');
     });
+  });
+});
+
+describe('Read tracking', () => {
+  test('newly created tags are unread', () => {
+    const tag = new Tag({
+      properties: {
+        hidden: {},
+        label: {eq: 'Name'},
+      },
+    });
+    expect(tag.getUnreadProperties()).toEqual([['hidden'], ['label']]);
+  });
+
+  test('has() marks a tag as read', () => {
+    const tag = new Tag({
+      properties: {
+        hidden: {},
+        label: {eq: 'Name'},
+      },
+    });
+    tag.has('hidden');
+    expect(tag.getUnreadProperties()).toEqual([['label']]);
+  });
+
+  test('text() marks a tag as read', () => {
+    const tag = new Tag({
+      properties: {
+        label: {eq: 'Name'},
+        color: {eq: 'blue'},
+      },
+    });
+    tag.text('label');
+    expect(tag.getUnreadProperties()).toEqual([['color']]);
+  });
+
+  test('nested property tracking', () => {
+    const tag = new Tag({
+      properties: {
+        viz: {
+          eq: 'bar',
+          properties: {
+            x: {eq: 'category'},
+            yy: {eq: 'total'},
+          },
+        },
+      },
+    });
+    // Read viz and x, but not yy
+    tag.text('viz');
+    tag.text('viz', 'x');
+    expect(tag.getUnreadProperties()).toEqual([['viz', 'yy']]);
+  });
+
+  test('unread nested tags under unread parent are reported as parent only', () => {
+    const tag = new Tag({
+      properties: {
+        viz: {
+          properties: {
+            x: {eq: 'category'},
+          },
+        },
+      },
+    });
+    // Don't read anything
+    expect(tag.getUnreadProperties()).toEqual([['viz']]);
+  });
+
+  test('resetReadTracking clears all reads', () => {
+    const tag = new Tag({
+      properties: {
+        hidden: {},
+        label: {eq: 'Name'},
+      },
+    });
+    tag.has('hidden');
+    tag.text('label');
+    expect(tag.getUnreadProperties()).toEqual([]);
+
+    tag.resetReadTracking();
+    expect(tag.getUnreadProperties()).toEqual([['hidden'], ['label']]);
+  });
+
+  test('deleted properties are not reported as unread', () => {
+    const tag = new Tag({
+      properties: {
+        hidden: {},
+        removed: {deleted: true},
+      },
+    });
+    expect(tag.getUnreadProperties()).toEqual([['hidden']]);
+  });
+
+  test('all properties read returns empty array', () => {
+    const tag = new Tag({
+      properties: {
+        hidden: {},
+        label: {eq: 'Name'},
+      },
+    });
+    tag.has('hidden');
+    tag.text('label');
+    expect(tag.getUnreadProperties()).toEqual([]);
+  });
+
+  test('numeric() marks as read', () => {
+    const tag = new Tag({
+      properties: {
+        size: {eq: 42},
+      },
+    });
+    tag.numeric('size');
+    expect(tag.getUnreadProperties()).toEqual([]);
+  });
+
+  test('tag() marks as read', () => {
+    const tag = new Tag({
+      properties: {
+        column: {
+          properties: {
+            width: {eq: 100},
+          },
+        },
+      },
+    });
+    const col = tag.tag('column');
+    expect(col).toBeDefined();
+    // column is read, but width inside it is not
+    expect(tag.getUnreadProperties()).toEqual([['column', 'width']]);
+  });
+});
+
+describe('Location tracking', () => {
+  test('tag has location when parsed with source origin', () => {
+    const origin: SourceOrigin = {
+      url: 'file:///test.malloy',
+      startLine: 10,
+      startColumn: 0,
+    };
+    const session = new TagParser();
+    session.parse('color=blue size=10', origin);
+    const tag = session.finish();
+    const color = tag.tag('color');
+    expect(color).toBeDefined();
+    expect(color!.location).toBeDefined();
+    expect(color!.location!.url).toBe('file:///test.malloy');
+    expect(color!.location!.range.start.line).toBeGreaterThanOrEqual(10);
+  });
+
+  test('tag has no location without source origin', () => {
+    const session = new TagParser();
+    session.parse('color=blue');
+    const tag = session.finish();
+    expect(tag.tag('color')?.location).toBeUndefined();
+  });
+
+  test('prefix is accounted for in column offset', () => {
+    const origin: SourceOrigin = {
+      url: 'file:///test.malloy',
+      startLine: 5,
+      startColumn: 0,
+    };
+    const session = new TagParser();
+    // "# " prefix is 2 chars, stripped by parser
+    session.parse('# color=blue', origin);
+    const tag = session.finish();
+    const color = tag.tag('color');
+    expect(color).toBeDefined();
+    expect(color!.location).toBeDefined();
+    // Column should account for the stripped prefix
+    expect(color!.location!.range.start.character).toBeGreaterThanOrEqual(2);
+  });
+
+  test('location preserved through clone', () => {
+    const origin: SourceOrigin = {
+      url: 'file:///test.malloy',
+      startLine: 0,
+      startColumn: 0,
+    };
+    const session = new TagParser();
+    session.parse('name=test', origin);
+    const tag = session.finish();
+    const cloned = tag.clone();
+    const nameTag = cloned.tag('name');
+    expect(nameTag?.location).toBeDefined();
+    expect(nameTag!.location!.url).toBe('file:///test.malloy');
+  });
+
+  test('multiple parse calls track separate origins', () => {
+    const session = new TagParser();
+    session.parse('color=blue', {
+      url: 'file:///a.malloy',
+      startLine: 1,
+      startColumn: 0,
+    });
+    session.parse('size=10', {
+      url: 'file:///b.malloy',
+      startLine: 5,
+      startColumn: 0,
+    });
+    const tag = session.finish();
+    const color = tag.tag('color');
+    const size = tag.tag('size');
+    expect(color?.location?.url).toBe('file:///a.malloy');
+    expect(size?.location?.url).toBe('file:///b.malloy');
   });
 });

--- a/packages/malloy-tag/src/tags.ts
+++ b/packages/malloy-tag/src/tags.ts
@@ -28,6 +28,18 @@ export interface TagError {
   code: string;
 }
 
+/**
+ * Source location for a Tag node. Structurally compatible with
+ * DocumentLocation from the malloy package.
+ */
+export interface TagLocation {
+  url: string;
+  range: {
+    start: {line: number; character: number};
+    end: {line: number; character: number};
+  };
+}
+
 // TagInterface exists for tests and serialization only.
 // Internally, Tag uses Tag instances for properties and array elements.
 export type TagDict = Record<string, TagInterface>;
@@ -103,7 +115,10 @@ export class Tag {
   properties?: Record<string, Tag>;
   prefix?: string;
   deleted?: boolean;
+  location?: TagLocation;
   private _parent?: Tag;
+  private _read = false;
+  protected _clonedFrom?: Tag;
 
   /**
    * Get the parent tag, if this tag is part of a tree.
@@ -379,6 +394,8 @@ export class Tag {
     const cloned = new Tag({}, newParent);
     cloned.prefix = this.prefix;
     cloned.deleted = this.deleted;
+    cloned.location = this.location;
+    cloned._clonedFrom = this;
 
     if (this.eq !== undefined) {
       if (Array.isArray(this.eq)) {
@@ -660,9 +677,67 @@ export class Tag {
       if (next === undefined) {
         return undefined;
       }
+      next.markRead();
       currentTag = next;
     }
     return currentTag.deleted ? undefined : currentTag;
+  }
+
+  /**
+   * Mark this tag as read, propagating to the original if this is a clone.
+   * Only propagates one level (clone→original). This is sufficient because
+   * set() is the only operation that creates clones, and it doesn't chain.
+   */
+  private markRead(): void {
+    this._read = true;
+    if (this._clonedFrom) {
+      this._clonedFrom._read = true;
+    }
+  }
+
+  /**
+   * Returns true if this tag was accessed via find/has/text/etc.
+   */
+  get wasRead(): boolean {
+    return this._read;
+  }
+
+  /**
+   * Recursively reset read tracking on this tag and all descendants.
+   */
+  resetReadTracking(): void {
+    this._read = false;
+    if (this.properties) {
+      for (const prop of Object.values(this.properties)) {
+        prop.resetReadTracking();
+      }
+    }
+    if (Array.isArray(this.eq)) {
+      for (const el of this.eq) {
+        el.resetReadTracking();
+      }
+    }
+  }
+
+  /**
+   * Collect all unread, non-deleted property names in this tag tree.
+   * Returns paths like ['viz', 'yy'] for nested unread properties.
+   */
+  getUnreadProperties(prefix: string[] = []): string[][] {
+    const unread: string[][] = [];
+    if (this.properties) {
+      for (const [key, prop] of Object.entries(this.properties)) {
+        if (prop.deleted) continue;
+        const path = [...prefix, key];
+        if (!prop._read) {
+          unread.push(path);
+        } else {
+          // Recurse into read tags to find unread sub-properties
+          unread.push(...prop.getUnreadProperties(path));
+        }
+      }
+    }
+    return unread;
   }
 
   has(...path: Path): boolean {
@@ -934,7 +1009,9 @@ export class RefTag extends Tag {
    * Clone this RefTag, preserving the reference information.
    */
   override clone(newParent?: Tag): RefTag {
-    return new RefTag(this.ups, [...this.refPath], newParent);
+    const cloned = new RefTag(this.ups, [...this.refPath], newParent);
+    cloned._clonedFrom = this;
+    return cloned;
   }
 }
 

--- a/packages/malloy/src/annotation.ts
+++ b/packages/malloy/src/annotation.ts
@@ -1,4 +1,4 @@
-import type {Tag, TagError} from '@malloydata/malloy-tag';
+import type {Tag, TagError, SourceOrigin} from '@malloydata/malloy-tag';
 import {TagParser} from '@malloydata/malloy-tag';
 import type {Annotation, Note} from './model';
 import type {LogMessage} from './lang';
@@ -41,12 +41,6 @@ export interface MalloyTagParse {
   log: LogMessage[];
 }
 
-// TODO: Error location mapping currently works by post-hoc mapping
-// parse errors back to source locations using the Note's `at` field.
-// The proper approach is to pass source location information into the
-// MOTLY parser session so that errors come back with correct locations
-// directly, eliminating the need for this remapping step.
-
 export function annotationToTag(
   annote: Annotation | undefined,
   spec: TagParseSpec = {}
@@ -57,7 +51,12 @@ export function annotationToTag(
   const allErrs: LogMessage[] = [];
   const session = new TagParser();
   for (const note of notes) {
-    const noteParse = session.parse(note.text);
+    const origin: SourceOrigin = {
+      url: note.at.url,
+      startLine: note.at.range.start.line,
+      startColumn: note.at.range.start.character,
+    };
+    const noteParse = session.parse(note.text, origin);
     allErrs.push(
       ...noteParse.log.map((e: TagError) => mapMalloyError(e, note))
     );

--- a/scripts/femto-build.js
+++ b/scripts/femto-build.js
@@ -88,7 +88,7 @@ if (!existsSync(CONFIG_FILE)) {
 
 const configText = readFileSync(CONFIG_FILE, 'utf-8');
 const session = new MOTLYSession();
-const errors = session.parse(configText);
+const {errors} = session.parse(configText);
 if (errors.length > 0) {
   for (const e of errors) {
     console.error(

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -1,0 +1,359 @@
+import {API} from '@malloydata/malloy';
+import {runtimeFor} from '../runtimes';
+
+const runtime = runtimeFor('duckdb');
+
+// Dynamic import for malloy-render (has Solid.js transforms, needs window/navigator)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let MalloyRenderer: any;
+
+beforeAll(async () => {
+  // @ts-expect-error malloy-render UMD bundle requires window/navigator globals
+  global.window = global.document.defaultView;
+  global.navigator = global.window.navigator;
+  MalloyRenderer = (await import('@malloydata/render')).MalloyRenderer;
+});
+
+afterAll(async () => {
+  // @ts-expect-error cleaning up browser globals
+  delete global.window;
+  // @ts-expect-error cleaning up browser globals
+  delete global.navigator;
+  await runtime.connection.close();
+});
+
+interface LogMessage {
+  severity: string;
+  message: string;
+}
+
+async function getValidationLogs(malloySource: string): Promise<LogMessage[]> {
+  const result = await runtime
+    .loadModel(malloySource)
+    .loadQueryByName('q')
+    .run();
+  const malloyResult = API.util.wrapResult(result);
+  const renderer = new MalloyRenderer();
+  const viz = renderer.createViz();
+  // Silence plugin instantiation warnings during validation tests
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  viz.setResult(malloyResult);
+  spy.mockRestore();
+  return viz.getLogs();
+}
+
+function expectError(logs: LogMessage[], substring: string) {
+  expect(logs).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining(substring),
+      }),
+    ])
+  );
+}
+
+function expectNoErrors(logs: LogMessage[]) {
+  const errors = logs.filter(l => l.severity === 'error');
+  expect(errors).toHaveLength(0);
+}
+
+function expectNoWarnings(logs: LogMessage[]) {
+  const warnings = logs.filter(l => l.severity === 'warn');
+  expect(warnings).toHaveLength(0);
+}
+
+// Reusable SQL fragments
+const NUM_FIELD = 'duckdb.sql("SELECT 1 as val")';
+const STR_FIELD = 'duckdb.sql("SELECT \'hello\' as val")';
+
+describe('render tag validation', () => {
+  describe('tags on wrong field types', () => {
+    it.each(['link', 'image'])(
+      'errors when # %s is on a number field',
+      async tagName => {
+        const logs = await getValidationLogs(`
+          query: q is ${NUM_FIELD} -> {
+            select:
+              # ${tagName}
+              val
+          }
+        `);
+        expectError(logs, `'${tagName}'`);
+      }
+    );
+
+    it.each(['currency', 'percent'])(
+      'errors when # %s is on a string field',
+      async tagName => {
+        const logs = await getValidationLogs(`
+          query: q is ${STR_FIELD} -> {
+            select:
+              # ${tagName}
+              val
+          }
+        `);
+        expectError(logs, `'${tagName}'`);
+      }
+    );
+
+    it('errors when # duration is on a string field', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${STR_FIELD} -> {
+          select:
+            # duration=seconds
+            val
+        }
+      `);
+      expectError(logs, "'duration'");
+    });
+  });
+
+  describe('invalid enum values', () => {
+    it('errors on invalid currency code', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # currency=yen
+            val
+        }
+      `);
+      expectError(logs, 'yen');
+    });
+
+    it('errors on invalid duration unit', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # duration=fortnights
+            val
+        }
+      `);
+      expectError(logs, 'fortnights');
+    });
+
+    it('accepts valid currency code', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # currency=usd
+            val
+        }
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('accepts valid duration unit', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # duration=milliseconds
+            val
+        }
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('errors on invalid viz mode', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as x, 2 as y") extend {
+          # viz=line viz { mode=sparkle }
+          view: q is { group_by: x; aggregate: y is count() }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'sparkle');
+    });
+
+    it('errors on invalid big_value size', async () => {
+      const logs = await getValidationLogs(`
+        source: s is ${NUM_FIELD} extend {
+          # big_value { size=huge }
+          view: q is { aggregate: val is count() }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'huge');
+    });
+
+    it('errors on invalid big_value comparison_format', async () => {
+      const logs = await getValidationLogs(`
+        source: s is ${NUM_FIELD} extend {
+          # big_value
+          view: q is {
+            aggregate: total is count()
+            aggregate:
+              # big_value { comparison_field=total comparison_format=ratio }
+              prior is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'ratio');
+    });
+
+    it('errors on invalid number scale', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # number { scale=z }
+            val
+        }
+      `);
+      expectError(logs, 'scale');
+    });
+
+    it('errors on invalid number suffix', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # number { suffix=emoji }
+            val
+        }
+      `);
+      expectError(logs, 'emoji');
+    });
+
+    it('errors on invalid column word_break', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${STR_FIELD} -> {
+          select:
+            # column { word_break=wrap }
+            val
+        }
+      `);
+      expectError(logs, 'wrap');
+    });
+  });
+
+  describe('nest-only tags on scalar fields', () => {
+    it.each(['bar_chart', 'list', 'dashboard', 'transpose', 'table'])(
+      'errors when # %s is on a scalar field',
+      async tagName => {
+        const logs = await getValidationLogs(`
+          query: q is ${NUM_FIELD} -> {
+            select:
+              # ${tagName}
+              val
+          }
+        `);
+        expectError(logs, `'${tagName}'`);
+      }
+    );
+  });
+
+  describe('big_value', () => {
+    it('no error when big_value view has group_by fields (needed for sparklines)', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'Acme' as manufacturer, 5 as recall_count") extend {
+          # big_value
+          view: q is {
+            group_by: manufacturer
+            aggregate: total_recalls is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      const bigValueGroupByErrors = logs.filter(
+        l =>
+          l.severity === 'error' &&
+          l.message.includes('big_value') &&
+          l.message.includes('group_by')
+      );
+      expect(bigValueGroupByErrors).toHaveLength(0);
+    });
+  });
+
+  describe('no errors for valid tags', () => {
+    it('no errors for # currency=usd on a number', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # currency=usd
+            val
+        }
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('no errors for # link on a string', async () => {
+      const logs = await getValidationLogs(`
+        query: q is duckdb.sql("SELECT 'http://example.com' as url") -> {
+          select:
+            # link
+            url
+        }
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('no errors for # number on a date', async () => {
+      const logs = await getValidationLogs(`
+        query: q is duckdb.sql("SELECT DATE '2024-01-01' as dt") -> {
+          select:
+            # number
+            dt
+        }
+      `);
+      expectNoErrors(logs);
+    });
+  });
+
+  describe('declared tag paths suppress unread warnings', () => {
+    it('no warnings for # image with alt.field', async () => {
+      const logs = await getValidationLogs(`
+        query: q is duckdb.sql("SELECT 'http://img.png' as logo, 'Alt text' as alt_text") -> {
+          select:
+            # image { alt { field=alt_text } height=32 }
+            logo
+            alt_text
+        }
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for # link with url_template', async () => {
+      const logs = await getValidationLogs(`
+        query: q is duckdb.sql("SELECT 'hello' as val") -> {
+          select:
+            # link { url_template='http://example.com/{val}' }
+            val
+        }
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for # duration=seconds { terse }', async () => {
+      const logs = await getValidationLogs(`
+        query: q is ${NUM_FIELD} -> {
+          select:
+            # duration=seconds { terse }
+            val
+        }
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for embedded channel tags on child fields', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as a, 2 as b") extend {
+          # viz=bar
+          view: q is {
+            group_by:
+              # x
+              a
+            aggregate:
+              # y
+              b is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Tag validation**: Semantic validation of render tags at `setResult()` time — type/field compatibility checks, enum value validation, chart field reference validation, number format properties
- **Unread tag detection**: After render completes (`onReady`), warns about tag properties that were never read (likely misspellings or unknown tags)
- **Plugin declared tag paths**: Plugins declare what tags they read via `getDeclaredTagPaths()`, preventing false-positive unread warnings for virtualized/lazy content
- **Tag.location**: Source origin tracking through MOTLY parser so log messages carry source locations
- **Tag clone read propagation**: Reads on cloned tags (from `convertLegacyToVizTag`) propagate back to originals
- **Storybook addon**: "Renderer Logs" panel shows validation errors and warnings per story
- **28 integration tests**: Validate tag validation against real DuckDB queries
- **Plugin authoring docs**: Added to malloy-render CONTEXT.md

## Test plan

- [x] 28 render validator tests pass (`test/src/render/render-validator.spec.ts`)
- [x] 120 malloy-tag tests pass
- [x] 16 plugin tests pass
- [x] `npm run test-duckdb` clean
- [x] Lint clean
- [x] Storybook verified — Renderer Logs panel shows warnings/errors per story
- [x] CI Passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)