### PR TITLE
Fix rendering issues revealed by storybook

### DIFF
--- a/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
@@ -218,12 +218,19 @@ export function getBarChartSettings(
   // Validate dimensions with series concatenation logic
   const xDimensionsCount = xChannel.fields.length;
   const seriesDimensionsCount = seriesChannel.fields.length;
+  const yDimensionsCount = yChannel.fields.filter(path => {
+    const field = explore.fieldAt(path);
+    return field.wasDimension();
+  }).length;
   const totalDimensions = dimensions.length;
 
   // Validation logic:
   // - If 3+ dimensions exist, multiple series fields must be explicitly tagged
   // - Otherwise, follow the standard 2-dimension limit
-  if (totalDimensions > xDimensionsCount + seriesDimensionsCount) {
+  if (
+    totalDimensions >
+    xDimensionsCount + seriesDimensionsCount + yDimensionsCount
+  ) {
     throw new Error(
       'Malloy Bar Chart: Too many dimensions. A bar chart can have at most 2 dimensions: 1 for the x axis, and 1 for the series. To use 3+ dimensions, explicitly tag multiple fields as series.'
     );

--- a/packages/malloy-render/src/stories/scroll-override.stories.malloy
+++ b/packages/malloy-render/src/stories/scroll-override.stories.malloy
@@ -61,7 +61,7 @@ source: products is duckdb.table("static/data/products.parquet") extend {
             limit: 10
           }
           top_products is {
-            select: name, retail_price, cost
+            group_by: name, retail_price, cost
             order_by: retail_price desc
             limit: 5
           }

--- a/packages/malloy-render/src/stories/static/data/logos.csv
+++ b/packages/malloy-render/src/stories/static/data/logos.csv
@@ -1,10 +1,10 @@
 id,brand,logo,product
-1,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,gViz
-2,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,Plex
-3,Google,https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2560px-Google_2015_logo.svg.png,Google Charts
-4,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker
-5,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker Studio
-6,Looker,https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Looker.svg/2560px-Looker.svg.png,Looker Studio Pro
+1,Google,https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png,gViz
+2,Google,https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png,Plex
+3,Google,https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png,Google Charts
+4,Looker,https://www.gstatic.com/devrel-devsite/prod/v75e3d64006adca2b8b590c38f10bf440310b485b03499ed9671198292b2883b7/cloud/images/favicons/onecloud/apple-icon.png,Looker
+5,Looker,https://www.gstatic.com/devrel-devsite/prod/v75e3d64006adca2b8b590c38f10bf440310b485b03499ed9671198292b2883b7/cloud/images/favicons/onecloud/apple-icon.png,Looker Studio
+6,Looker,https://www.gstatic.com/devrel-devsite/prod/v75e3d64006adca2b8b590c38f10bf440310b485b03499ed9671198292b2883b7/cloud/images/favicons/onecloud/apple-icon.png,Looker Studio Pro
 7,Malloy,https://docs.malloydata.dev/img/logo.png,Malloy
 8,Malloy,https://docs.malloydata.dev/img/logo.png,Malloy Composer
 9,Malloy,https://docs.malloydata.dev/img/logo.png,Malloy Py


### PR DESCRIPTION
## Summary

- **Bar chart numeric dimensions as Y**: The auto concat series feature introduced a dimension validation that doesn't account for dimensions explicitly mapped to the Y channel via `# y` tag. Fixed by including Y-channel dimensions in the validation count.
- **Image story broken logos**: Wikimedia Commons SVG thumbnail URLs return 403. Replaced with working hosted URLs.
- **Deeply nested table story**: `select:` inside a doubly-nested `group_by` generates invalid SQL. Replaced with `group_by`.

## Test plan
- [x] All storybook stories render correctly