### PR TITLE
fix: local config supersedes shared instead of merging

### DIFF
--- a/packages/malloy/src/api/foundation/config.spec.ts
+++ b/packages/malloy/src/api/foundation/config.spec.ts
@@ -460,7 +460,7 @@ describe('discoverConfig', () => {
     ).rejects.toThrow(/Malformed JSON.*malloy-config\.json/);
   });
 
-  it('merges shared+local with local winning on connection entries', async () => {
+  it('local supersedes shared entirely when both exist', async () => {
     const reader = mockReader({
       'file:///project/malloy-config.json': {
         connections: {
@@ -482,12 +482,13 @@ describe('discoverConfig', () => {
     );
     expect(config).not.toBeNull();
     expect(config?.log).toEqual([]);
-    // All three connections are reachable — local's `both` wins.
-    await config!.connections.lookupConnection('shared_only');
+    // Only local's connections are present — shared is not merged in.
     await config!.connections.lookupConnection('local_only');
     await config!.connections.lookupConnection('both');
-    // When both files exist at the same level, manifestURL hangs off the
-    // local file's directory (same directory as shared here).
+    await expect(
+      config!.connections.lookupConnection('shared_only')
+    ).rejects.toThrow();
+    // manifestURL hangs off the local file's directory.
     expect(config?.manifestURL?.toString()).toBe(
       'file:///project/MANIFESTS/malloy-manifest.json'
     );

--- a/packages/malloy/src/api/foundation/config_discover.ts
+++ b/packages/malloy/src/api/foundation/config_discover.ts
@@ -103,35 +103,12 @@ async function tryReadAtLevel(
     tryReadJSON(localURL, urlReader),
   ]);
 
-  if (!sharedPOJO && !localPOJO) return null;
-
-  if (sharedPOJO && localPOJO) {
-    // Shallow-merge top-level keys, local wins. `connections` is the one
-    // section we deep-merge by entry name (local winning) — the documented
-    // shop workflow is shared credentials as env refs in git, local
-    // overrides with literal values outside git.
-    //
-    // All other sections (virtualMap, manifestPath, includeDefaultConnections)
-    // are replaced wholesale when present in the local file. If you want to
-    // augment a shared virtualMap from the local file, you have to copy
-    // the shared entries into the local file explicitly.
-    const sharedConns = isRecord(sharedPOJO['connections'])
-      ? sharedPOJO['connections']
-      : {};
-    const localConns = isRecord(localPOJO['connections'])
-      ? localPOJO['connections']
-      : {};
-    const merged: Record<string, unknown> = {
-      ...sharedPOJO,
-      ...localPOJO,
-      connections: {...sharedConns, ...localConns},
-    };
-    return {configURL: localURL, pojo: merged};
-  }
-
+  // Local supersedes shared entirely when both exist — no merging of any
+  // kind. The person writing a local file is responsible for including
+  // everything they need.
   if (localPOJO) return {configURL: localURL, pojo: localPOJO};
-  // Narrowed: sharedPOJO is truthy here.
-  return {configURL: sharedURL, pojo: sharedPOJO as Record<string, unknown>};
+  if (sharedPOJO) return {configURL: sharedURL, pojo: sharedPOJO};
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- When both `malloy-config.json` and `malloy-config-local.json` exist at the same directory level, the local file now replaces shared entirely — no merge of connections or any other section.
- Simplifies `tryReadAtLevel` from a three-branch merge to a clean priority chain (`local > shared > null`).

## Test plan
- [x] Updated existing merge test to verify supersede: `shared_only` connection rejects, only local's connections are present
- [x] All 50 config tests pass