### PR TITLE
Bump google-github-actions/auth from v2 to v3

### DIFF
--- a/.github/workflows/db-bigquery.yaml
+++ b/.github/workflows/db-bigquery.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 20.x
       - name: GCloud auth
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'
       - name: npm install, build, and test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: 20.x
       - name: GCloud auth
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'
       - name: npm install, build, and test


### PR DESCRIPTION
## Summary
- Bumps `google-github-actions/auth` from v2 to v3 in `db-bigquery.yaml` and `main.yaml`
- Resolves Node.js 20 deprecation warnings — v3 supports Node.js 24

## Test plan
- [ ] Verify BigQuery CI tests pass
- [ ] Verify Core CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)