### PR TITLE
Remove dead 'calculate' kind from render schema filter

### DIFF
--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -43,9 +43,7 @@ export class RenderFieldMetadata {
           kind: 'array_type',
           element_type: {
             kind: 'record_type',
-            fields: result.schema.fields.filter(
-              f => f.kind === 'dimension' || f.kind === 'calculate'
-            ),
+            fields: result.schema.fields.filter(f => f.kind === 'dimension'),
           },
         },
         annotations: result.annotations,


### PR DESCRIPTION
## Summary

- Remove unreachable `|| f.kind === 'calculate'` from the result schema filter in `RenderFieldMetadata`
- Result schemas only ever contain `kind: 'dimension'` fields — by the time a query result reaches the renderer, all fields (aggregates, calculations, nested views) have been materialized as dimensions
- The `'calculate'` check was added in #2439 but was never needed; the query builder constructs *queries*, not *result schemas*

## Test plan

- All existing malloy-render tests pass (90/90)
- Verified empirically that `toStableResult`, `wrapResult`, and the async `runQuery` API all produce only `kind: 'dimension'` fields in result schemas