### PR TITLE
Fix duplicate unread-tag warnings for cloned tag trees

### DIFF
--- a/packages/malloy-tag/src/tags.spec.ts
+++ b/packages/malloy-tag/src/tags.spec.ts
@@ -985,6 +985,58 @@ describe('Read tracking', () => {
     // column is read, but width inside it is not
     expect(tag.getUnreadProperties()).toEqual([['column', 'width']]);
   });
+
+  test('walk yields all descendant paths', () => {
+    const tag = new Tag({
+      properties: {
+        viz: {
+          eq: 'bar',
+          properties: {
+            stack: {},
+            mode: {eq: 'normal'},
+          },
+        },
+        label: {eq: 'Name'},
+      },
+    });
+    const paths = [...tag.walk()].map(({path}) => path);
+    expect(paths).toEqual([
+      ['viz'],
+      ['viz', 'stack'],
+      ['viz', 'mode'],
+      ['label'],
+    ]);
+  });
+
+  test('walk skips deleted properties', () => {
+    const tag = new Tag({
+      properties: {
+        visible: {},
+        removed: {deleted: true},
+      },
+    });
+    const paths = [...tag.walk()].map(({path}) => path);
+    expect(paths).toEqual([['visible']]);
+  });
+
+  test('clone marks source tree as read', () => {
+    const tag = new Tag({
+      properties: {
+        bar_chart: {
+          properties: {
+            stack: {},
+            mode: {eq: 'normal'},
+          },
+        },
+        label: {eq: 'Name'},
+      },
+    });
+    expect(tag.getUnreadProperties()).toEqual([['bar_chart'], ['label']]);
+    const barChart = tag.tag('bar_chart');
+    barChart!.clone();
+    // bar_chart and its entire subtree should be marked as read
+    expect(tag.getUnreadProperties()).toEqual([['label']]);
+  });
 });
 
 describe('Location tracking', () => {

--- a/packages/malloy-tag/src/tags.ts
+++ b/packages/malloy-tag/src/tags.ts
@@ -117,7 +117,7 @@ export class Tag {
   deleted?: boolean;
   location?: TagLocation;
   private _parent?: Tag;
-  private _read = false;
+  protected _read = false;
   protected _clonedFrom?: Tag;
 
   /**
@@ -400,6 +400,8 @@ export class Tag {
   }
 
   clone(newParent?: Tag): Tag {
+    // Mark the source as read — cloning consumes the original.
+    this._read = true;
     const cloned = new Tag({}, newParent);
     cloned.prefix = this.prefix;
     cloned.deleted = this.deleted;
@@ -712,19 +714,35 @@ export class Tag {
   }
 
   /**
+   * Walk the tag tree, yielding each descendant tag with its path.
+   * Covers named properties and array element values. Pre-order traversal.
+   * Skips deleted properties.
+   */
+  *walk(prefix: string[] = []): Generator<{path: string[]; tag: Tag}> {
+    if (this.properties) {
+      for (const [key, prop] of Object.entries(this.properties)) {
+        if (prop.deleted) continue;
+        const path = [...prefix, key];
+        yield {path, tag: prop};
+        yield* prop.walk(path);
+      }
+    }
+    if (Array.isArray(this.eq)) {
+      for (let i = 0; i < this.eq.length; i++) {
+        const path = [...prefix, i.toString()];
+        yield {path, tag: this.eq[i]};
+        yield* this.eq[i].walk(path);
+      }
+    }
+  }
+
+  /**
    * Recursively reset read tracking on this tag and all descendants.
    */
   resetReadTracking(): void {
     this._read = false;
-    if (this.properties) {
-      for (const prop of Object.values(this.properties)) {
-        prop.resetReadTracking();
-      }
-    }
-    if (Array.isArray(this.eq)) {
-      for (const el of this.eq) {
-        el.resetReadTracking();
-      }
+    for (const {tag} of this.walk()) {
+      tag._read = false;
     }
   }
 
@@ -1018,6 +1036,7 @@ export class RefTag extends Tag {
    * Clone this RefTag, preserving the reference information.
    */
   override clone(newParent?: Tag): RefTag {
+    this._read = true;
     const cloned = new RefTag(this.ups, [...this.refPath], newParent);
     cloned._clonedFrom = this;
     return cloned;


### PR DESCRIPTION
## Summary

Fixes #2703

- `Tag.clone()` now marks the source tree as read, since cloning consumes the original. This prevents legacy chart tags (e.g. `# bar_chart { stacked }`) from producing duplicate "unknown tag" warnings — one for `bar_chart.stacked` and another for `viz.stacked`.
- Added `walk()` generator to `Tag` for pre-order tree traversal over properties and array elements.
- Simplified `resetReadTracking()` to use `walk()`.
- `RefTag.clone()` also marks source as read for consistency.

## Test plan

- [x] New tests: `walk yields all descendant paths`, `walk skips deleted properties`, `clone marks source tree as read`
- [x] All existing tag tests pass (130)
- [x] Render validator tests pass (32)
- [x] `npm run test-duckdb` passes (2749 tests)
- [x] Verify in VS Code that `# bar_chart { stacked }` produces one warning, not two