### PR TITLE
Fix four regressions in imports, composites, and symmetric aggregates

### DIFF
--- a/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
+++ b/packages/malloy/src/lang/ast/field-space/rename-space-field.ts
@@ -58,6 +58,13 @@ export class RenameSpaceField extends SpaceField {
       ...returnFieldDef,
       as: this.newName,
       location: this.location,
+      fieldUsage: returnFieldDef.fieldUsage?.map(u => ({
+        ...u,
+        path:
+          u.path[0] === (returnFieldDef.as ?? returnFieldDef.name)
+            ? [this.newName, ...u.path.slice(1)]
+            : u.path,
+      })),
     };
   }
 

--- a/packages/malloy/src/lang/ast/statements/import-statement.ts
+++ b/packages/malloy/src/lang/ast/statements/import-statement.ts
@@ -117,7 +117,7 @@ export class ImportStatement
         const importedModel = trans.importModelDef(this.fullURL);
         if (importedModel) {
           const importAll = this.empty();
-          const explicitImport: Record<string, string> = {};
+          const explicitImport: Record<string, string[]> = {};
           for (const importOne of this.list) {
             const dstName = importOne.text;
             const srcName = importOne.from ? importOne.from.text : dstName;
@@ -132,14 +132,17 @@ export class ImportStatement
                 `Cannot redefine '${dstName}'`
               );
             } else {
-              explicitImport[srcName] = dstName;
+              if (explicitImport[srcName] === undefined) {
+                explicitImport[srcName] = [];
+              }
+              explicitImport[srcName].push(dstName);
             }
           }
           const neededSourceIDs = new Set<SourceID>();
           for (const srcName of importedModel.exports) {
-            const picked = explicitImport[srcName];
-            const dstName = picked || srcName;
-            if (importAll || picked) {
+            const pickedNames = explicitImport[srcName];
+            const dstNames = pickedNames || (importAll ? [srcName] : []);
+            for (const dstName of dstNames) {
               const importMe = {
                 ...safeRecordGet(importedModel.contents, srcName)!,
               };

--- a/packages/malloy/src/lang/composite-source-utils.ts
+++ b/packages/malloy/src/lang/composite-source-utils.ts
@@ -486,10 +486,29 @@ function expandFieldUsage(
   const activeJoinGraph: Record<string, JoinDependency> = {};
   const ungroupings: AggregateUngrouping[] = [];
 
+  function mergeIntoSeen(usage: FieldUsage): boolean {
+    const key = pathToKey('field', usage.path);
+    if (!seen[key]) {
+      seen[key] = {...usage};
+      return true;
+    }
+    const existing = seen[key];
+    if (usage.uniqueKeyRequirement) {
+      existing.uniqueKeyRequirement = {
+        isCount:
+          existing.uniqueKeyRequirement?.isCount ||
+          usage.uniqueKeyRequirement.isCount,
+      };
+    }
+    if (usage.analyticFunctionUse) {
+      existing.analyticFunctionUse = true;
+    }
+    return false;
+  }
+
   // Initialize: mark original inputs and add them to processing queue
   for (const usage of fieldUsage) {
-    const seenKey = pathToKey('field', usage.path);
-    seen[seenKey] = usage;
+    mergeIntoSeen(usage);
     toProcess.push(usage);
   }
 
@@ -510,16 +529,8 @@ function expandFieldUsage(
       // Add the atomic field's dependencies to the queue
       const refPath = reference.path.slice(0, -1);
       for (const usage of joinedFieldUsage(refPath, fieldUsage)) {
-        const key = pathToKey('field', usage.path);
-        if (!seen[key]) {
-          seen[key] = usage;
+        if (mergeIntoSeen(usage)) {
           toProcess.push(usage);
-        } else if (usage.uniqueKeyRequirement) {
-          seen[key].uniqueKeyRequirement = {
-            isCount:
-              usage.uniqueKeyRequirement.isCount ??
-              seen[key].uniqueKeyRequirement?.isCount,
-          };
         }
       }
 

--- a/packages/malloy/src/lang/test/composite-field-usage.spec.ts
+++ b/packages/malloy/src/lang/test/composite-field-usage.spec.ts
@@ -1109,6 +1109,59 @@ describe('field usage with compiler extensions', () => {
     });
     expect(found, message).toBeTruthy();
   });
+  test('inline count and calculate preserve uniqueKeyRequirement', () => {
+    // When count() and rank() are both inline in the same query, their
+    // fieldUsage entries both have path []. The expandFieldUsage init loop
+    // must not overwrite one with the other.
+    const mTest = model`
+      run: ab -> {
+        group_by: astr
+        aggregate: c is count()
+        calculate: r is rank()
+      }
+    `;
+    expect(mTest).toTranslate();
+    const mq = mTest.translator.getQuery(0);
+    let [found, message] = checkForFieldUsage(mq, {
+      path: [],
+      uniqueKeyRequirement: {isCount: true},
+    });
+    expect(found, message).toBeTruthy();
+    [found, message] = checkForFieldUsage(mq, {
+      path: [],
+      analyticFunctionUse: true,
+    });
+    expect(found, message).toBeTruthy();
+  });
+  test('predefined count in view with calculate preserves uniqueKeyRequirement', () => {
+    // When a predefined measure (count()) is used in a view alongside
+    // calculate (rank()), the uniqueKeyRequirement from the measure's
+    // field def must survive expansion even though analyticFunctionUse
+    // is on the same path.
+    const mTest = model`
+      source: f is ab extend {
+        measure: c is count()
+        view: ranking is {
+          group_by: astr
+          aggregate: c
+          calculate: r is rank()
+        }
+      }
+      run: f -> ranking
+    `;
+    expect(mTest).toTranslate();
+    const mq = mTest.translator.getQuery(0);
+    let [found, message] = checkForFieldUsage(mq, {
+      path: [],
+      uniqueKeyRequirement: {isCount: true},
+    });
+    expect(found, message).toBeTruthy();
+    [found, message] = checkForFieldUsage(mq, {
+      path: [],
+      analyticFunctionUse: true,
+    });
+    expect(found, message).toBeTruthy();
+  });
   it('transitive joins activated, in order', () => {
     const joinModel = model`
         source: root is a extend { dimension: id is 1 }
@@ -1317,5 +1370,24 @@ describe('field usage with compiler extensions', () => {
     expect(found, message).toBeTruthy();
     [found, message] = checkForFieldUsage(mq, {path: ['c', 'af']});
     expect(found, message).toBeTruthy();
+  });
+
+  test('composite with renamed field resolves correctly', () => {
+    // When a composite input renames a field (airport_code is code),
+    // querying the renamed field should resolve to that input without
+    // also requiring the original field name.
+    const m = model`
+      ##! experimental.composite_sources
+      source: ap is _db_.table('malloytest.airports')
+      source: state_facts is ap extend {
+        dimension: state_pop is 1
+      }
+      source: my_airports is ap extend {
+        rename: airport_code is code
+      }
+      source: comp is compose(state_facts, my_airports)
+      run: comp -> { select: airport_code, state }
+    `;
+    expect(m).toTranslate();
   });
 });

--- a/packages/malloy/src/lang/test/imports.spec.ts
+++ b/packages/malloy/src/lang/test/imports.spec.ts
@@ -287,6 +287,21 @@ source: botProjQSrc is botProjQ
       errorMessage("Cannot find 'bb', not imported")
     );
   });
+  test('selective import with rename of same source', () => {
+    // import { aa, bb is aa } should import aa as itself AND as bb
+    const docParse = new TestTranslator('import { aa, bb is aa } from "child"');
+    const xr = docParse.unresolved();
+    expect(docParse).toParse();
+    expect(xr).toMatchObject({urls: ['internal://test/langtests/child']});
+    docParse.update({
+      urls: {'internal://test/langtests/child': 'source: aa is a'},
+    });
+    expect(docParse).toTranslate();
+    const aa = docParse.getSourceDef('aa');
+    expect(aa).toBeDefined();
+    const bb = docParse.getSourceDef('bb');
+    expect(bb).toBeDefined();
+  });
   test('selective import of source, no-redefinition', () => {
     const doc = model`
       import { cc is ${'bb'} } from "child"

--- a/packages/malloy/src/model/query_query.ts
+++ b/packages/malloy/src/model/query_query.ts
@@ -293,7 +293,6 @@ export class QueryQuery extends QueryField {
           resultRoot.isComplexQuery = true;
           resultRoot.queryUsesPartitioning = true;
         }
-        continue;
       }
       if (usage.uniqueKeyRequirement) {
         if (usage.path.length === 0) {

--- a/test/src/core/bugless.spec.ts
+++ b/test/src/core/bugless.spec.ts
@@ -69,6 +69,24 @@ describe('misc tests for regressions that have no better home', () => {
       `).toMatchResult(testModel, {});
     });
   });
+
+  test('view with joined dimension and calculate compiles', async () => {
+    // Regression: a view using a joined field as a dimension and
+    // calculate (e.g. rank()) stopped compiling.
+    await expect(`
+      source: model is duckdb.table('malloytest.flights') extend {
+        join_many: carriers is duckdb.table('malloytest.carriers') on carriers.code = carrier
+        dimension: airline is carriers.name
+        measure: flight_count is count()
+        view: ranking is {
+          group_by: airline
+          aggregate: flight_count
+          calculate: rank is rank()
+        }
+      }
+      run: model -> ranking
+    `).toMatchResult(testModel, {});
+  });
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary

- **Import with rename of same source**: `import { aa, bb is aa }` lost the first mapping because `explicitImport` was `Record<string, string>` (one dest per source). Changed to `Record<string, string[]>`.
- **Composite source with renamed field**: `RenameSpaceField.fieldDef()` preserved the old field name in `fieldUsage`, causing composite resolution to require the removed original name. Now updates self-referential paths to use the new name.
- **`expandFieldUsage` init loop overwrites**: When multiple field usages share the same path (e.g., `count()` and `rank()` both at `[]`), the second entry overwrote the first, losing `uniqueKeyRequirement`. Extracted `mergeIntoSeen()` helper that properly merges both properties.
- **`dependenciesFromFieldUsage` skips `uniqueKeyRequirement`**: The `continue` after handling `analyticFunctionUse` skipped the `uniqueKeyRequirement` check when both were on the same entry. This caused `join_many` + `count()` + `calculate` queries to generate SQL referencing `__distinct_key` without creating it.

## Test plan

- [x] New translator test: selective import with rename of same source
- [x] New translator test: composite with renamed field resolves correctly
- [x] New translator test: inline count + calculate preserves uniqueKeyRequirement
- [x] New translator test: predefined count in view with calculate preserves uniqueKeyRequirement
- [x] New runtime test: join_many + dimension from join + count + calculate view compiles and runs
- [x] `npm run test-duckdb` passes
- [x] `npm run lint-fix` clean