### PR TITLE
Fix big_value plugin throwing on child config tags

### DIFF
--- a/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
+++ b/packages/malloy-render/src/plugins/big-value/big-value-plugin.tsx
@@ -191,6 +191,15 @@ export const BigValuePluginFactory: RenderPluginFactory<BigValuePluginInstance> 
         fieldType === FieldType.Record;
 
       if (hasBigValueTag && !isValidType) {
+        // Child config tags (sparkline, comparison_field) are read by the
+        // parent big_value plugin — not a match request for this field.
+        const bigValueTag = fieldTag.tag('big_value');
+        if (
+          bigValueTag?.has('sparkline') ||
+          bigValueTag?.has('comparison_field')
+        ) {
+          return false;
+        }
         throw new Error(
           'Malloy Big Value: field must be a query result (repeated record or record)'
         );

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -297,6 +297,42 @@ describe('render tag validation', () => {
       );
       expect(bigValueGroupByErrors).toHaveLength(0);
     });
+
+    it('no error when aggregate has big_value comparison config', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as val") extend {
+          # big_value
+          view: q is {
+            aggregate: total is count()
+            aggregate:
+              # big_value { comparison_field=total }
+              prior is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('no error when aggregate has big_value sparkline config', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as val, DATE '2024-01-01' as dt") extend {
+          # big_value
+          view: q is {
+            aggregate: total is count()
+            # big_value { sparkline=trend }
+            aggregate: total2 is count()
+            # hidden # line_chart { size=spark }
+            nest: trend is {
+              group_by: dt
+              aggregate: c is count()
+            }
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+    });
   });
 
   describe('no errors for valid tags', () => {


### PR DESCRIPTION
## Summary

- The big_value plugin's `matches()` threw on aggregate fields with `# big_value { sparkline=... }` or `# big_value { comparison_field=... }` tags, because it saw `big_value` on a non-Record field
- These tags are child configuration read by the parent big_value plugin during `create()` — not standalone match requests
- Now returns `false` instead of throwing when the tag has `sparkline` or `comparison_field` properties
- This was causing the docs build to fail when it copied storybook patterns that use these tags

## Test plan

- [x] Two new tests in `render-validator.spec.ts` for comparison and sparkline config on aggregates
- [x] All 35 render-validator tests pass
- [x] Verified all big_value storybook stories render without error logs
- [x] Lint clean