### PR TITLE
Fix index queries with joins failing on __distinct_key

### DIFF
--- a/packages/malloy/src/lang/ast/query-builders/index-builder.ts
+++ b/packages/malloy/src/lang/ast/query-builders/index-builder.ts
@@ -146,6 +146,14 @@ export class IndexBuilder implements QueryBuilder {
         : emptyFieldUsage();
     indexSegment.fieldUsage = mergeFieldUsage(fromFieldUsage, this.fieldUsage);
 
+    // Index queries always compute an aggregate for weight (at minimum COUNT(*)).
+    // The compiler needs a uniqueKeyRequirement on the base path so that
+    // symmetric aggregation is enabled when joins are present.
+    indexSegment.fieldUsage.push({
+      path: [],
+      uniqueKeyRequirement: {isCount: true},
+    });
+
     return indexSegment;
   }
 }

--- a/test/src/core/bugless.spec.ts
+++ b/test/src/core/bugless.spec.ts
@@ -87,6 +87,27 @@ describe('misc tests for regressions that have no better home', () => {
       run: model -> ranking
     `).toMatchResult(testModel, {});
   });
+
+  test('index query piped to select compiles', async () => {
+    // Regression: piping an index query into a select stage caused a
+    // __distinct_key error in the compiler.
+    await expect(`
+      run: duckdb.table('malloytest.flights') extend {
+        join_many: carriers is duckdb.table('malloytest.carriers') on carriers.code = carrier
+        measure: total_flights is count()
+      } -> {
+        index:
+          *
+          carriers.*
+        by total_flights
+        sample: 5000
+      } -> {
+        select: *
+        where: fieldValue ~ 'United%'
+        order_by: weight desc
+      }
+    `).toMatchResult(testModel, {});
+  });
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary

- Index queries with joins (e.g. `index: *, carriers.*`) failed at runtime with `"base" does not have a column named "__distinct_key"` when a weight measure was used
- The index segment's `fieldUsage` was missing the `uniqueKeyRequirement` that tells the compiler to enable symmetric aggregation (and add `__distinct_key` to the base table)
- Added `{path: [], uniqueKeyRequirement: {isCount: true}}` to every index segment's fieldUsage in the translator, so the compiler's existing pipeline handles it correctly

## Test plan

- [x] Added regression test in `bugless.spec.ts` — index query with `join_many`, wildcard expansion, weight measure, piped to a select stage
- [x] `npm run test-duckdb` passes
- [x] Lint clean