### PR TITLE
fix: avoid scalarType() crash in tag validator

### DIFF
--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -236,11 +236,13 @@ export class RenderFieldMetadata {
     }
 
     // --- number tag with bare numeric value ---
-    const numberValTag = tag.tag('number');
-    if (numberValTag?.scalarType() === 'number') {
+    // Detect # number=123 (bare numeric) vs # number="###,##0" (format string).
+    // Use numeric() + text() since scalarType() may not be in the built package.
+    const numberNumeric = tag.numeric('number');
+    if (numberNumeric !== undefined && tag.text('number') === String(numberNumeric)) {
       log.error(
         `Tag 'number' on field '${field.name}' has a bare numeric value. Use a quoted format string instead, e.g. # number="#,##0.00"`,
-        numberValTag
+        tag.tag('number')
       );
     }
 


### PR DESCRIPTION
## Summary

- **Fix TypeError**: `numberValTag?.scalarType is not a function` crashes all Storybook stories that use `# number`, `# currency`, or any numeric tag
- **Root cause**: `scalarType()` exists in `malloy-tag` source but is missing from the built `dist/tags.js` — the method was added to source but the package wasn't rebuilt
- **Fix**: Replace `scalarType()` call with equivalent `numeric()` + `text()` checks that are available in the built package

## Test plan

- [ ] Open Storybook and verify Big Value stories render (Basic Metrics, Formatted Metrics, Currency Scaling, Number Scaling, Number Verbose)
- [ ] Verify Bar Chart stories render (Interactions Sandbox, etc.)
- [ ] Confirm bare numeric `# number=123` still produces a validation error


🤖 Generated with [Claude Code](https://claude.com/claude-code)