### PR TITLE
Upgrade motly-ts-parser to 0.7.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@malloydata/db-bigquery": "*",
         "@malloydata/db-mysql": "*",
         "@malloydata/malloy": "*",
-        "@malloydata/motly-ts-parser": "^0.6.0",
+        "@malloydata/motly-ts-parser": "^0.7.1",
         "@malloydata/render": "*",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^29.0.3",
@@ -6220,9 +6220,9 @@
       "link": true
     },
     "node_modules/@malloydata/motly-ts-parser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.6.0.tgz",
-      "integrity": "sha512-mqqbLph3ATVIpclLY4Pofj54fLR9quumv/AdKkENl0u2/VUplfQuqwJRmisniDL620+UXOb0bRywkIwxBxtELw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@malloydata/motly-ts-parser/-/motly-ts-parser-0.7.1.tgz",
+      "integrity": "sha512-zL08Dkbzlx+m2Br4lAlcaV/xHlxnLRsJWcAfTNpjuI5Amy5cYBJwPEvkEAUaXCU8JVT5XuR2MtEyJufYaw5pjw==",
       "license": "MIT"
     },
     "node_modules/@malloydata/render": {
@@ -30136,7 +30136,7 @@
       "version": "0.0.354",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/motly-ts-parser": "^0.6.0",
+        "@malloydata/motly-ts-parser": "^0.7.1",
         "assert": "^2.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@malloydata/db-bigquery": "*",
     "@malloydata/db-mysql": "*",
     "@malloydata/malloy": "*",
-    "@malloydata/motly-ts-parser": "^0.6.0",
+    "@malloydata/motly-ts-parser": "^0.7.1",
     "@malloydata/render": "*",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29.0.3",

--- a/packages/malloy-tag/package.json
+++ b/packages/malloy-tag/package.json
@@ -29,7 +29,7 @@
     "generate-flow": "node ../../scripts/femto-build.js flow"
   },
   "dependencies": {
-    "@malloydata/motly-ts-parser": "^0.6.0",
+    "@malloydata/motly-ts-parser": "^0.7.1",
     "assert": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/malloy-tag/src/parser.ts
+++ b/packages/malloy-tag/src/parser.ts
@@ -6,10 +6,10 @@
 import type {
   MOTLYError,
   MOTLYLocation,
-  MOTLYPropertyValue,
+  MOTLYNode,
 } from '@malloydata/motly-ts-parser';
 import {MOTLYSession, isRef, isEnvRef} from '@malloydata/motly-ts-parser';
-import {Tag, RefTag} from './tags';
+import {Tag} from './tags';
 import type {TagParse, TagError, TagLocation} from './tags';
 
 /**
@@ -80,16 +80,17 @@ function resolveLocation(
 }
 
 /**
- * Convert a MOTLYPropertyValue (node or ref) into a Tag tree with parent links.
- * Env references (@env.NAME) are resolved from process.env during hydration.
+ * Convert a MOTLYNode (node or ref) into a Tag tree with parent links.
+ * Refs are dropped (skipped). Env references (@env.NAME) are resolved
+ * from process.env during hydration.
  */
 function hydrate(
-  pv: MOTLYPropertyValue,
+  pv: MOTLYNode,
   parent?: Tag,
   origins?: Map<number, SourceOrigin>
 ): Tag {
   if (isRef(pv)) {
-    return new RefTag(pv.linkUps, pv.linkTo, parent);
+    return new Tag({deleted: true}, parent);
   }
 
   const tag = new Tag({}, parent);

--- a/packages/malloy-tag/src/tags.spec.ts
+++ b/packages/malloy-tag/src/tags.spec.ts
@@ -22,7 +22,7 @@
  */
 
 import type {TagDict} from './tags';
-import {Tag, RefTag, interfaceFromDict} from './tags';
+import {Tag, interfaceFromDict} from './tags';
 import {parseTag, TagParser} from './parser';
 import type {SourceOrigin} from './parser';
 
@@ -530,6 +530,30 @@ describe('Error handling', () => {
   });
 });
 
+describe('References are dropped', () => {
+  test('reference property is treated as deleted', () => {
+    const {tag} = parseTag('x=$y');
+    expect(tag.has('x')).toBe(false);
+  });
+
+  test('non-reference siblings are preserved', () => {
+    const {tag} = parseTag('a=1 b=$c d=2');
+    expect(tag.numeric('a')).toBe(1);
+    expect(tag.has('b')).toBe(false);
+    expect(tag.numeric('d')).toBe(2);
+  });
+
+  test('reference in array is treated as deleted', () => {
+    const {tag} = parseTag('items=[hello, $ref, world]');
+    const arr = tag.array('items');
+    expect(arr).toBeDefined();
+    expect(arr!.length).toBe(3);
+    expect(arr![0].text()).toBe('hello');
+    expect(arr![1].deleted).toBe(true);
+    expect(arr![2].text()).toBe('world');
+  });
+});
+
 function idempotent(tag: Tag) {
   const str = tag.toString();
   const clone = parseTag(str).tag;
@@ -541,95 +565,6 @@ function idempotent(tag: Tag) {
   clone2.prefix = tag.prefix;
   expect(clone2.toString()).toBe(str2);
 }
-
-describe('toObject', () => {
-  test('bare tag becomes true', () => {
-    const {tag} = parseTag('hidden');
-    expect(tag.toObject()).toEqual({hidden: true});
-  });
-
-  test('string value becomes string', () => {
-    const {tag} = parseTag('color=blue');
-    expect(tag.toObject()).toEqual({color: 'blue'});
-  });
-
-  test('numeric value becomes number', () => {
-    const {tag} = parseTag('size=10');
-    expect(tag.toObject()).toEqual({size: 10});
-  });
-
-  test('float value becomes number', () => {
-    const {tag} = parseTag('ratio=3.14');
-    expect(tag.toObject()).toEqual({ratio: 3.14});
-  });
-
-  test('properties only becomes nested object', () => {
-    const {tag} = parseTag('box { width=100 height=200 }');
-    expect(tag.toObject()).toEqual({box: {width: 100, height: 200}});
-  });
-
-  test('value and properties uses = key', () => {
-    const {tag} = parseTag('link="http://example.com" { target=_blank }');
-    expect(tag.toObject()).toEqual({
-      link: {'=': 'http://example.com', 'target': '_blank'},
-    });
-  });
-
-  test('array of simple values', () => {
-    const {tag} = parseTag('items=[a, b, c]');
-    expect(tag.toObject()).toEqual({items: ['a', 'b', 'c']});
-  });
-
-  test('array of numeric values', () => {
-    const {tag} = parseTag('nums=[1, 2, 3]');
-    expect(tag.toObject()).toEqual({nums: [1, 2, 3]});
-  });
-
-  test('array with properties on elements', () => {
-    const {tag} = parseTag('items=[a { x=1 }, b { y=2 }]');
-    expect(tag.toObject()).toEqual({
-      items: [
-        {'=': 'a', 'x': 1},
-        {'=': 'b', 'y': 2},
-      ],
-    });
-  });
-
-  test('complex nested structure', () => {
-    const {tag} = parseTag('# hidden color=blue size=10 box { width=100 }');
-    expect(tag.toObject()).toEqual({
-      hidden: true,
-      color: 'blue',
-      size: 10,
-      box: {width: 100},
-    });
-  });
-
-  test('deleted properties are excluded', () => {
-    const {tag} = parseTag('a b -a');
-    expect(tag.toObject()).toEqual({b: true});
-  });
-
-  test('empty tag returns empty object', () => {
-    const {tag} = parseTag('');
-    expect(tag.toObject()).toEqual({});
-  });
-
-  test('deeply nested properties', () => {
-    const {tag} = parseTag('a.b.c=1');
-    expect(tag.toObject()).toEqual({a: {b: {c: 1}}});
-  });
-
-  test('array of objects (dictionaries)', () => {
-    const {tag} = parseTag('items=[{name=alice age=30}, {name=bob age=25}]');
-    expect(tag.toObject()).toEqual({
-      items: [
-        {name: 'alice', age: 30},
-        {name: 'bob', age: 25},
-      ],
-    });
-  });
-});
 
 describe('Tag parent tracking', () => {
   test('root tag has no parent', () => {
@@ -697,164 +632,6 @@ describe('Tag parent tracking', () => {
     for (const [, child] of tag.entries()) {
       expect(child.parent).toBe(tag);
     }
-  });
-});
-
-describe('References (RefTag)', () => {
-  test('absolute reference resolves to root property', () => {
-    const {tag} = parseTag('source=hello target=$source');
-    expect(tag.text('target')).toBe('hello');
-  });
-
-  test('absolute reference with path resolves correctly', () => {
-    const {tag} = parseTag(
-      'config { db { host=localhost } } target=$config.db.host'
-    );
-    expect(tag.text('target')).toBe('localhost');
-  });
-
-  test('relative reference up one level', () => {
-    const {tag} = parseTag('outer { value=42 inner { ref=$^value } }');
-    expect(tag.numeric('outer', 'inner', 'ref')).toBe(42);
-  });
-
-  test('relative reference up two levels', () => {
-    const {tag} = parseTag('root=hello outer { inner { ref=$^^root } }');
-    expect(tag.text('outer', 'inner', 'ref')).toBe('hello');
-  });
-
-  test('reference with array index', () => {
-    const {tag} = parseTag('items=[first, second, third] target=$items[1]');
-    expect(tag.text('target')).toBe('second');
-  });
-
-  test('reference in array', () => {
-    const {tag} = parseTag('source=value refs=[$source, $source]');
-    const arr = tag.textArray('refs');
-    expect(arr).toEqual(['value', 'value']);
-  });
-
-  test('unresolved reference returns undefined', () => {
-    const {tag} = parseTag('ref=$nonexistent');
-    expect(tag.text('ref')).toBeUndefined();
-  });
-
-  test('RefTag.toRefString() returns source representation', () => {
-    const {tag} = parseTag('ref=$path.to.thing');
-    const ref = tag.tag('ref');
-    expect(ref).toBeInstanceOf(RefTag);
-    expect((ref as RefTag).toRefString()).toBe('$path.to.thing');
-  });
-
-  test('RefTag.toRefString() with ups', () => {
-    const {tag} = parseTag('a { ref=$^^root.path }');
-    const ref = tag.tag('a', 'ref');
-    expect(ref).toBeInstanceOf(RefTag);
-    expect((ref as RefTag).toRefString()).toBe('$^^root.path');
-  });
-
-  test('RefTag.toRefString() with array index', () => {
-    const {tag} = parseTag('ref=$items[0].name');
-    const ref = tag.tag('ref');
-    expect(ref).toBeInstanceOf(RefTag);
-    expect((ref as RefTag).toRefString()).toBe('$items[0].name');
-  });
-
-  test('chained reference access', () => {
-    const {tag} = parseTag('data { name=alice age=30 } ref=$data');
-    expect(tag.text('ref', 'name')).toBe('alice');
-    expect(tag.numeric('ref', 'age')).toBe(30);
-  });
-
-  test('reference has correct parent', () => {
-    const {tag} = parseTag('outer { ref=$something }');
-    const outer = tag.tag('outer');
-    const ref = outer?.tag('ref');
-    expect(ref?.parent).toBe(outer);
-  });
-
-  describe('validateReferences', () => {
-    test('no errors for valid references', () => {
-      const {tag} = parseTag('source=hello target=$source');
-      expect(tag.validateReferences()).toEqual([]);
-    });
-
-    test('error for unresolved reference', () => {
-      const {tag} = parseTag('ref=$nonexistent');
-      const errors = tag.validateReferences();
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain('Unresolved reference');
-      expect(errors[0]).toContain('$nonexistent');
-    });
-
-    test('error for unresolved nested reference', () => {
-      const {tag} = parseTag('outer { inner { ref=$missing } }');
-      const errors = tag.validateReferences();
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain('outer.inner.ref');
-    });
-
-    test('error for reference that goes up too far', () => {
-      const {tag} = parseTag('ref=$^^^^^way.too.far');
-      const errors = tag.validateReferences();
-      expect(errors).toHaveLength(1);
-    });
-
-    test('multiple unresolved references', () => {
-      const {tag} = parseTag('a=$missing1 b=$missing2');
-      const errors = tag.validateReferences();
-      expect(errors).toHaveLength(2);
-    });
-  });
-
-  describe('toJSON for references', () => {
-    test('RefTag serializes to linkTo marker', () => {
-      const {tag} = parseTag('ref=$path.to.thing');
-      const ref = tag.tag('ref');
-      expect(ref?.toJSON()).toEqual({linkTo: '$path.to.thing'});
-    });
-
-    test('RefTag with ups serializes correctly', () => {
-      const {tag} = parseTag('a { ref=$^^root }');
-      const ref = tag.tag('a', 'ref');
-      expect(ref?.toJSON()).toEqual({linkTo: '$^^root'});
-    });
-  });
-
-  describe('toObject with references', () => {
-    test('reference resolves to actual value', () => {
-      const {tag} = parseTag('source=hello target=$source');
-      const obj = tag.toObject();
-      expect(obj['target']).toBe('hello');
-    });
-
-    test('reference to object resolves correctly', () => {
-      const {tag} = parseTag('data { name=alice } ref=$data');
-      const obj = tag.toObject();
-      expect(obj['ref']).toEqual({name: 'alice'});
-    });
-
-    test('unresolved reference becomes undefined', () => {
-      const {tag} = parseTag('ref=$nonexistent');
-      const obj = tag.toObject();
-      expect(obj['ref']).toBeUndefined();
-    });
-  });
-
-  describe('cloning with references', () => {
-    test('reference survives when extending tag is cloned', () => {
-      // Parse two lines - first creates reference, second extends it
-      const {tag} = parseTag(['source=hello target=$source', 'extra=data']);
-      // The reference should still work after the second parse cloned the first result
-      expect(tag.text('target')).toBe('hello');
-    });
-
-    test('clone preserves RefTag', () => {
-      const {tag} = parseTag('source=hello target=$source');
-      const cloned = tag.clone();
-      // After cloning, the reference should still resolve
-      expect(cloned.text('target')).toBe('hello');
-    });
   });
 });
 

--- a/packages/malloy-tag/src/tags.ts
+++ b/packages/malloy-tag/src/tags.ts
@@ -55,21 +55,13 @@ export interface TagInterface {
   prefix?: string;
 }
 
-// Output format - for toJSON (can contain links)
-// This format is round-trippable: a Tag.fromJSON(TagJSON) could reconstruct
-// the original Tag tree, including RefTags from TagLink.linkTo strings.
-export interface TagLink {
-  linkTo: string;
-}
-
-export interface TagJSONInterface {
+export interface TagJSON {
   eq?: TagScalar | TagJSON[];
   properties?: Record<string, TagJSON>;
   deleted?: boolean;
   prefix?: string;
+  location?: TagLocation;
 }
-
-export type TagJSON = TagJSONInterface | TagLink;
 
 export interface TagParse {
   tag: Tag;
@@ -107,7 +99,6 @@ export type TagSetValue =
  * tag.has(p?)          => boolean "tag contains tag.p"
  * tag.bare(p?)         => tag.p exists and has no properties
  * tag.dict             => Record<string,Tag> of tag properties
- * tag.toObject()       => Plain JS object representation
  * ```
  */
 export class Tag {
@@ -285,17 +276,14 @@ export class Tag {
     return !p.hasProperties();
   }
 
-  /** Virtual accessor for eq - overridden in RefTag to resolve */
   getEq(): TagValue | undefined {
     return this.eq;
   }
 
-  /** Virtual accessor for a property - overridden in RefTag to resolve */
   getProperty(name: string): Tag | undefined {
     return this.properties?.[name];
   }
 
-  /** Virtual accessor for an array element - overridden in RefTag to resolve */
   getArrayElement(index: number): Tag | undefined {
     if (Array.isArray(this.eq) && index < this.eq.length) {
       return this.eq[index];
@@ -427,117 +415,12 @@ export class Tag {
     return cloned;
   }
 
-  private static scalarToObject(
-    val: TagScalar
-  ): string | number | boolean | Date {
-    return val;
-  }
-
-  private static tagToObject(tag: TagInterface): unknown {
-    const hasProps =
-      tag.properties !== undefined && Object.keys(tag.properties).length > 0;
-    const hasValue = tag.eq !== undefined;
-
-    // Bare tag (no value, no properties)
-    if (!hasValue && !hasProps) {
-      return true;
-    }
-
-    // Properties only
-    if (!hasValue && hasProps) {
-      const result: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(tag.properties!)) {
-        if (!val.deleted) {
-          result[key] = Tag.tagToObject(val);
-        }
-      }
-      return result;
-    }
-
-    // Value only
-    if (hasValue && !hasProps) {
-      if (Array.isArray(tag.eq)) {
-        return tag.eq.map(el => Tag.tagToObject(el));
-      }
-      return Tag.scalarToObject(tag.eq!);
-    }
-
-    // Both value and properties
-    const result: Record<string, unknown> = {};
-    if (Array.isArray(tag.eq)) {
-      result['='] = tag.eq.map(el => Tag.tagToObject(el));
-    } else {
-      result['='] = Tag.scalarToObject(tag.eq!);
-    }
-    for (const [key, val] of Object.entries(tag.properties!)) {
-      if (!val.deleted) {
-        result[key] = Tag.tagToObject(val);
-      }
-    }
-    return result;
-  }
-
-  /**
-   * Convert to a plain JS object. References are resolved to actual
-   * object pointers (which may be circular in JS - that's fine).
-   * @param resolving - RefTags currently being resolved (for cycle detection)
-   */
-  toObject(resolving: Set<RefTag> = new Set()): Record<string, unknown> {
-    const result: Record<string, unknown> = {};
-    if (this.properties) {
-      for (const [key, prop] of Object.entries(this.properties)) {
-        if (!prop.deleted) {
-          result[key] = prop.toObjectValue(resolving);
-        }
-      }
-    }
-    return result;
-  }
-
-  /**
-   * Convert this tag's value to a plain JS object.
-   * Override in RefTag to resolve references.
-   * @param resolving - RefTags currently being resolved (for cycle detection)
-   */
-  toObjectValue(resolving: Set<RefTag>): unknown {
-    const hasProps =
-      this.properties !== undefined && Object.keys(this.properties).length > 0;
-    const hasValue = this.eq !== undefined;
-
-    // Bare tag (no value, no properties)
-    if (!hasValue && !hasProps) {
-      return true;
-    }
-
-    // Properties only
-    if (!hasValue && hasProps) {
-      return this.toObject(resolving);
-    }
-
-    // Value only
-    if (hasValue && !hasProps) {
-      if (Array.isArray(this.eq)) {
-        return this.eq.map(el => el.toObjectValue(resolving));
-      }
-      return this.eq;
-    }
-
-    // Both value and properties
-    const result: Record<string, unknown> = this.toObject(resolving);
-    if (Array.isArray(this.eq)) {
-      result['='] = this.eq.map(el => el.toObjectValue(resolving));
-    } else {
-      result['='] = this.eq;
-    }
-    return result;
-  }
-
   /**
    * Custom JSON serialization that excludes _parent to avoid circular references.
    * This is called automatically by JSON.stringify().
    */
   toJSON(): TagJSON {
-    const result: TagJSONInterface = {};
+    const result: TagJSON = {};
     if (this.eq !== undefined) {
       if (Array.isArray(this.eq)) {
         result.eq = this.eq.map(el => el.toJSON());
@@ -556,6 +439,9 @@ export class Tag {
     }
     if (this.prefix) {
       result.prefix = this.prefix;
+    }
+    if (this.location) {
+      result.location = this.location;
     }
     return result;
   }
@@ -893,153 +779,6 @@ export class Tag {
       }
     }
     return this;
-  }
-}
-
-/**
- * A tag that references another location in the tag tree.
- * When accessed, it dereferences to the target tag.
- *
- * Reference syntax:
- *   $path.to.thing     - absolute from root
- *   $^thing            - up one level, then 'thing'
- *   $^^thing           - up two levels, then 'thing'
- *   $items[0].name     - with array indexing
- */
-export class RefTag extends Tag {
-  readonly ups: number;
-  readonly refPath: Path;
-
-  constructor(ups: number, refPath: Path, parent?: Tag) {
-    super({}, parent);
-    this.ups = ups;
-    this.refPath = refPath;
-  }
-
-  /**
-   * Resolve this reference to the target tag.
-   * Returns undefined if the reference cannot be resolved.
-   */
-  resolve(): Tag | undefined {
-    // Start from the appropriate point based on ups
-    let current: Tag | undefined;
-    if (this.ups === 0) {
-      // Absolute reference from root
-      current = this.root;
-    } else {
-      // Relative reference - go up 'ups' levels from parent
-      // $^ means go up 1 level from the containing scope
-      current = this.parent;
-      for (let i = 0; i < this.ups && current !== undefined; i++) {
-        current = current.parent;
-      }
-    }
-
-    if (current === undefined) {
-      return undefined;
-    }
-
-    // Follow the path
-    return current.find(this.refPath);
-  }
-
-  /**
-   * Quote an identifier if it contains special characters.
-   */
-  private quoteSegment(seg: string): string {
-    // Match bareString from peggy grammar: [0-9A-Za-z_\u00C0-\u024F\u1E00-\u1EFF]+
-    if (/^[0-9A-Za-z_\u00C0-\u024F\u1E00-\u1EFF]+$/.test(seg)) {
-      return seg;
-    }
-    // Otherwise, backquote it (escaping backslashes and backquotes)
-    return '`' + seg.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
-  }
-
-  /**
-   * Convert this reference to its string representation.
-   */
-  toRefString(): string {
-    const prefix = '$' + '^'.repeat(this.ups);
-    const pathStr = this.refPath
-      .map((seg, i) => {
-        if (typeof seg === 'number') {
-          return `[${seg}]`;
-        }
-        const quoted = this.quoteSegment(seg);
-        return i === 0 ? quoted : `.${quoted}`;
-      })
-      .join('');
-    return prefix + pathStr;
-  }
-
-  // Override virtual accessors to resolve the reference
-  override getEq(): TagValue | undefined {
-    return this.resolve()?.getEq();
-  }
-
-  override getProperty(name: string): Tag | undefined {
-    return this.resolve()?.getProperty(name);
-  }
-
-  override getArrayElement(index: number): Tag | undefined {
-    return this.resolve()?.getArrayElement(index);
-  }
-
-  override hasProperties(): boolean {
-    return this.resolve()?.hasProperties() ?? false;
-  }
-
-  /**
-   * For toObject, resolve the reference and return the target's object value.
-   * This creates actual object pointers (circular references are allowed).
-   * Detects cycles in the reference chain to prevent infinite recursion.
-   */
-  override toObjectValue(resolving: Set<RefTag>): unknown {
-    // Check for cycle in reference chain
-    if (resolving.has(this)) {
-      // We're in a cycle - return undefined to break it
-      // (The cycle will be completed when the outer resolution finishes)
-      return undefined;
-    }
-
-    const resolved = this.resolve();
-    if (resolved === undefined) {
-      return undefined;
-    }
-
-    // Track that we're resolving this RefTag
-    resolving.add(this);
-    const result = resolved.toObjectValue(resolving);
-    resolving.delete(this);
-
-    return result;
-  }
-
-  /**
-   * For JSON serialization, return a marker object instead of resolving.
-   */
-  override toJSON(): TagJSON {
-    return {linkTo: this.toRefString()};
-  }
-
-  /**
-   * Check if this reference resolves, add error if not.
-   */
-  override collectReferenceErrors(errors: string[], path: string[]): void {
-    if (this.resolve() === undefined) {
-      const location = path.length > 0 ? path.join('.') : 'root';
-      errors.push(`Unresolved reference at ${location}: ${this.toRefString()}`);
-    }
-  }
-
-  /**
-   * Clone this RefTag, preserving the reference information.
-   */
-  override clone(newParent?: Tag): RefTag {
-    this._read = true;
-    const cloned = new RefTag(this.ups, [...this.refPath], newParent);
-    cloned._clonedFrom = this;
-    return cloned;
   }
 }
 

--- a/scripts/femto-build.js
+++ b/scripts/femto-build.js
@@ -108,10 +108,10 @@ function validateTarget(name) {
     );
     process.exit(1);
   }
-  const commands = config.get('commands').texts;
-  const inputs = config.get('inputs').texts;
-  const deps = config.get('deps').texts;
-  const outputs = config.get('outputs').texts;
+  const commands = config.texts('commands');
+  const inputs = config.texts('inputs');
+  const deps = config.texts('deps');
+  const outputs = config.texts('outputs');
   if (config.has('commands') && !commands) {
     console.error(
       `femto-build: target "${name}" "commands" must be an array of strings`


### PR DESCRIPTION
I spent the weekend tweaking the MOTLY API and thinking about the difference between a `Mot` ( the MOTLY loaded data node ) and a `Tag` which is how parsed MOTLY data shows up inside Malloy.

I took a run at unifying `Mot` and `Tag` but in the end that felt like it made both `Mot` and `Tag` worse. I don't know if `Tag` is badly designed or `Mot` is not powerful enough. I did not arrive at a conclusion.

This PR updates to the latest MOTLY, which has some cleanup in syntax which does not affect Malloy users. ( it is now possible in MOTLY for all values to have properties ... which is mostly a pedantic extension of the tag language that probably nobody cares about ). These changes did require a slight upgrade to the code which parses MOTLY into tags.