### PR TITLE
docs: rewrite simple builder as persistence builder tutorial

### DIFF
--- a/scripts/simple_builder/build.ts
+++ b/scripts/simple_builder/build.ts
@@ -264,7 +264,9 @@ export async function build(opts: BuildOptions): Promise<void> {
         if (existingEntry) {
           manifest.touch(buildId);
 
-          console.log(`  Exists: ${persistSource.name} -> ${existingEntry.tableName}`);
+          console.log(
+            `  Exists: ${persistSource.name} -> ${existingEntry.tableName}`
+          );
           logEntries.push({
             action: 'exists',
             buildId,

--- a/scripts/simple_builder/build.ts
+++ b/scripts/simple_builder/build.ts
@@ -3,6 +3,91 @@
  * SPDX-License-Identifier: MIT
  */
 
+/**
+ * SIMPLE BUILDER — A teaching implementation of the Malloy persistence builder.
+ *
+ * This file demonstrates the builder contract: the 5-step workflow that every
+ * persistence builder must follow. The malloy-cli `build` command is a
+ * production implementation of the same contract with multi-connection support,
+ * config file discovery, and error reporting. This sample trades all of that
+ * for clarity.
+ *
+ * ## The builder contract
+ *
+ *   1. LOAD — Load (or create) a Manifest from an existing manifest file.
+ *      The manifest maps BuildIDs to table names from prior builds.
+ *
+ *   2. COMPILE — Compile the model to obtain its IR. The manifest is not
+ *      passed to the compiler. Manifest substitution happens in step 4,
+ *      when calling `source.getSQL({buildManifest, connectionDigests})`.
+ *
+ *   3. PLAN — Call `model.getBuildPlan()` to get the dependency graph.
+ *      The plan groups sources by connection and levels them for parallel
+ *      execution. All nodes in the same level are independent of each other.
+ *
+ *   4. BUILD — Walk the graph in dependency order. For each source:
+ *      a. Compute the BuildID from `source.getSQL()` (no manifest — full
+ *         inline SQL) and the connection digest.
+ *      b. If the BuildID is already in the manifest, `touch()` it (marks
+ *         it active for GC, but does not rebuild).
+ *      c. Otherwise, get the *build SQL* from `source.getSQL({buildManifest,
+ *         connectionDigests})` — this version substitutes already-built
+ *         dependencies with their table names — then CREATE TABLE and
+ *         `update()` the manifest.
+ *
+ *   5. WRITE — Write `manifest.activeEntries` to disk. Only entries that
+ *      were touched or updated in this run are included. Entries from prior
+ *      builds that were not referenced are pruned — this is how GC works.
+ *
+ * ## Key insight: the manifest is part of the build loop
+ *
+ *   `manifest.buildManifest` returns a *stable reference*. When you call
+ *   `manifest.update(buildId, {tableName})`, the change is immediately
+ *   visible to subsequent `source.getSQL({buildManifest, ...})` calls in
+ *   the same build run. This is how dependency chains work:
+ *
+ *     source A (persist) → builds first, manifest.update(A)
+ *     source B (persist, depends on A) → getSQL() sees A's table name
+ *
+ *   Without this, B's SQL would contain A's full inline SQL instead of a
+ *   table reference, producing a different (and much more expensive) query.
+ *
+ * ## BuildID vs build SQL
+ *
+ *   These are two different SQL strings for the same source:
+ *
+ *   - **BuildID SQL** — `source.getSQL()` with no options. Produces the
+ *     fully-inlined SQL with no manifest substitution. This is hashed
+ *     (with the connection digest) to produce the BuildID. The BuildID
+ *     must be stable regardless of build order, so it never includes
+ *     manifest-substituted table names.
+ *
+ *   - **Build SQL** — `source.getSQL({buildManifest, connectionDigests})`.
+ *     Dependencies that are already in the manifest are replaced with
+ *     their table names. This is the SQL you actually execute in
+ *     CREATE TABLE. It's more efficient because it reads from pre-built
+ *     tables instead of recomputing dependencies inline.
+ *
+ * ## Divergences from malloy-cli
+ *
+ *   This sample differs from the production CLI builder in a few ways:
+ *
+ *   - **Table naming:** The CLI requires `#@ persist name=...` and errors
+ *     if missing. This sample falls back to `persist_<buildId prefix>` for
+ *     sources without an explicit name. Use explicit names in production.
+ *
+ *   - **Strict mode:** The CLI sets `manifest.strict = true` on new
+ *     manifests so that missing entries throw at query time. This sample
+ *     does not set strict mode.
+ *
+ *   - **Execution:** This sample only generates a SQL script file — it does
+ *     not execute the CREATE TABLE statements. The CLI executes them and
+ *     reports timing.
+ *
+ *   - **Connections:** The CLI uses MalloyConfig to create connections from
+ *     a config file. This sample hardcodes a single DuckDB connection.
+ */
+
 import {readFile, writeFile, mkdir} from 'fs/promises';
 import * as path from 'path';
 import type {Connection} from '@malloydata/malloy';
@@ -11,7 +96,6 @@ import {Malloy, Manifest} from '@malloydata/malloy';
 import {DuckDBConnection} from '@malloydata/db-duckdb';
 import type {BuilderLog, BuildLogEntry} from './log_types';
 import {logFileName} from './log_types';
-import {flattenBuildNodes} from './build_graph';
 
 export interface BuildOptions {
   modelFile: string;
@@ -37,9 +121,9 @@ export async function build(opts: BuildOptions): Promise<void> {
   const fileDir = path.dirname(modelFile);
   const fileUrl = `file://${modelFile}`;
 
-  // --- Connection setup (hardcoded DuckDB for this sample builder) ---
+  // --- Connection setup (hardcoded DuckDB for this sample) ---
   // A real builder would use MalloyConfig to create connections from a
-  // config file. This sample hardcodes a DuckDB connection for simplicity.
+  // config file. See malloy-cli's build.ts for that pattern.
   const connection = new DuckDBConnection({
     name: 'duckdb',
     databasePath: ':memory:',
@@ -62,16 +146,42 @@ export async function build(opts: BuildOptions): Promise<void> {
     },
   };
 
-  // --- Compile ---
-  const source = await readFile(modelFile, {encoding: 'utf-8'});
-  const parse = Malloy.parse({source, url: new URL(fileUrl)});
+  // =========================================================
+  // STEP 1: LOAD — Load existing manifest (or start empty)
+  // =========================================================
+  // The manifest maps BuildIDs to table names from prior builds. Loading
+  // it lets us skip sources that haven't changed (their BuildID still
+  // matches an entry).
+  const manifest = new Manifest();
+  try {
+    manifest.loadText(await readFile(manifestFile, 'utf-8'));
+  } catch {
+    // No existing manifest — start fresh
+  }
+
+  // =========================================================
+  // STEP 2: COMPILE — Compile the model
+  // =========================================================
+  // Compile the model to get its IR. The manifest is NOT passed here —
+  // the compiler doesn't need it yet. Manifest substitution happens later,
+  // when we call source.getSQL({buildManifest, connectionDigests}) during
+  // the build loop (step 4). That's where already-built dependencies
+  // resolve to table references instead of inline SQL.
+  const modelText = await readFile(modelFile, {encoding: 'utf-8'});
+  const parse = Malloy.parse({source: modelText, url: new URL(fileUrl)});
   const model = await Malloy.compile({
     urlReader: {readURL},
     connections,
     parse,
   });
 
-  // --- Build plan ---
+  // =========================================================
+  // STEP 3: PLAN — Get the build plan from the compiled model
+  // =========================================================
+  // The build plan contains:
+  //   - graphs: one per connection, each with leveled BuildNode arrays
+  //   - sources: keyed by sourceID, each a PersistSource with getSQL()
+  //   - tagParseLog: errors from parsing #@ annotations
   const plan = model.getBuildPlan();
 
   for (const msg of plan.tagParseLog) {
@@ -89,103 +199,131 @@ export async function build(opts: BuildOptions): Promise<void> {
     `Found ${Object.keys(plan.sources).length} persist sources in ${plan.graphs.length} graph(s)`
   );
 
+  // Cache connection digests. The connection digest includes
+  // connection-specific settings (database path, search path, etc.).
+  // Two users with different connection configs get different BuildIDs
+  // for the same Malloy source.
   const connectionDigest = await connection.getDigest();
   const connectionDigests: Record<string, string> = {
     duckdb: connectionDigest,
   };
 
-  // --- Load existing manifest ---
-  const manifest = new Manifest();
-  try {
-    manifest.loadText(await readFile(manifestFile, 'utf-8'));
-  } catch {
-    // No existing manifest — start fresh
-  }
   const sqlStatements: string[] = [];
   const logEntries: BuildLogEntry[] = [];
   const now = new Date();
   const buildStartedAt = now.toISOString();
 
-  // --- Process build graphs ---
-  // Each graph contains sources for one connection, organized into levels.
-  // Levels represent parallelism boundaries: all nodes within a level are
-  // independent and could be built concurrently. This sample builder
-  // serializes everything into a SQL script, but a live builder could
-  // execute all nodes within a level in parallel, waiting for each level
-  // to complete before starting the next.
+  // =========================================================
+  // STEP 4: BUILD — Walk graphs in dependency order
+  // =========================================================
+  // Each graph contains sources for one connection. Within a graph,
+  // sources are organized into levels:
+  //
+  //   graph.nodes = [
+  //     [nodeA, nodeB],   // level 0 — no dependencies, parallel-safe
+  //     [nodeC],          // level 1 — depends on level 0, parallel-safe within level
+  //     [nodeD, nodeE],   // level 2 — depends on levels 0+1
+  //   ]
+  //
+  // All nodes within a level are independent and can be built concurrently.
+  // Levels must be processed sequentially — level N depends on level N-1.
+  // A production builder would parallelize within each level.
   for (const graph of plan.graphs) {
     console.log(`\nProcessing graph for connection: ${graph.connectionName}`);
 
-    // Flatten into topological order for serial SQL output
-    const allNodes = graph.nodes.flatMap(level =>
-      level.flatMap(node => flattenBuildNodes([node]))
-    );
+    for (const level of graph.nodes) {
+      // Within this level, all nodes are independent. A production builder
+      // could build them in parallel (Promise.all). This sample serializes
+      // for simplicity.
+      //
+      // Note: diamond dependencies could cause a sourceID to appear more
+      // than once. No dedup needed — the second visit finds the entry
+      // already in the manifest and just touch()es it.
+      for (const node of level) {
+        const persistSource = plan.sources[node.sourceID];
+        if (!persistSource) {
+          console.error(`  Warning: Source not found for ${node.sourceID}`);
+          continue;
+        }
 
-    // Dedup (keep first occurrence = the dependency)
-    const seenIds = new Set<string>();
-    const uniqueNodes = allNodes.filter(node => {
-      if (seenIds.has(node.sourceID)) return false;
-      seenIds.add(node.sourceID);
-      return true;
-    });
+        // Read the #@ persist annotation for builder-specific properties.
+        // The CLI requires name=...; this sample falls back to a hash prefix.
+        const parsed = persistSource.tagParse({prefix: /^#@ /});
+        const explicitName = parsed.tag.text('name');
 
-    console.log(`  ${uniqueNodes.length} sources to build`);
+        // --- Compute the BuildID ---
+        // IMPORTANT: BuildID uses the no-options SQL (fully inlined, no manifest
+        // substitution). This ensures the BuildID is stable regardless of build
+        // order — it depends only on the source's SQL and connection config,
+        // not on whether dependencies happen to be built yet.
+        const buildIdSQL = persistSource.getSQL();
+        const buildId = persistSource.makeBuildId(connectionDigest, buildIdSQL);
 
-    for (const node of uniqueNodes) {
-      const source = plan.sources[node.sourceID];
-      if (!source) {
-        console.error(`  Warning: Source not found for ${node.sourceID}`);
-        continue;
+        // Already built — just mark it active so it survives GC
+        const existingEntry = manifest.buildManifest.entries[buildId];
+        if (existingEntry) {
+          manifest.touch(buildId);
+
+          console.log(`  Exists: ${persistSource.name} -> ${existingEntry.tableName}`);
+          logEntries.push({
+            action: 'exists',
+            buildId,
+            tableName: existingEntry.tableName,
+            nameProvided: !!explicitName,
+          });
+          continue;
+        }
+
+        // --- Not yet built: compute the build SQL ---
+        // This version substitutes already-built dependencies with their table
+        // names. Because manifest.buildManifest is a stable reference, any
+        // manifest.update() call from a prior iteration is already visible here.
+        const buildSQL = persistSource.getSQL({
+          buildManifest: manifest.buildManifest,
+          connectionDigests,
+        });
+
+        const nameProvided = !!explicitName;
+        const tableName = explicitName || `persist_${buildId.substring(0, 12)}`;
+        validateTableName(tableName);
+
+        // NOTE: This sample only generates SQL, it does not execute it.
+        // A live builder would run the SQL here:
+        //   await conn.runSQL(`CREATE TABLE ${tableName} AS ${buildSQL}`);
+        const buildStartTime = new Date().toISOString();
+        const createStatement = `-- ${persistSource.name} (${node.sourceID})\nCREATE TABLE ${tableName} AS\n${buildSQL};\n`;
+        sqlStatements.push(createStatement);
+        const buildEndTime = new Date().toISOString();
+
+        console.log(`  Built: ${persistSource.name} -> ${tableName}`);
+
+        // Update the manifest IMMEDIATELY after building. This is critical:
+        // subsequent sources in this build that depend on this one will call
+        // getSQL({buildManifest, ...}) and see this table name instead of
+        // the full inline SQL.
+        manifest.update(buildId, {tableName});
+
+        logEntries.push({
+          action: 'built',
+          buildId,
+          tableName,
+          nameProvided,
+          buildStartedAt: buildStartTime,
+          buildEndedAt: buildEndTime,
+        });
       }
-
-      const parsed = source.tagParse({prefix: /^#@ /});
-      const explicitName = parsed.tag.text('name');
-
-      // BuildID must use no-opts SQL (fully inlined) to match the runtime,
-      // which always compiles with empty options for BuildID computation.
-      // The manifest-substituted SQL is used for CREATE TABLE (more efficient).
-      const buildId = source.makeBuildId(connectionDigest, source.getSQL());
-      const sql = source.getSQL({
-        buildManifest: manifest.buildManifest,
-        connectionDigests,
-      });
-      const nameProvided = !!explicitName;
-      const tableName = explicitName || `persist_${buildId.substring(0, 12)}`;
-      validateTableName(tableName);
-
-      // Already built — just mark it active in the manifest
-      if (manifest.buildManifest.entries[buildId]) {
-        manifest.touch(buildId);
-        console.log(`  Exists: ${source.name} -> ${tableName}`);
-        logEntries.push({action: 'exists', buildId, tableName, nameProvided});
-        continue;
-      }
-
-      // Not yet built — emit CREATE TABLE
-      // NOTE: this sample builder only generates SQL, it does not execute it.
-      // A live builder would run the SQL here and time the actual execution.
-      const buildStartTime = new Date().toISOString();
-      const createStatement = `-- ${source.name} (${node.sourceID})\nCREATE TABLE ${tableName} AS\n${sql};\n`;
-      sqlStatements.push(createStatement);
-      const buildEndTime = new Date().toISOString();
-
-      console.log(`  Built: ${source.name} -> ${tableName}`);
-      manifest.update(buildId, {tableName});
-
-      logEntries.push({
-        action: 'built',
-        buildId,
-        tableName,
-        nameProvided,
-        buildStartedAt: buildStartTime,
-        buildEndedAt: buildEndTime,
-      });
     }
   }
 
   const buildEndedAt = new Date().toISOString();
 
-  // --- Write outputs ---
+  // =========================================================
+  // STEP 5: WRITE — Persist the manifest with only active entries
+  // =========================================================
+  // manifest.activeEntries contains only entries that were touched (already
+  // existed) or updated (newly built) during this run. Entries from prior
+  // builds that were not referenced are excluded — this is garbage collection.
+  // A separate GC pass can then drop the corresponding tables.
   await writeFile(sqlFile, sqlStatements.join('\n'));
   console.log(`\nWrote SQL: ${sqlFile}`);
 


### PR DESCRIPTION
## Summary

- Restructure `scripts/simple_builder/build.ts` as a teaching document for the persistence builder contract
- Add top-level doc block explaining the 5-step workflow (load, compile, plan, build, write), the key insight that the manifest is part of the build loop, the BuildID vs build SQL distinction, and explicit divergences from the CLI builder
- Walk graph levels directly instead of flattening, to make the level/parallelism structure visible to readers
- Rename variables for clarity (`source` → `modelText`, `source` → `persistSource`, split SQL into `buildIdSQL`/`buildSQL`)
- Use manifest entry as authoritative source for table name in the "already built" path

## Test plan
- [x] `npx ts-node scripts/simple_builder/test.ts` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>