### PR TITLE
refactor(tiny-parser): clearer API with expect/match/read

### DIFF
--- a/packages/malloy-db-databricks/src/databricks_connection.ts
+++ b/packages/malloy-db-databricks/src/databricks_connection.ts
@@ -23,9 +23,9 @@ import {
   DatabricksDialect,
   sqlKey,
   makeDigest,
-  TinyParser,
   mkFieldDef,
 } from '@malloydata/malloy';
+import {TinyParser} from '@malloydata/malloy/internal';
 import {BaseConnection} from '@malloydata/malloy/connection';
 import {DBSQLClient, DBSQLLogger, LogLevel} from '@databricks/sql';
 
@@ -45,32 +45,28 @@ class DatabricksTypeParser extends TinyParser {
   }
 
   typeDef(): AtomicTypeDef {
-    const typToken = this.next();
+    const typToken = this.read();
     if (typToken.type === 'eof') {
       throw this.parseError('Unexpected EOF parsing type');
     }
     const typText = typToken.text.toLowerCase();
 
-    if (typText === 'struct' && this.peek().text === '<') {
-      this.next('<');
+    if (typText === 'struct' && this.match('<')) {
       const fields: FieldDef[] = [];
       for (;;) {
-        const name = this.next('id');
-        this.next(':');
+        const name = this.expect('id');
+        this.expect(':');
         const fieldType = this.typeDef();
         fields.push(mkFieldDef(fieldType, name.text));
-        const sep = this.next();
-        if (sep.text === '>') break;
-        if (sep.text === ',') continue;
-        throw this.parseError(`Expected '>' or ',', got '${sep.text}'`);
+        if (this.match('>')) break;
+        this.expect(',');
       }
       return {type: 'record', fields} as RecordTypeDef;
     }
 
-    if (typText === 'array' && this.peek().text === '<') {
-      this.next('<');
+    if (typText === 'array' && this.match('<')) {
       const elType = this.typeDef();
-      this.next('>');
+      this.expect('>');
       return elType.type === 'record'
         ? {
             type: 'array',
@@ -80,34 +76,30 @@ class DatabricksTypeParser extends TinyParser {
         : {type: 'array', elementTypeDef: elType};
     }
 
-    if (typText === 'map' && this.peek().text === '<') {
-      this.next('<');
+    if (typText === 'map' && this.match('<')) {
       this.typeDef(); // key type
-      this.next(',');
+      this.expect(',');
       this.typeDef(); // value type
-      this.next('>');
+      this.expect('>');
       return {type: 'sql native'};
     }
 
     // Atomic type — parse parameters for DECIMAL, skip for others
     if (typToken.type === 'id') {
-      if (typText === 'decimal' && this.peek().text === '(') {
-        this.next('(');
-        this.next('id'); // precision
+      if (typText === 'decimal' && this.match('(')) {
+        this.expect('id'); // precision
         let numberType: 'integer' | 'float' = 'integer';
-        if (this.peek().text === ',') {
-          this.next(',');
-          const scale = this.next('id');
+        if (this.match(',')) {
+          const scale = this.expect('id');
           if (scale.text !== '0') numberType = 'float';
         }
-        this.next(')');
+        this.expect(')');
         return {type: 'number', numberType};
       }
-      if (this.peek().text === '(') {
-        this.next('(');
+      if (this.match('(')) {
         let depth = 1;
         while (depth > 0) {
-          const t = this.next();
+          const t = this.read();
           if (t.text === '(') depth++;
           else if (t.text === ')') depth--;
         }

--- a/packages/malloy-db-snowflake/src/snowflake_connection.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_connection.ts
@@ -42,11 +42,11 @@ import type {
 } from '@malloydata/malloy';
 import {
   SnowflakeDialect,
-  TinyParser,
   mkArrayDef,
   sqlKey,
   makeDigest,
 } from '@malloydata/malloy';
+import {TinyParser} from '@malloydata/malloy/internal';
 import {BaseConnection} from '@malloydata/malloy/connection';
 
 import {SnowflakeExecutor} from './snowflake_executor';
@@ -548,13 +548,13 @@ export class PathParser extends TinyParser {
   }
 
   getName() {
-    const nameStart = this.next();
+    const nameStart = this.read();
     if (nameStart.type === 'word') {
       return nameStart.text;
     }
     if (nameStart.type === '[') {
-      const quotedName = this.next('quoted');
-      this.next(']');
+      const quotedName = this.expect('quoted');
+      this.expect(']');
       return quotedName.text;
     }
     throw this.parseError('Expected column name');
@@ -564,22 +564,22 @@ export class PathParser extends TinyParser {
     const chain: PathChain = {name: this.getName()};
     let node: PathChain = chain;
     for (;;) {
-      const sep = this.next();
+      const sep = this.read();
       if (sep.type === 'eof') {
         return chain;
       }
       if (sep.type === '.') {
-        node.next = {name: this.next('word').text};
+        node.next = {name: this.expect('word').text};
         node = node.next;
       } else if (sep.type === 'array_of') {
         node.next = {arrayRef: true};
         node = node.next;
       } else if (sep.type === '[') {
         // Actually a dot access through a quoted name
-        const quoted = this.next('quoted');
+        const quoted = this.expect('quoted');
         node.next = {name: quoted.text};
         node = node.next;
-        this.next(']');
+        this.expect(']');
       } else {
         throw this.parseError(`Unexpected ${sep.type}`);
       }

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -39,12 +39,7 @@ import type {
   TestableConnection,
   SQLSourceRequest,
 } from '@malloydata/malloy';
-import {
-  TrinoDialect,
-  mkFieldDef,
-  sqlKey,
-  makeDigest,
-} from '@malloydata/malloy';
+import {TrinoDialect, mkFieldDef, sqlKey, makeDigest} from '@malloydata/malloy';
 import {TinyParser} from '@malloydata/malloy/internal';
 
 import {BaseConnection} from '@malloydata/malloy/connection';

--- a/packages/malloy-db-trino/src/trino_connection.ts
+++ b/packages/malloy-db-trino/src/trino_connection.ts
@@ -42,10 +42,10 @@ import type {
 import {
   TrinoDialect,
   mkFieldDef,
-  TinyParser,
   sqlKey,
   makeDigest,
 } from '@malloydata/malloy';
+import {TinyParser} from '@malloydata/malloy/internal';
 
 import {BaseConnection} from '@malloydata/malloy/connection';
 import type {PrestoClientConfig, PrestoQuery} from '@prestodb/presto-js-client';
@@ -603,21 +603,15 @@ class TrinoPrestoSchemaParser extends TinyParser {
 
   fieldNameList(): string[] {
     this.skipTo(']'); // Skip to end of plan
-    this.next('['); // Expect start of name list
+    this.expect('['); // Expect start of name list
     const fieldNames: string[] = [];
     for (;;) {
-      const nmToken = this.next('id');
+      const nmToken = this.expect('id');
       fieldNames.push(nmToken.text);
-      const sep = this.next();
-      if (sep.type === ',') {
-        continue;
+      if (!this.match(',')) {
+        this.expect(']');
+        break;
       }
-      if (sep.type !== ']') {
-        throw this.parseError(
-          `Unexpected '${sep.text}' while getting field name list`
-        );
-      }
-      break;
     }
     return fieldNames;
   }
@@ -625,20 +619,16 @@ class TrinoPrestoSchemaParser extends TinyParser {
   parseQueryPlan(): FieldDef[] {
     const fieldNames = this.fieldNameList();
     const fields: FieldDef[] = [];
-    this.next('arrow', '[');
+    this.expect('arrow', '[');
     for (let nameIndex = 0; ; nameIndex += 1) {
       const name = fieldNames[nameIndex];
-      this.next('id', ':');
+      this.expect('id', ':');
       const nextType = this.typeDef();
       fields.push(mkFieldDef(nextType, name));
-      const sep = this.next();
-      if (sep.text === ',') {
-        continue;
+      if (!this.match(',')) {
+        this.expect(']');
+        break;
       }
-      if (sep.text !== ']') {
-        throw this.parseError(`Unexpected '${sep.text}' between field types`);
-      }
-      break;
     }
     if (fields.length !== fieldNames.length) {
       throw new Error(
@@ -649,26 +639,24 @@ class TrinoPrestoSchemaParser extends TinyParser {
   }
 
   typeDef(): AtomicTypeDef {
-    const typToken = this.next();
+    const typToken = this.read();
     if (typToken.type === 'eof') {
       throw this.parseError(
         'Unexpected EOF parsing type, expected a type name'
       );
-    } else if (typToken.text === 'row' && this.next('(')) {
+    } else if (typToken.text === 'row') {
+      this.expect('(');
       const fields: FieldDef[] = [];
       for (;;) {
-        const name = this.next();
-        if (name.type !== 'id' && name.type !== 'quoted_name') {
-          throw this.parseError(`Expected property name, got '${name.type}'`);
+        const name = this.match('id') ?? this.match('quoted_name');
+        if (!name) {
+          throw this.parseError('Expected property name');
         }
         const getDef = this.typeDef();
         fields.push(mkFieldDef(getDef, name.text));
-        const sep = this.next();
-        if (sep.text === ')') {
+        if (!this.match(',')) {
+          this.expect(')');
           break;
-        }
-        if (sep.text === ',') {
-          continue;
         }
       }
       const def: RecordTypeDef = {
@@ -676,9 +664,10 @@ class TrinoPrestoSchemaParser extends TinyParser {
         fields,
       };
       return def;
-    } else if (typToken.text === 'array' && this.next('(')) {
+    } else if (typToken.text === 'array') {
+      this.expect('(');
       const elType = this.typeDef();
-      this.next(')');
+      this.expect(')');
       return elType.type === 'record'
         ? {
             type: 'array',
@@ -686,38 +675,33 @@ class TrinoPrestoSchemaParser extends TinyParser {
             fields: elType.fields,
           }
         : {type: 'array', elementTypeDef: elType};
-    } else if (typToken.text === 'map' && this.next('(')) {
+    } else if (typToken.text === 'map') {
+      this.expect('(');
       const _keyType = this.typeDef();
-      this.next(',');
+      this.expect(',');
       const _valType = this.typeDef();
-      this.next(')');
+      this.expect(')');
       return {type: 'sql native'};
     } else if (typToken.type === 'id') {
       const sqlType = typToken.text.toLowerCase();
       if (sqlType === 'varchar') {
-        if (this.peek().type === '(') {
-          this.next('(', 'id', ')');
-        }
+        if (this.match('(')) this.expect('id', ')');
       } else if (sqlType === 'timestamp') {
-        if (this.peek().text === '(') {
-          this.next('(', 'id', ')');
-        }
-        if (this.peek().text === 'with') {
-          this.nextText('with', 'time', 'zone');
+        if (this.match('(')) this.expect('id', ')');
+        if (this.matchText('with', 'time', 'zone')) {
           return {type: 'timestamptz'};
         }
         return {type: 'timestamp'};
       }
       const typeDef = this.dialect.sqlTypeToMalloyType(sqlType);
       if (typeDef.type === 'number' && sqlType === 'decimal') {
-        this.next('(', 'id');
-        if (this.peek().type === ',') {
-          this.next(',', 'id');
+        this.expect('(', 'id');
+        if (this.match(',', 'id')) {
           typeDef.numberType = 'float';
         } else {
           typeDef.numberType = 'integer';
         }
-        this.next(')');
+        this.expect(')');
       }
       if (typeDef === undefined) {
         throw this.parseError(`Can't parse presto type ${sqlType}`);

--- a/packages/malloy/package.json
+++ b/packages/malloy/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js",
+    "./internal": "./dist/internal.js",
     "./test": "./dist/test/index.js",
     "./test/matchers": "./dist/test/matchers.js",
     "./connection": "./dist/connection/index.js",
@@ -13,6 +14,9 @@
     "*": {
       "index": [
         "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
       ],
       "test": [
         "./dist/test/index.d.ts"

--- a/packages/malloy/src/dialect/duckdb/duckdb.ts
+++ b/packages/malloy/src/dialect/duckdb/duckdb.ts
@@ -537,23 +537,16 @@ class DuckDBTypeParser extends TinyParser {
   }
 
   typeDef(): AtomicTypeDef {
-    const wantID = this.next('id');
+    const wantID = this.expect('id');
     const id = this.sqlID(wantID);
     let baseType: AtomicTypeDef;
     if (id === 'VARCHAR') {
-      if (this.peek().type === 'size') {
-        this.next();
-      }
+      this.match('size');
     }
-    if (
-      (id === 'DECIMAL' || id === 'NUMERIC') &&
-      this.peek().type === 'precision'
-    ) {
-      this.next();
+    if ((id === 'DECIMAL' || id === 'NUMERIC') && this.match('precision')) {
       baseType = {type: 'number', numberType: 'float'};
     } else if (id === 'TIMESTAMP') {
-      if (this.peek().text.toUpperCase() === 'WITH') {
-        this.nextText('WITH', 'TIME', 'ZONE');
+      if (this.matchText('WITH', 'TIME', 'ZONE')) {
         baseType = {type: 'timestamptz'};
       } else {
         baseType = {type: 'timestamp'};
@@ -561,27 +554,24 @@ class DuckDBTypeParser extends TinyParser {
     } else if (duckDBToMalloyTypes[id]) {
       baseType = duckDBToMalloyTypes[id];
     } else if (id === 'STRUCT') {
-      this.next('(');
+      this.expect('(');
       baseType = {type: 'record', fields: []};
       for (;;) {
-        const fieldName = this.next();
-        if (
-          fieldName.type === 'qsingle' ||
-          fieldName.type === 'qdouble' ||
-          fieldName.type === 'id'
-        ) {
-          const fieldType = this.typeDef();
-          baseType.fields.push(
-            mkFieldDef(fieldType, this.unquoteName(fieldName))
-          );
-        } else {
-          if (fieldName.type !== ')') {
+        const fieldName =
+          this.match('qsingle') ?? this.match('qdouble') ?? this.match('id');
+        if (!fieldName) {
+          if (!this.match(')')) {
             throw this.parseError('Expected identifier or ) to end STRUCT');
           }
           break;
         }
-        if (this.peek().type === ',') {
-          this.next();
+        const fieldType = this.typeDef();
+        baseType.fields.push(
+          mkFieldDef(fieldType, this.unquoteName(fieldName))
+        );
+        if (!this.match(',')) {
+          this.expect(')');
+          break;
         }
       }
     } else {
@@ -589,9 +579,7 @@ class DuckDBTypeParser extends TinyParser {
         // unknown field type, strip all type decorations, there was a regex for this
         // in the pre-parser code, but no tests, so this is also untested
         let idEnd = wantID.cursor + wantID.text.length;
-        if (this.peek().type === 'precision') {
-          this.next();
-        }
+        this.match('precision');
         if (this.peek().type === 'eof') {
           idEnd = this.input.length;
         }
@@ -603,8 +591,7 @@ class DuckDBTypeParser extends TinyParser {
         throw this.parseError('Could not understand type');
       }
     }
-    while (this.peek().type === 'arrayOf') {
-      this.next();
+    while (this.match('arrayOf')) {
       if (baseType.type === 'record') {
         baseType = {
           type: 'array',

--- a/packages/malloy/src/dialect/tiny_parser.spec.ts
+++ b/packages/malloy/src/dialect/tiny_parser.spec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {TinyParser} from './tiny_parser';
+
+describe('TinyParser', () => {
+  test('read consumes the next token without requiring a type', () => {
+    const parser = new TinyParser('abc)', {
+      id: /^\w+/,
+      char: /^[()]/,
+    });
+
+    expect(parser.read().text).toBe('abc');
+    expect(parser.read().type).toBe(')');
+  });
+
+  test('match is atomic for token types', () => {
+    const parser = new TinyParser('abc)', {
+      id: /^\w+/,
+      char: /^[()]/,
+    });
+
+    expect(parser.match('id', '(')).toBeUndefined();
+    expect(parser.expect('id').text).toBe('abc');
+    expect(parser.expect(')').type).toBe(')');
+  });
+
+  test('match remains atomic when a longer sequence fails at the last token', () => {
+    const parser = new TinyParser('a b c', {
+      space: /^\s+/,
+      id: /^\w+/,
+    });
+
+    expect(parser.match('id', 'id', '(')).toBeUndefined();
+    expect(parser.expect('id').text).toBe('a');
+    expect(parser.expect('id').text).toBe('b');
+    expect(parser.expect('id').text).toBe('c');
+  });
+
+  test('matchText is atomic and case-insensitive', () => {
+    const parser = new TinyParser('with x', {
+      space: /^\s+/,
+      id: /^\w+/,
+    });
+
+    expect(parser.matchText('WITH', 'TIME')).toBeUndefined();
+    expect(parser.expect('id').text).toBe('with');
+    expect(parser.expect('id').text).toBe('x');
+  });
+
+  test('expect and expectText consume required sequences', () => {
+    const parser = new TinyParser('with time zone', {
+      space: /^\s+/,
+      id: /^\w+/,
+    });
+
+    expect(parser.expect('id').text).toBe('with');
+    expect(parser.expectText('time', 'zone').text).toBe('zone');
+  });
+
+  test('expect reports errors at the current token cursor', () => {
+    const parser = new TinyParser('abc )', {
+      space: /^\s+/,
+      id: /^\w+/,
+      char: /^[()]/,
+    });
+
+    parser.expect('id');
+    expect(() => parser.expect('(')).toThrow(`abc )\n    ^`);
+  });
+
+  test('skipTo consumes until the requested token', () => {
+    const parser = new TinyParser('a b )', {
+      space: /^\s+/,
+      id: /^\w+/,
+      char: /^[)]/,
+    });
+
+    parser.skipTo(')');
+    expect(parser.peek().type).toBe('eof');
+  });
+
+  test('expect and match helpers reject zero-argument misuse', () => {
+    const parser = new TinyParser('abc', {id: /^\w+/});
+
+    expect(() => parser.expect()).toThrow('TinyParser.expect()');
+    expect(() => parser.expectText()).toThrow('TinyParser.expectText()');
+    expect(() => parser.match()).toThrow('TinyParser.match()');
+    expect(() => parser.matchText()).toThrow('TinyParser.matchText()');
+  });
+
+  test('dump applies special token conventions', () => {
+    const parser = new TinyParser(` "abc",x`, {
+      space: /^\s+/,
+      qstr: /^"[^"]*"/,
+      char: /^[,]/,
+      id: /^\w+/,
+    });
+
+    expect(parser.dump()).toEqual([
+      {cursor: 1, type: 'qstr', text: 'abc'},
+      {cursor: 6, type: ',', text: ','},
+      {cursor: 7, type: 'id', text: 'x'},
+    ]);
+  });
+});

--- a/packages/malloy/src/dialect/tiny_parser.spec.ts
+++ b/packages/malloy/src/dialect/tiny_parser.spec.ts
@@ -68,7 +68,7 @@ describe('TinyParser', () => {
     });
 
     parser.expect('id');
-    expect(() => parser.expect('(')).toThrow(`abc )\n    ^`);
+    expect(() => parser.expect('(')).toThrow('abc )\n    ^');
   });
 
   test('skipTo consumes until the requested token', () => {
@@ -92,7 +92,7 @@ describe('TinyParser', () => {
   });
 
   test('dump applies special token conventions', () => {
-    const parser = new TinyParser(` "abc",x`, {
+    const parser = new TinyParser(' "abc",x', {
       space: /^\s+/,
       qstr: /^"[^"]*"/,
       char: /^[,]/,

--- a/packages/malloy/src/dialect/tiny_parser.ts
+++ b/packages/malloy/src/dialect/tiny_parser.ts
@@ -12,28 +12,54 @@ export interface TinyToken {
 }
 
 /**
- * Simple framework for writing schema parsers. The parsers using this felt
- * better than the more ad-hoc code they replaced, and are smaller than
- * using a parser generator.
+ * Tiny combined lexer/parser for short recursive-descent parsers.
+ *
+ * TinyParser is intentionally small and biased toward readability over
+ * framework features. It is primarily used for schema and type parsers where
+ * a hand-written parser is clearer than ad-hoc regex matching, but a parser
+ * generator would be overkill.
+ *
+ * Design goals:
+ * - Keep parser implementations short and readable.
+ * - Support custom tokenization rules per parser.
+ * - Make parser intent obvious at call sites.
+ * - Minimize hidden consumption and parser-state surprises.
+ *
+ * Core parser API:
+ * - peek(): inspect the next token without consuming it.
+ * - read(): consume and return the next token, regardless of type.
+ * - expect(...types): consume a required sequence of token types.
+ * - expectText(...texts): consume a required sequence of token texts.
+ * - match(...types): consume an optional sequence of token types.
+ * - matchText(...texts): consume an optional sequence of token texts.
+ *
+ * Semantics:
+ * - expect*() is for required grammar and throws on failure.
+ * - match*() is for optional grammar and is atomic. If the full sequence does
+ *   not match, nothing is consumed.
+ * - peek() remains available, but most optional syntax should prefer match*().
+ *
+ * Token rules are tested in order. The first matching rule wins.
+ *
+ * Special token rule names:
+ * - space: matched text is skipped and never returned.
+ * - char: matched text becomes both token.type and token.text.
+ * - q*: any token name starting with q is treated as quoted text and has its
+ *   first and last characters stripped from token.text.
  *
  * NOTE: All parse errors are exceptions.
  */
 export class TinyParseError extends Error {}
 export class TinyParser {
-  private tokens: Generator<TinyToken>;
+  private readonly tokens: TinyToken[] = [];
+  private tokenCursor = 0;
+  private scanCursor = 0;
+  private scanState: 'scanning' | 'afterUnexpected' | 'done' = 'scanning';
   protected parseCursor = 0;
-  private lookAhead?: TinyToken;
-  private tokenMap: Record<string, RegExp>;
+  private readonly tokenMap: Record<string, RegExp>;
 
   /**
-   * The token map is tested in order. Return TinyToken
-   * is {type: tokenMapKey, text: matchingText }, except
-   * for the special tokenMapKeys:
-   * * space: skipped and never returned
-   * * char: matched string return in both .type and .text
-   * * q*: any token name starting with 'q' is assumed to be
-   *   a quoted string and the text will have the first and
-   *   last characters stripped
+   * The token map is tested in order and the first matching rule wins.
    */
   constructor(
     readonly input: string,
@@ -45,10 +71,10 @@ export class TinyParser {
       id: /^\w+/,
       qstr: /^"\w+"/,
     };
-    this.tokens = this.tokenize(input);
   }
 
   parseError(str: string) {
+    this.parseCursor = this.peek().cursor;
     const errText =
       `INTERNAL ERROR parsing schema: ${str}\n` +
       `${this.input}\n` +
@@ -57,20 +83,18 @@ export class TinyParser {
   }
 
   peek(): TinyToken {
-    if (this.lookAhead) {
-      return this.lookAhead;
-    } else {
-      const {value} = this.tokens.next();
-      const peekVal = value ?? {type: 'eof', text: ''};
-      this.lookAhead = peekVal;
-      return peekVal;
-    }
+    return this.peekAt(0);
   }
 
-  private getNext(): TinyToken {
-    const next = this.lookAhead ?? this.peek();
-    this.lookAhead = undefined;
-    return next;
+  read(): TinyToken {
+    return this.consume();
+  }
+
+  private peekAt(offset: number): TinyToken {
+    this.fillBufferTo(this.tokenCursor + offset);
+    const token = this.tokens[this.tokenCursor + offset] ?? this.eofToken();
+    this.parseCursor = token.cursor;
+    return token;
   }
 
   /**
@@ -79,41 +103,67 @@ export class TinyParser {
    * @param types list of token types
    * @returns The last token read
    */
-  next(...types: string[]): TinyToken {
-    if (types.length === 0) return this.getNext();
-    let next: TinyToken | undefined = undefined;
-    let expected = types[0];
-    for (const typ of types) {
-      next = this.getNext();
-      expected = typ;
-      if (next.type !== typ) {
-        next = undefined;
-        break;
-      }
+  expect(...types: string[]): TinyToken {
+    if (types.length === 0) {
+      throw new Error('TinyParser.expect() requires at least one token type');
     }
-    if (next) return next;
-    throw this.parseError(`Expected token type '${expected}'`);
+    let next: TinyToken | undefined;
+    for (const typ of types) {
+      next = this.peek();
+      if (next.type !== typ) {
+        throw this.parseError(`Expected token type '${typ}'`);
+      }
+      this.consume();
+    }
+    return next!;
   }
 
-  nextText(...texts: string[]): TinyToken {
-    if (texts.length === 0) return this.getNext();
-    let next: TinyToken | undefined = undefined;
-    let expected = texts[0];
+  expectText(...texts: string[]): TinyToken {
+    if (texts.length === 0) {
+      throw new Error(
+        'TinyParser.expectText() requires at least one token text'
+      );
+    }
+    let next: TinyToken | undefined;
     for (const txt of texts) {
-      next = this.getNext();
-      expected = txt;
+      next = this.peek();
       if (next.text.toUpperCase() !== txt.toUpperCase()) {
-        next = undefined;
-        break;
+        throw this.parseError(`Expected '${txt}'`);
+      }
+      this.consume();
+    }
+    return next!;
+  }
+
+  match(...types: string[]): TinyToken | undefined {
+    if (types.length === 0) {
+      throw new Error('TinyParser.match() requires at least one token type');
+    }
+    for (let index = 0; index < types.length; index += 1) {
+      if (this.peekAt(index).type !== types[index]) {
+        return undefined;
       }
     }
-    if (next) return next;
-    throw this.parseError(`Expected '${expected}'`);
+    return this.consume(types.length);
+  }
+
+  matchText(...texts: string[]): TinyToken | undefined {
+    if (texts.length === 0) {
+      throw new Error(
+        'TinyParser.matchText() requires at least one token text'
+      );
+    }
+    for (let index = 0; index < texts.length; index += 1) {
+      if (this.peekAt(index).text.toUpperCase() !== texts[index].toUpperCase()) {
+        return undefined;
+      }
+    }
+    return this.consume(texts.length);
   }
 
   skipTo(type: string) {
     for (;;) {
-      const next = this.next();
+      const next = this.read();
       if (next.type === 'eof') {
         throw this.parseError(`Expected token '${type}`);
       }
@@ -124,41 +174,119 @@ export class TinyParser {
   }
 
   dump(): TinyToken[] {
-    const p = this.parseCursor;
-    const parts = [...this.tokenize(this.input)];
-    this.parseCursor = p;
+    const parts: TinyToken[] = [];
+    let cursor = 0;
+    let state: 'scanning' | 'afterUnexpected' | 'done' = 'scanning';
+    while (state !== 'done') {
+      const {token, nextCursor, nextState} = this.scanToken(cursor, state);
+      if (token.type === 'eof') {
+        break;
+      }
+      parts.push(token);
+      cursor = nextCursor;
+      state = nextState;
+    }
     return parts;
   }
 
-  private *tokenize(src: string): Generator<TinyToken> {
-    const tokenList = this.tokenMap;
-    while (this.parseCursor < src.length) {
-      let notFound = true;
-      for (const tokenType in tokenList) {
-        const srcAtCursor = src.slice(this.parseCursor);
-        const foundToken = srcAtCursor.match(tokenList[tokenType]);
+  private fillBufferTo(index: number) {
+    while (this.tokens.length <= index) {
+      this.tokens.push(this.readNextToken());
+    }
+  }
+
+  private consume(count = 1): TinyToken {
+    let token = this.peek();
+    for (let index = 0; index < count; index += 1) {
+      token = this.peek();
+      this.tokenCursor += 1;
+    }
+    this.parseCursor = this.peek().cursor;
+    return token;
+  }
+
+  private readNextToken(): TinyToken {
+    const {token, nextCursor, nextState} = this.scanToken(
+      this.scanCursor,
+      this.scanState
+    );
+    this.scanCursor = nextCursor;
+    this.scanState = nextState;
+    return token;
+  }
+
+  private scanToken(
+    cursor: number,
+    state: 'scanning' | 'afterUnexpected' | 'done'
+  ): {
+    token: TinyToken;
+    nextCursor: number;
+    nextState: 'scanning' | 'afterUnexpected' | 'done';
+  } {
+    if (state === 'done') {
+      return {
+        token: this.eofToken(),
+        nextCursor: this.input.length,
+        nextState: 'done',
+      };
+    }
+    if (state === 'afterUnexpected' || cursor >= this.input.length) {
+      return {
+        token: this.eofToken(),
+        nextCursor: this.input.length,
+        nextState: 'done',
+      };
+    }
+
+    let nextCursor = cursor;
+    while (nextCursor < this.input.length) {
+      const srcAtCursor = this.input.slice(nextCursor);
+      let matched = false;
+      for (const tokenType in this.tokenMap) {
+        const foundToken = srcAtCursor.match(this.tokenMap[tokenType]);
         if (foundToken) {
-          notFound = false;
+          matched = true;
           let tokenText = foundToken[0];
-          const cursor = this.parseCursor;
-          this.parseCursor += tokenText.length;
-          if (tokenType !== 'space') {
-            if (tokenType[0] === 'q') {
-              tokenText = tokenText.slice(1, -1); // strip quotes
-            }
-            yield {
-              cursor,
-              type: tokenType === 'char' ? tokenText : tokenType,
-              text: tokenText,
-            };
+          const tokenCursor = nextCursor;
+          nextCursor += tokenText.length;
+          if (tokenType === 'space') {
             break;
           }
+          if (tokenType[0] === 'q') {
+            tokenText = tokenText.slice(1, -1);
+          }
+          return {
+            token: {
+              cursor: tokenCursor,
+              type: tokenType === 'char' ? tokenText : tokenType,
+              text: tokenText,
+            },
+            nextCursor,
+            nextState: 'scanning',
+          };
         }
       }
-      if (notFound) {
-        yield {cursor: this.parseCursor, type: 'unexpected token', text: src};
-        return;
+      if (!matched) {
+        return {
+          token: {
+            cursor: nextCursor,
+            type: 'unexpected token',
+            text: this.input,
+          },
+          nextCursor: this.input.length,
+          nextState: 'afterUnexpected',
+        };
       }
     }
+
+    return {
+      token: this.eofToken(),
+      nextCursor: this.input.length,
+      nextState: 'done',
+    };
+  }
+
+  private eofToken(): TinyToken {
+    return {cursor: this.input.length, type: 'eof', text: ''};
   }
 }

--- a/packages/malloy/src/dialect/tiny_parser.ts
+++ b/packages/malloy/src/dialect/tiny_parser.ts
@@ -154,7 +154,9 @@ export class TinyParser {
       );
     }
     for (let index = 0; index < texts.length; index += 1) {
-      if (this.peekAt(index).text.toUpperCase() !== texts[index].toUpperCase()) {
+      if (
+        this.peekAt(index).text.toUpperCase() !== texts[index].toUpperCase()
+      ) {
         return undefined;
       }
     }

--- a/packages/malloy/src/doc/adding-a-new-database.md
+++ b/packages/malloy/src/doc/adding-a-new-database.md
@@ -70,7 +70,7 @@ Create `packages/malloy-db-{name}/`. See [connection CONTEXT.md](../connection/C
 
 ### Implementation notes
 
-**Schema fetching**: Most databases support `DESCRIBE` or dry-run queries. Map raw type strings to Malloy types via `dialect.sqlTypeToMalloyType()`. For complex types you'll likely need a type-string parser — see `TinyParser` in the dialect package.
+**Schema fetching**: Most databases support `DESCRIBE` or dry-run queries. Map raw type strings to Malloy types via `dialect.sqlTypeToMalloyType()`. For complex types you'll likely need a type-string parser — see [`TinyParser`](../dialect/tiny_parser.ts) in `@malloydata/malloy/internal`. The class comment is the reference for token rules and parser helpers.
 
 **Async initialization**: You can't `await` in a constructor. Use the standard pattern: store an `init()` promise in the constructor, `await` it at the top of every public method.
 

--- a/packages/malloy/src/index.ts
+++ b/packages/malloy/src/index.ts
@@ -43,7 +43,6 @@ export {
   literal,
   spread,
   Dialect,
-  TinyParser,
 } from './dialect';
 export type {
   DialectFieldList,
@@ -53,7 +52,6 @@ export type {
   DefinitionBlueprint,
   DefinitionBlueprintMap,
   OverloadedDefinitionBlueprint,
-  TinyToken,
 } from './dialect';
 // TODO tighten up exports
 export type {

--- a/packages/malloy/src/internal.ts
+++ b/packages/malloy/src/internal.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+// Unstable implementation-facing exports for Malloy packages, tests, and
+// advanced integrations. Do not treat this surface as public API.
+export {
+  mkArrayDef,
+  mkArrayTypeDef,
+  mkFieldDef,
+  mkModelDef,
+  mkQuerySourceDef,
+  mkSQLSourceDef,
+  mkTableSourceDef,
+  pathToKey,
+} from './model';
+export {TinyParseError, TinyParser} from './dialect/tiny_parser';
+export type {TinyToken} from './dialect/tiny_parser';

--- a/packages/malloy/src/model/index.ts
+++ b/packages/malloy/src/model/index.ts
@@ -55,7 +55,13 @@ export {
   getResultStructDefForQuery,
   getResultStructDefForView,
 } from './query_model_impl';
-export {indent, composeSQLExpr, makeDigest, mkModelDef} from './utils';
+export {
+  indent,
+  composeSQLExpr,
+  makeDigest,
+  mkModelDef,
+  pathToKey,
+} from './utils';
 export {constantExprToSQL} from './constant_expression_compiler';
 export {getCompiledSQL} from './sql_compiled';
 export {


### PR DESCRIPTION
## Summary

Clean up the nano parser used for schema parsing. Make it a little easier for future dialects to use it.

## Test plan

- [x] `npx jest packages/malloy/src/dialect/tiny_parser.spec.ts`
- [x] CI: full malloy-core suite
- [x] CI: connection packages (duckdb, trino, databricks, snowflake) since their schema parsers were ported