### PR TITLE
Add Postgres all-aggregates tests and improve error diagnostic

### DIFF
--- a/packages/malloy/src/model/query_node.ts
+++ b/packages/malloy/src/model/query_node.ts
@@ -417,9 +417,9 @@ export class QueryStruct {
         // According to the type system this should be impossible, but we have seen this happen
         // in the wild, so we are leaving error handling here to help debug if it happens again.
         throw new Error(
-          `Unexpected field '${as}' in addFieldsFromFieldList`
-          + `\n  field: ${JSON.stringify(field)}`
-          + `\n  structDef: ${JSON.stringify(this.structDef)}`
+          `Unexpected field '${as}' in addFieldsFromFieldList` +
+            `\n  field: ${JSON.stringify(field)}` +
+            `\n  structDef: ${JSON.stringify(this.structDef)}`
         );
       }
     }

--- a/test/src/databases/postgres/postgres.spec.ts
+++ b/test/src/databases/postgres/postgres.spec.ts
@@ -294,9 +294,7 @@ describe('Postgres tests', () => {
       `
       );
       // Mimic MCP server pattern: getPreparedResult() then run()
-      const runnable = model.model.loadQuery(
-        'run: orders -> explore_totals'
-      );
+      const runnable = model.model.loadQuery('run: orders -> explore_totals');
       const preparedResult = await runnable.getPreparedResult();
       expect(preparedResult).toBeDefined();
       const result = await runnable.run();


### PR DESCRIPTION
## Summary
- Add `structDef` JSON dump to the `addFieldsFromFieldList` error message so the full query context is available when this "impossible" error occurs in the wild
- Add Postgres tests for all-aggregates views with joins and nested views, exercising the finalize stage code path
- Add test mimicking MCP server pattern (`getPreparedResult()` then `run()`) to cover that specific code path

## Test plan
- [x] All new Postgres tests pass locally
- [x] TypeScript compiles cleanly