### PR TITLE
feat(duckdb): filesystem and network policies for restricted execution

### DIFF
--- a/packages/malloy-db-duckdb/MAINTENANCE_NOTES.md
+++ b/packages/malloy-db-duckdb/MAINTENANCE_NOTES.md
@@ -1,0 +1,487 @@
+# DuckDB Config Maintenance Notes
+
+This file is the self-contained maintainer handoff for Malloy's native DuckDB
+configuration and restricted-execution policy code. A future maintainer should
+be able to understand the policy entities, their purpose, and the safe way to
+extend them from this file plus the implementation.
+
+Historical design notes may exist elsewhere in the repository, but this file
+must not depend on them for essential context.
+
+## Mental Model
+
+Malloy exposes two user-facing policy axes for native DuckDB:
+
+- `filesystemPolicy: "open" | "sandboxed"`
+- `networkPolicy: "open" | "closed"`
+
+Those fields are Malloy policy controls. They are not raw DuckDB option names
+and they are not a general policy language.
+
+The reviewed strict recipe for untrusted Malloy is:
+
+- `filesystemPolicy: "sandboxed"`
+- `networkPolicy: "closed"`
+
+The implementation compiles those public policy values into an internal
+`NormalizedDuckDBSafetyPolicy`. That internal object records the derived
+enforcement requirements, such as locked configuration, no setup SQL,
+temp-file encryption, extension restrictions, and secret neutralization. Keep
+the public surface small and make new enforcement consequences explicit in the
+derived policy object.
+
+Restricted execution is about DuckDB filesystem reach, network reach, mutable
+configuration, extension loading, instance sharing, and ambient persistent
+secrets. It is not a complete sandbox. It does not provide CPU, memory,
+temp-space, query-timeout, or denial-of-service isolation. Hosts that need
+resource isolation must configure controls such as `threads`, `memoryLimit`,
+process isolation, query cancellation, and host-level quotas separately.
+
+## Code Map
+
+- Native connection schema: `src/native.ts`
+  - Registers native DuckDB properties.
+  - `filesystemPolicy` and `networkPolicy` are `requireLiteralString` so
+    invalid reference-shaped or non-string values reach registry validation
+    instead of being silently dropped by generic config compilation.
+- Config compiler literal guard: `../malloy/src/api/foundation/config_compile.ts`
+  - Preserves invalid literal-required values as values after warning, allowing
+    registry lookup to fail closed before the DuckDB factory runs.
+- Normalization and policy derivation: `src/duckdb_config.ts`
+  - Parses raw effective config.
+  - Derives `NormalizedDuckDBSafetyPolicy`.
+  - Applies conflict checks, policy-derived defaults, canonicalization, secret
+    directory derivation, and share-key construction.
+- Path security helpers: `src/path_security.ts`
+  - Canonicalizes paths and performs containment checks.
+  - Path handling is part of the security boundary.
+- Native lifecycle and baseline setup: `src/duckdb_connection.ts`
+  - Normalizes before opening DuckDB.
+  - Builds the share key.
+  - Opens or reuses a native instance.
+  - Applies the final baseline, then optional unrestricted `setupSQL`, then
+    `lock_configuration=true` when policy requires it.
+- Policy tests:
+  - `src/duckdb_config.spec.ts`
+  - `src/duckdb_restricted.spec.ts`
+
+## Core Invariants
+
+- Restricted execution must fail closed. Unknown policy values, conflicting
+  explicit settings, missing required values, or inability to apply the
+  baseline must fail connection creation.
+- Policy validation must run early enough that invalid raw values such as
+  `true`, `42`, or `{env: "POLICY"}` cannot be silently dropped and interpreted
+  as the default `"open"` policy.
+- A restricted DuckDB connection must never share a live instance with a less
+  restrictive or otherwise semantically different connection.
+- The fixed baseline must be established before any Malloy-derived SQL runs.
+- Configuration must be locked whenever the derived safety policy requires it.
+- Ordinary DuckDB connections must remain ordinary. Do not implicitly turn them
+  into locked connections. Mixed Malloy/SQL workflows that rely on later DuckDB
+  `SET` statements remain unrestricted workflows.
+- `duckdb_wasm` does not receive these native policy guarantees. WASM hardening
+  is host-owned unless a separate WASM-specific policy design is implemented.
+
+## User-Facing Policy Behavior
+
+`filesystemPolicy: "open"` means Malloy does not derive a filesystem sandbox.
+
+`filesystemPolicy: "sandboxed"` means Malloy derives and enforces a native
+DuckDB filesystem boundary:
+
+- `allowedDirectories` is required or derived.
+- `tempDirectory` is required or derived.
+- `workingDirectory`, when present, must be inside `allowedDirectories`.
+- `tempDirectory` must be inside `allowedDirectories`.
+- Non-POSIX hosts are rejected. Do not approximate Windows path behavior for
+  the current policy.
+
+`networkPolicy: "open"` means network-capable DuckDB behavior may remain
+available.
+
+`networkPolicy: "closed"` means Malloy disables network-capable DuckDB behavior:
+
+- `enableExternalAccess` is forced to `false`.
+- `httpfs` must not load.
+- DuckDB must not `INSTALL` extensions.
+- network-requiring `databasePath` values, including MotherDuck paths, are
+  rejected.
+- `motherDuckToken` is rejected.
+
+The two axes can be used independently:
+
+- sandboxed filesystem plus open network is allowed, but it is not the reviewed
+  strict recipe.
+- open filesystem plus closed network is allowed, for hosts that trust an
+  external filesystem/container boundary but want Malloy to close DuckDB's
+  network-capable surface.
+
+## Registered Config Surface
+
+Native DuckDB supports the existing Malloy-facing properties:
+
+- `databasePath`
+- `workingDirectory`
+- `motherDuckToken`
+- `additionalExtensions`
+- `readOnly`
+- `setupSQL`
+
+The config extension adds policy properties:
+
+- `filesystemPolicy`
+- `networkPolicy`
+
+It also adds curated DuckDB-level properties:
+
+- `allowedDirectories`
+- `enableExternalAccess`
+- `lockConfiguration`
+- `autoloadKnownExtensions`
+- `autoinstallKnownExtensions`
+- `allowCommunityExtensions`
+- `allowUnsignedExtensions`
+- `tempFileEncryption`
+- `threads`
+- `memoryLimit`
+- `tempDirectory`
+- `extensionDirectory`
+
+`allowedDirectories` is intentionally registered as `json` for now because the
+connection property model does not yet have a first-class string-array type.
+Even though the registry metadata says `json`, DuckDB normalization must require
+the value to be a JSON array of strings. Do not add a registry default for
+`allowedDirectories`; its only defaulting behavior belongs to
+`filesystemPolicy: "sandboxed"` normalization.
+
+`workingDirectory` defaults to `{config: "rootDirectory"}` in the native DuckDB
+registry. Hosts that know the project root should populate `config.rootDirectory`
+so relative DuckDB file paths resolve against the project root rather than the
+location of an individual Malloy file or config file. If a sandboxed connection
+expected this overlay and it is missing, normalization should fail with an error
+that points at `workingDirectory`/`allowedDirectories` and mentions the
+`config.rootDirectory` overlay.
+
+`memoryLimit` remains a string because DuckDB accepts values such as `1GB`.
+
+## Normalization Rules
+
+All policy reasoning belongs in `normalizeDuckDBConfig()`.
+
+Policy parsing:
+
+- Missing `filesystemPolicy` defaults to `"open"`.
+- Missing `networkPolicy` defaults to `"open"`.
+- Accepted policy values are exact documented strings only.
+- Unknown strings, strings with whitespace or different casing, non-strings,
+  and reference-shaped values must fail closed.
+
+Derived safety policy:
+
+- If either policy is restricted, derive:
+  - `requiresLockedConfiguration: true`
+  - `requiresNoSetupSQL: true`
+  - `requiresTempFileEncryption: true`
+  - `requiresSecretNeutralization: true`
+  - `forbidAdditionalExtensions: true`
+  - required baseline extensions `icu` and `json`
+- If `filesystemPolicy === "sandboxed"`, also derive:
+  - POSIX host required
+  - sandboxed path validation required
+  - derived temp directory name `.tmp`
+- If `networkPolicy === "closed"`, also derive:
+  - `allowHttpfs: false`
+  - no extension install or auto-install/autoload expansion
+
+Conflict checks:
+
+- Reject `setupSQL` whenever a restricted policy requires a locked baseline.
+- Reject non-empty `additionalExtensions` whenever a restricted policy forbids
+  extension broadening.
+- Reject `lockConfiguration: false` under any restricted policy.
+- Reject `tempFileEncryption: false` under any restricted policy.
+- Under `networkPolicy: "closed"`, reject:
+  - `enableExternalAccess: true`
+  - `autoloadKnownExtensions: true`
+  - `autoinstallKnownExtensions: true`
+  - `allowCommunityExtensions: true`
+  - `allowUnsignedExtensions: true`
+  - `motherDuckToken`
+  - remote or network-requiring `databasePath`
+- Redundant matching values are allowed. For example,
+  `networkPolicy: "closed"` plus `enableExternalAccess: false` is valid.
+
+Derived defaults:
+
+- Under `networkPolicy: "closed"`, force:
+  - `enableExternalAccess = false`
+  - `autoloadKnownExtensions = false`
+  - `autoinstallKnownExtensions = false`
+  - `allowCommunityExtensions = false`
+  - `allowUnsignedExtensions = false`
+- Under any restricted policy, force:
+  - `lockConfiguration = true`
+  - `tempFileEncryption = true`
+- Under `filesystemPolicy: "sandboxed"`:
+  - If `allowedDirectories` is omitted, derive it to exactly the canonical
+    `workingDirectory`, and nothing broader.
+  - If `tempDirectory` is omitted, derive it to `workingDirectory/.tmp`.
+  - If Malloy cannot derive the required paths safely, fail closed with a
+    field-specific error.
+- Outside `filesystemPolicy: "sandboxed"`, do not invent an
+  `allowedDirectories` default.
+- With `databasePath: ":memory:"`, normalize `readOnly` to `false`.
+  This intentionally preserves existing behavior. A user-facing warning for
+  ignored `readOnly: true` is deferred until host warning plumbing has a
+  reviewed path for normalized connection options.
+
+Empty text/list handling:
+
+- Empty or whitespace-only `setupSQL` is absent.
+- Empty or whitespace-only `motherDuckToken` is absent.
+- Empty `additionalExtensions` is absent.
+
+## Path Handling
+
+Canonicalize path-bearing values before validation and before share-key
+comparison:
+
+- `databasePath`, except `:memory:` and recognized remote paths
+- `workingDirectory`
+- `allowedDirectories`
+- `tempDirectory`
+- `extensionDirectory`
+
+Canonicalization must:
+
+- resolve `.` and `..`
+- normalize separators and remove trailing separators
+- resolve symlinks when the path or its nearest existing parent exists
+- deduplicate and sort list-valued paths before identity comparison
+
+Containment checks must operate only on canonicalized values. Treat path
+normalization as security logic, not cosmetic cleanup.
+
+`allowedDirectories` is not read-only. Hosts must assume DuckDB may read and
+write inside every allowed directory through features that remain available
+inside the boundary, including `COPY TO`, `EXPORT DATABASE`, and attached
+writable databases. Do not point `allowedDirectories` at shared writable
+locations unless that write surface is acceptable.
+
+## Sharing And Identity
+
+Do not cache native DuckDB instances by `databasePath` alone.
+
+Use the derived share key from `buildDuckDBShareKey()` and include every
+effective setting that can affect runtime behavior, safety, or semantics:
+
+- `databasePath`
+- `readOnly`
+- `filesystemPolicy`
+- `networkPolicy`
+- `setupSQL`
+- canonicalized `allowedDirectories`
+- `enableExternalAccess`
+- `lockConfiguration`
+- `autoloadKnownExtensions`
+- `autoinstallKnownExtensions`
+- `allowCommunityExtensions`
+- `allowUnsignedExtensions`
+- `tempFileEncryption`
+- `threads`
+- `memoryLimit`
+- `tempDirectory`
+- `workingDirectory`
+- normalized `additionalExtensions`
+- `extensionDirectory`
+- `motherDuckToken`
+
+List-valued inputs must be canonicalized, sorted, and deduplicated so
+semantically identical configs share and semantically different configs do not.
+
+Keep the share key separate from `getDigest()`:
+
+- `getDigest()` is about build/result identity.
+- the share key is about safe native instance reuse.
+
+This share-key behavior intentionally affects ordinary connections too:
+connections with the same `databasePath` but different effective settings
+should not share a live instance.
+
+Share keys are sensitive because `motherDuckToken` contributes to them. Use
+`makeDigest(...)` and do not log raw share-key inputs.
+
+## Baseline Setup
+
+Prefer open-time DuckDB config through `DuckDBInstance.create(path, options)`
+when the option is supported and serializes cleanly. Keep post-connect setup as
+small as practical.
+
+The final baseline must happen before Malloy-derived SQL. When locking is
+required, `lock_configuration=true` is the final baseline step.
+
+Current baseline mapping:
+
+- `FILE_SEARCH_PATH`
+  - set before user SQL when `workingDirectory` exists
+  - currently post-connect because open-time behavior is not verified
+- `allowed_directories`
+  - set before lock when normalized config has `allowedDirectories`
+  - currently post-connect because the DuckDB Node API rejects the list-valued
+    option during local verification
+- `secret_directory`
+  - set before lock when restricted secret neutralization derives a directory
+  - currently post-connect because open-time behavior is not verified
+- `enable_external_access`
+  - set at open time when no `allowed_directories` baseline SET is required
+  - otherwise set immediately after `allowed_directories`
+  - DuckDB rejects changing `allowed_directories` after
+    `enable_external_access=false`, so the strict sandboxed recipe has this
+    small post-connect ordering constraint until the Node API can apply the
+    allowlist at instance creation
+- `TimeZone='UTC'`
+  - always part of Malloy's fixed correctness baseline
+  - not user-configurable
+  - must be established before lock
+- built-in extension loading
+  - preserve ordinary compatibility outside restricted modes
+  - under `networkPolicy: "closed"`, do not `INSTALL`, do not load `httpfs`,
+    and load only the fixed Malloy baseline extensions
+- `setupSQL`
+  - preserve outside restricted modes
+  - reject when a restricted policy requires a locked baseline
+  - run only after fixed baseline steps and before optional lock
+
+Do not introduce later Malloy-emitted DuckDB `SET` statements that mutate
+configuration after `lock_configuration=true`.
+
+## Extensions
+
+`icu` and `json` are part of the fixed Malloy DuckDB baseline.
+
+`httpfs` is not part of that baseline. It broadens remote/network-capable
+behavior and is controlled by `networkPolicy`.
+
+Under `networkPolicy: "closed"`:
+
+- do not load `httpfs`
+- do not `INSTALL` extensions
+- do not allow `additionalExtensions`
+- load only fixed baseline extensions `icu` and `json`
+- fail closed if a required baseline extension is unavailable locally
+
+Outside `networkPolicy: "closed"`, preserve ordinary compatibility unless a
+separate product decision changes it.
+
+## Secrets
+
+The full DuckDB secrets product story is deferred. Do not add public
+secrets-related config surface as part of restricted-policy maintenance unless
+there is a reviewed product design.
+
+Even without a public secrets product, restricted execution must not expose
+ambient persistent DuckDB secrets from the host environment or another tenant.
+
+Current interim behavior:
+
+- Any restricted policy derives a private `secretDirectory`.
+- If `tempDirectory` exists, derive secrets under
+  `tempDirectory/.duckdb-secrets`.
+- Otherwise, if `workingDirectory` exists, derive secrets under
+  `workingDirectory/.duckdb-secrets`.
+- If restricted mode cannot derive a scoped secret directory, fail closed.
+- Apply `secret_directory` before lock.
+
+If this behavior changes, update both the safety policy derivation and the
+restricted-mode tests.
+
+## WASM Scope
+
+The policy system described here targets native DuckDB.
+
+Do not register native-only policy fields in the `duckdb_wasm` connection
+schema in this pass:
+
+- `filesystemPolicy`
+- `networkPolicy`
+- native-only hardening properties
+
+Do not add native restricted-policy behavior to `DuckDBWASMConnection` as a
+side effect of native DuckDB maintenance. WASM runs in a host-provided
+JavaScript/WASM environment, where the host controls the virtual filesystem,
+browser file APIs, fetch/network reach, OPFS, registered files, remote URL
+registration, and credential injection.
+
+If Malloy later wants restricted execution for `duckdb_wasm`, design it
+explicitly for WASM instead of copying native policy semantics.
+
+## Adding A New DuckDB Config Property
+
+When adding a new native DuckDB config property, update all relevant layers:
+
+- Register the property in `src/native.ts` with the correct config metadata.
+- Parse and validate it in `normalizeDuckDBConfig()`.
+- Decide whether it conflicts with `filesystemPolicy` or `networkPolicy`.
+- Decide whether any restricted policy must derive or force a value.
+- If it is path-like, canonicalize it before validation and identity
+  comparison.
+- Include it in `buildDuckDBShareKey()` if it can affect runtime behavior,
+  security posture, or semantics.
+- Decide whether it belongs in open-time options or final baseline setup.
+- Add tests for validation, derived behavior, conflict behavior, and sharing
+  identity when relevant.
+- Update this file if the property changes the policy model or maintainer
+  checklist.
+
+Be conservative: new settings that broaden filesystem, network, extension,
+credential, or mutable-configuration behavior should usually be rejected or
+forced to a safe value under restricted policies.
+
+## Changing Policy Behavior
+
+When changing `filesystemPolicy`, `networkPolicy`, or
+`NormalizedDuckDBSafetyPolicy`, review these together:
+
+- user-facing policy contract
+- normalizer parsing and conflict checks
+- derived defaults
+- path canonicalization and containment rules
+- secret neutralization
+- open-time options
+- final baseline ordering
+- extension install/load behavior
+- lock timing
+- share-key inputs
+- native restricted tests
+- WASM non-claim boundary
+- public documentation
+
+Do not make a policy change only in `DuckDBConnection`. The normalizer should
+remain the central place where raw config becomes effective policy and runtime
+state.
+
+## Test Expectations
+
+Keep focused tests for:
+
+- `allowedDirectories` accepted as a JSON array of strings
+- `allowedDirectories` rejected for non-array or non-string JSON values
+- exact policy value parsing
+- policy fields rejected when provided as non-literal or reference-shaped
+  values
+- missing policy-required values failing closed
+- conflict checks
+- redundant matching explicit values accepted
+- sandboxed derived defaults
+- `tempDirectory` containment
+- network-requiring `databasePath` rejection
+- `readOnly: true` with `:memory:` normalizing to `false`
+- share keys differing when safety-relevant settings differ
+- semantically identical allowlists sharing
+- restricted baseline order
+- `networkPolicy: "closed"` not loading `httpfs`
+- `networkPolicy: "closed"` not running `INSTALL`
+- required baseline extensions loaded or failing closed
+- later config-changing `SET` statements failing after lock
+- `closeAllInstances()` clearing all share-keyed native instances

--- a/packages/malloy-db-duckdb/src/duckdb.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb.spec.ts
@@ -116,9 +116,9 @@ describe('DuckDBConnection', () => {
       );
 
       expect(Object.keys(DuckDBConnection.activeDBs).length).toEqual(1);
-      expect(DuckDBConnection.activeDBs[':memory:'].connections.length).toEqual(
-        3
-      );
+      expect(
+        Object.values(DuckDBConnection.activeDBs)[0].connections.length
+      ).toEqual(3);
       expect(val1).toEqual({rows: [{val: '/home/user1'}], totalRows: 1});
       expect(val2).toEqual({rows: [{val: '/home/user2'}], totalRows: 1});
 

--- a/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type {ConnectionConfig} from '@malloydata/malloy';
+import {
+  buildDuckDBShareKey,
+  DuckDBConfigValidationError,
+  normalizeDuckDBConfig,
+} from './duckdb_config';
+import * as pathSecurity from './path_security';
+
+describe('normalizeDuckDBConfig', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-duckdb-'));
+  const workingDirectory = path.join(tempRoot, 'working');
+  const allowedA = path.join(tempRoot, 'allowed-a');
+  const allowedB = path.join(tempRoot, 'allowed-b');
+  const canonical = (value: string) => fs.realpathSync.native(value);
+
+  beforeAll(() => {
+    fs.mkdirSync(workingDirectory, {recursive: true});
+    fs.mkdirSync(allowedA, {recursive: true});
+    fs.mkdirSync(allowedB, {recursive: true});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const baseConfig = (
+    overrides: Partial<ConnectionConfig> = {}
+  ): ConnectionConfig => ({
+    name: 'duckdb',
+    databasePath: ':memory:',
+    ...overrides,
+  });
+
+  it('accepts allowedDirectories as a JSON array of strings', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({allowedDirectories: [allowedA, allowedB]})
+    );
+
+    expect(normalized.allowedDirectories).toEqual(
+      [allowedA, allowedB].map(value => canonical(value)).sort()
+    );
+  });
+
+  it('rejects non-array allowedDirectories', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({allowedDirectories: allowedA as unknown as string[]})
+      )
+    ).toThrow(DuckDBConfigValidationError);
+  });
+
+  it('rejects non-string entries inside allowedDirectories', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({allowedDirectories: [allowedA, 42] as unknown as string[]})
+      )
+    ).toThrow('allowedDirectories must be a JSON array of strings');
+  });
+
+  it('wraps invalid path inputs as DuckDB config validation errors', () => {
+    expect(() =>
+      normalizeDuckDBConfig(baseConfig({workingDirectory: ''}))
+    ).toThrow(DuckDBConfigValidationError);
+    expect(() =>
+      normalizeDuckDBConfig(baseConfig({workingDirectory: ''}))
+    ).toThrow('workingDirectory is invalid: path must not be empty');
+  });
+
+  it('does not invent allowedDirectories outside sandboxed mode', () => {
+    const normalized = normalizeDuckDBConfig(baseConfig());
+
+    expect(normalized.allowedDirectories).toBeUndefined();
+  });
+
+  it('derives sandboxed defaults from workingDirectory', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({
+        filesystemPolicy: 'sandboxed',
+        workingDirectory,
+      })
+    );
+
+    expect(normalized.allowedDirectories).toEqual([
+      canonical(workingDirectory),
+    ]);
+    expect(normalized.tempDirectory).toEqual(
+      path.join(canonical(workingDirectory), '.tmp')
+    );
+    expect(normalized.secretDirectory).toEqual(
+      path.join(canonical(workingDirectory), '.tmp', '.duckdb-secrets')
+    );
+    expect(normalized.lockConfiguration).toBe(true);
+    expect(normalized.tempFileEncryption).toBe(true);
+  });
+
+  it('derives a working-directory scoped secret directory for network-only restricted mode', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({
+        networkPolicy: 'closed',
+        workingDirectory,
+      })
+    );
+
+    expect(normalized.tempDirectory).toBeUndefined();
+    expect(normalized.secretDirectory).toEqual(
+      path.join(canonical(workingDirectory), '.duckdb-secrets')
+    );
+  });
+
+  it('fails closed when restricted secret isolation has no scoped directory', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          networkPolicy: 'closed',
+        })
+      )
+    ).toThrow(
+      'restricted DuckDB policies require workingDirectory or tempDirectory'
+    );
+  });
+
+  it('rejects sandboxed mode without workingDirectory or allowedDirectories', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          filesystemPolicy: 'sandboxed',
+        })
+      )
+    ).toThrow(
+      'filesystemPolicy "sandboxed" requires either allowedDirectories or workingDirectory'
+    );
+  });
+
+  it('rejects sandboxed mode on non-POSIX hosts', () => {
+    jest.spyOn(pathSecurity, 'isPosixHost').mockReturnValue(false);
+
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          filesystemPolicy: 'sandboxed',
+          workingDirectory,
+        })
+      )
+    ).toThrow('filesystemPolicy "sandboxed" is only supported on POSIX hosts');
+  });
+
+  it('rejects tempDirectory outside the sandbox boundary', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          filesystemPolicy: 'sandboxed',
+          workingDirectory,
+          allowedDirectories: [workingDirectory],
+          tempDirectory: allowedA,
+        })
+      )
+    ).toThrow(
+      'tempDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+    );
+  });
+
+  it('rejects network-requiring database paths when networkPolicy is closed', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          networkPolicy: 'closed',
+          databasePath: 'md:malloy',
+        })
+      )
+    ).toThrow(
+      'databasePath "md:malloy" is not allowed when networkPolicy is "closed"'
+    );
+  });
+
+  it.each([
+    [
+      'enableExternalAccess',
+      {networkPolicy: 'closed', enableExternalAccess: true},
+      'enableExternalAccess cannot be true when networkPolicy "closed" is enabled',
+    ],
+    [
+      'autoloadKnownExtensions',
+      {networkPolicy: 'closed', autoloadKnownExtensions: true},
+      'autoloadKnownExtensions cannot be true when networkPolicy "closed" is enabled',
+    ],
+    [
+      'autoinstallKnownExtensions',
+      {networkPolicy: 'closed', autoinstallKnownExtensions: true},
+      'autoinstallKnownExtensions cannot be true when networkPolicy "closed" is enabled',
+    ],
+    [
+      'allowCommunityExtensions',
+      {networkPolicy: 'closed', allowCommunityExtensions: true},
+      'allowCommunityExtensions cannot be true when networkPolicy "closed" is enabled',
+    ],
+    [
+      'allowUnsignedExtensions',
+      {networkPolicy: 'closed', allowUnsignedExtensions: true},
+      'allowUnsignedExtensions cannot be true when networkPolicy "closed" is enabled',
+    ],
+    [
+      'lockConfiguration',
+      {filesystemPolicy: 'sandboxed', lockConfiguration: false},
+      'lockConfiguration cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+    ],
+    [
+      'tempFileEncryption',
+      {filesystemPolicy: 'sandboxed', tempFileEncryption: false},
+      'tempFileEncryption cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+    ],
+    [
+      'additionalExtensions',
+      {filesystemPolicy: 'sandboxed', additionalExtensions: ['spatial']},
+      'additionalExtensions is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+    ],
+    [
+      'motherDuckToken',
+      {networkPolicy: 'closed', motherDuckToken: 'token'},
+      'motherDuckToken is not allowed when networkPolicy is "closed"',
+    ],
+  ] satisfies Array<[string, Partial<ConnectionConfig>, string]>)(
+    'rejects conflicting restricted setting %s',
+    (_name, overrides, message) => {
+      expect(() =>
+        normalizeDuckDBConfig(baseConfig({workingDirectory, ...overrides}))
+      ).toThrow(message);
+    }
+  );
+
+  it('normalizes readOnly away for in-memory databases', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({
+        readOnly: true,
+        databasePath: ':memory:',
+      })
+    );
+
+    expect(normalized.readOnly).toBe(false);
+  });
+
+  it('builds the same share key for semantically identical allowedDirectories lists', () => {
+    const configA = normalizeDuckDBConfig(
+      baseConfig({
+        filesystemPolicy: 'sandboxed',
+        workingDirectory,
+        allowedDirectories: [workingDirectory, allowedA, allowedB],
+      })
+    );
+    const configB = normalizeDuckDBConfig(
+      baseConfig({
+        filesystemPolicy: 'sandboxed',
+        workingDirectory,
+        allowedDirectories: [allowedB, allowedA, workingDirectory, allowedA],
+      })
+    );
+
+    expect(buildDuckDBShareKey(configA)).toBe(buildDuckDBShareKey(configB));
+  });
+});

--- a/packages/malloy-db-duckdb/src/duckdb_config.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.ts
@@ -1,0 +1,632 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import path from 'path';
+import {makeDigest} from '@malloydata/malloy';
+import type {
+  ConnectionConfig,
+  ConnectionParameterValue,
+} from '@malloydata/malloy';
+import * as pathSecurity from './path_security';
+
+export type DuckDBFilesystemPolicy = 'open' | 'sandboxed';
+export type DuckDBNetworkPolicy = 'open' | 'closed';
+
+export interface NormalizedDuckDBSafetyPolicy {
+  requiresPosixHost: boolean;
+  requiresLockedConfiguration: boolean;
+  requiresNoSetupSQL: boolean;
+  requiresSandboxedPaths: boolean;
+  requiresTempFileEncryption: boolean;
+  requiresSecretNeutralization: boolean;
+  requiredBaselineExtensions: readonly ['icu', 'json'];
+  allowHttpfs: boolean;
+  forbidAdditionalExtensions: boolean;
+  derivedTempDirectoryName: '.tmp';
+}
+
+export interface NormalizedDuckDBConfig {
+  name: string;
+  databasePath: string;
+  readOnly: boolean;
+  workingDirectory?: string;
+  filesystemPolicy: DuckDBFilesystemPolicy;
+  networkPolicy: DuckDBNetworkPolicy;
+  safetyPolicy?: NormalizedDuckDBSafetyPolicy;
+  allowedDirectories?: string[];
+  enableExternalAccess?: boolean;
+  lockConfiguration?: boolean;
+  autoloadKnownExtensions?: boolean;
+  autoinstallKnownExtensions?: boolean;
+  allowCommunityExtensions?: boolean;
+  allowUnsignedExtensions?: boolean;
+  tempFileEncryption?: boolean;
+  threads?: number;
+  memoryLimit?: string;
+  tempDirectory?: string;
+  secretDirectory?: string;
+  extensionDirectory?: string;
+  motherDuckToken?: string;
+  additionalExtensions: string[];
+  setupSQL?: string;
+}
+
+export class DuckDBConfigValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DuckDBConfigValidationError';
+  }
+}
+
+const REQUIRED_BASELINE_EXTENSIONS = ['icu', 'json'] as const;
+const DERIVED_TEMP_DIRECTORY_NAME = '.tmp' as const;
+const DERIVED_SECRET_DIRECTORY_NAME = '.duckdb-secrets' as const;
+
+export function normalizeDuckDBConfig(
+  config: ConnectionConfig
+): NormalizedDuckDBConfig {
+  const filesystemPolicy = parsePolicyValue(
+    config['filesystemPolicy'],
+    'filesystemPolicy',
+    ['open', 'sandboxed']
+  );
+  const networkPolicy = parsePolicyValue(
+    config['networkPolicy'],
+    'networkPolicy',
+    ['open', 'closed']
+  );
+
+  if (filesystemPolicy === 'sandboxed' && !pathSecurity.isPosixHost()) {
+    throw new DuckDBConfigValidationError(
+      'filesystemPolicy "sandboxed" is only supported on POSIX hosts'
+    );
+  }
+
+  const rawDatabasePath =
+    readOptionalString(config, 'databasePath') ??
+    readOptionalString(config, 'path') ??
+    ':memory:';
+  const rawWorkingDirectory = readOptionalString(config, 'workingDirectory');
+  const rawSetupSQL = normalizeOptionalText(
+    readOptionalString(config, 'setupSQL')
+  );
+  const rawMotherDuckToken = normalizeOptionalText(
+    readOptionalString(config, 'motherDuckToken')
+  );
+  const readOnly = readOptionalBoolean(config, 'readOnly') ?? false;
+  const additionalExtensions = normalizeExtensions(
+    config['additionalExtensions'],
+    'additionalExtensions'
+  );
+  const enableExternalAccess = readOptionalBoolean(
+    config,
+    'enableExternalAccess'
+  );
+  const lockConfiguration = readOptionalBoolean(config, 'lockConfiguration');
+  const autoloadKnownExtensions = readOptionalBoolean(
+    config,
+    'autoloadKnownExtensions'
+  );
+  const autoinstallKnownExtensions = readOptionalBoolean(
+    config,
+    'autoinstallKnownExtensions'
+  );
+  const allowCommunityExtensions = readOptionalBoolean(
+    config,
+    'allowCommunityExtensions'
+  );
+  const allowUnsignedExtensions = readOptionalBoolean(
+    config,
+    'allowUnsignedExtensions'
+  );
+  const tempFileEncryption = readOptionalBoolean(config, 'tempFileEncryption');
+  const threads = readOptionalInteger(config, 'threads');
+  const memoryLimit = readOptionalString(config, 'memoryLimit');
+  const rawTempDirectory = readOptionalString(config, 'tempDirectory');
+  const rawExtensionDirectory = readOptionalString(
+    config,
+    'extensionDirectory'
+  );
+  const rawAllowedDirectories = readOptionalStringArray(
+    config['allowedDirectories'],
+    'allowedDirectories'
+  );
+
+  const restricted =
+    filesystemPolicy === 'sandboxed' || networkPolicy === 'closed';
+  const safetyPolicy = restricted
+    ? {
+        requiresPosixHost: filesystemPolicy === 'sandboxed',
+        requiresLockedConfiguration: true,
+        requiresNoSetupSQL: true,
+        requiresSandboxedPaths: filesystemPolicy === 'sandboxed',
+        requiresTempFileEncryption: true,
+        requiresSecretNeutralization: true,
+        requiredBaselineExtensions: REQUIRED_BASELINE_EXTENSIONS,
+        allowHttpfs: networkPolicy === 'open',
+        forbidAdditionalExtensions: true,
+        derivedTempDirectoryName: DERIVED_TEMP_DIRECTORY_NAME,
+      }
+    : undefined;
+
+  if (safetyPolicy?.requiresNoSetupSQL && rawSetupSQL !== undefined) {
+    throw new DuckDBConfigValidationError(
+      'setupSQL is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+    );
+  }
+
+  if (
+    safetyPolicy?.forbidAdditionalExtensions &&
+    additionalExtensions.length > 0
+  ) {
+    throw new DuckDBConfigValidationError(
+      'additionalExtensions is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+    );
+  }
+
+  if (restricted && lockConfiguration === false) {
+    throw new DuckDBConfigValidationError(
+      'lockConfiguration cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+    );
+  }
+
+  if (restricted && tempFileEncryption === false) {
+    throw new DuckDBConfigValidationError(
+      'tempFileEncryption cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+    );
+  }
+
+  if (networkPolicy === 'closed') {
+    rejectConflictingBoolean(
+      enableExternalAccess,
+      'enableExternalAccess',
+      true,
+      'networkPolicy "closed"'
+    );
+    rejectConflictingBoolean(
+      autoloadKnownExtensions,
+      'autoloadKnownExtensions',
+      true,
+      'networkPolicy "closed"'
+    );
+    rejectConflictingBoolean(
+      autoinstallKnownExtensions,
+      'autoinstallKnownExtensions',
+      true,
+      'networkPolicy "closed"'
+    );
+    rejectConflictingBoolean(
+      allowCommunityExtensions,
+      'allowCommunityExtensions',
+      true,
+      'networkPolicy "closed"'
+    );
+    rejectConflictingBoolean(
+      allowUnsignedExtensions,
+      'allowUnsignedExtensions',
+      true,
+      'networkPolicy "closed"'
+    );
+    if (rawMotherDuckToken !== undefined) {
+      throw new DuckDBConfigValidationError(
+        'motherDuckToken is not allowed when networkPolicy is "closed"'
+      );
+    }
+  }
+
+  let workingDirectory: string | undefined;
+  if (rawWorkingDirectory !== undefined) {
+    workingDirectory = canonicalizeConfigPath(
+      rawWorkingDirectory,
+      'workingDirectory',
+      {
+        mustExist: filesystemPolicy === 'sandboxed',
+      }
+    );
+  }
+
+  const databasePath = canonicalizeDatabasePath(rawDatabasePath);
+  const isMotherDuck = isMotherDuckPath(databasePath);
+  if (
+    networkPolicy === 'closed' &&
+    !isAllowedClosedNetworkDatabasePath(databasePath)
+  ) {
+    throw new DuckDBConfigValidationError(
+      `databasePath "${rawDatabasePath}" is not allowed when networkPolicy is "closed"`
+    );
+  }
+
+  if (networkPolicy === 'closed' && isMotherDuck) {
+    throw new DuckDBConfigValidationError(
+      'MotherDuck database paths are not allowed when networkPolicy is "closed"'
+    );
+  }
+
+  const normalizedAllowedDirectories =
+    rawAllowedDirectories === undefined
+      ? undefined
+      : canonicalizeConfigPathList(rawAllowedDirectories, 'allowedDirectories');
+
+  let allowedDirectories = normalizedAllowedDirectories;
+  if (filesystemPolicy === 'sandboxed') {
+    if (allowedDirectories === undefined) {
+      if (workingDirectory === undefined) {
+        throw new DuckDBConfigValidationError(
+          'filesystemPolicy "sandboxed" requires either allowedDirectories or workingDirectory. If you expected workingDirectory to come from config.rootDirectory, verify that overlay is available.'
+        );
+      }
+      allowedDirectories = [workingDirectory];
+    }
+    if (
+      workingDirectory !== undefined &&
+      !allowedDirectories.some(allowed =>
+        pathSecurity.isContainedPath(allowed, workingDirectory!)
+      )
+    ) {
+      throw new DuckDBConfigValidationError(
+        'workingDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+      );
+    }
+  }
+
+  let tempDirectory: string | undefined;
+  if (rawTempDirectory !== undefined) {
+    tempDirectory = canonicalizeConfigPath(rawTempDirectory, 'tempDirectory');
+  } else if (filesystemPolicy === 'sandboxed') {
+    if (workingDirectory === undefined) {
+      throw new DuckDBConfigValidationError(
+        'filesystemPolicy "sandboxed" requires tempDirectory or workingDirectory so Malloy can derive a safe temp directory'
+      );
+    }
+    tempDirectory = path.join(workingDirectory, DERIVED_TEMP_DIRECTORY_NAME);
+  }
+
+  if (filesystemPolicy === 'sandboxed') {
+    if (allowedDirectories === undefined) {
+      throw new DuckDBConfigValidationError(
+        'filesystemPolicy "sandboxed" requires allowedDirectories'
+      );
+    }
+    if (tempDirectory === undefined) {
+      throw new DuckDBConfigValidationError(
+        'filesystemPolicy "sandboxed" requires tempDirectory'
+      );
+    }
+    if (
+      !allowedDirectories.some(allowed =>
+        pathSecurity.isContainedPath(allowed, tempDirectory!)
+      )
+    ) {
+      throw new DuckDBConfigValidationError(
+        'tempDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+      );
+    }
+  }
+
+  const extensionDirectory =
+    rawExtensionDirectory === undefined
+      ? undefined
+      : canonicalizeConfigPath(rawExtensionDirectory, 'extensionDirectory');
+
+  const secretDirectory = deriveRestrictedSecretDirectory({
+    requiresSecretNeutralization:
+      safetyPolicy?.requiresSecretNeutralization ?? false,
+    tempDirectory,
+    workingDirectory,
+  });
+
+  return {
+    name: config.name,
+    databasePath,
+    readOnly: databasePath === ':memory:' ? false : readOnly,
+    workingDirectory,
+    filesystemPolicy,
+    networkPolicy,
+    safetyPolicy,
+    allowedDirectories,
+    enableExternalAccess:
+      networkPolicy === 'closed' ? false : enableExternalAccess,
+    lockConfiguration: safetyPolicy?.requiresLockedConfiguration
+      ? true
+      : lockConfiguration,
+    autoloadKnownExtensions:
+      networkPolicy === 'closed' ? false : autoloadKnownExtensions,
+    autoinstallKnownExtensions:
+      networkPolicy === 'closed' ? false : autoinstallKnownExtensions,
+    allowCommunityExtensions:
+      networkPolicy === 'closed' ? false : allowCommunityExtensions,
+    allowUnsignedExtensions:
+      networkPolicy === 'closed' ? false : allowUnsignedExtensions,
+    tempFileEncryption: safetyPolicy?.requiresTempFileEncryption
+      ? true
+      : tempFileEncryption,
+    threads,
+    memoryLimit,
+    tempDirectory,
+    secretDirectory,
+    extensionDirectory,
+    motherDuckToken: rawMotherDuckToken,
+    additionalExtensions,
+    setupSQL: rawSetupSQL,
+  };
+}
+
+export function buildDuckDBShareKey(config: NormalizedDuckDBConfig): string {
+  // secretDirectory is derived from policy + workingDirectory/tempDirectory,
+  // which already participate in the share key.
+  return makeDigest(
+    'duckdb-share-key-v1',
+    config.databasePath,
+    String(config.readOnly),
+    config.filesystemPolicy,
+    config.networkPolicy,
+    config.setupSQL ?? '',
+    ...(config.allowedDirectories ?? []),
+    config.enableExternalAccess === undefined
+      ? ''
+      : String(config.enableExternalAccess),
+    config.lockConfiguration === undefined
+      ? ''
+      : String(config.lockConfiguration),
+    config.autoloadKnownExtensions === undefined
+      ? ''
+      : String(config.autoloadKnownExtensions),
+    config.autoinstallKnownExtensions === undefined
+      ? ''
+      : String(config.autoinstallKnownExtensions),
+    config.allowCommunityExtensions === undefined
+      ? ''
+      : String(config.allowCommunityExtensions),
+    config.allowUnsignedExtensions === undefined
+      ? ''
+      : String(config.allowUnsignedExtensions),
+    config.tempFileEncryption === undefined
+      ? ''
+      : String(config.tempFileEncryption),
+    config.threads === undefined ? '' : String(config.threads),
+    config.memoryLimit ?? '',
+    config.tempDirectory ?? '',
+    config.workingDirectory ?? '',
+    ...[...config.additionalExtensions].sort(),
+    config.extensionDirectory ?? '',
+    config.motherDuckToken ?? ''
+  );
+}
+
+export function sqlStringLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function sqlStringListLiteral(values: string[]): string {
+  return `[${values.map(value => sqlStringLiteral(value)).join(',')}]`;
+}
+
+export function stringifyDuckDBOption(
+  value: string | number | boolean
+): string {
+  return String(value);
+}
+
+function parsePolicyValue<T extends string>(
+  rawValue: ConnectionParameterValue | undefined,
+  fieldName: string,
+  allowedValues: readonly T[]
+): T | 'open' {
+  if (rawValue === undefined) {
+    return 'open';
+  }
+  if (typeof rawValue !== 'string') {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be one of ${allowedValues
+        .map(v => `"${v}"`)
+        .join(' or ')}, got ${typeof rawValue}`
+    );
+  }
+  if ((allowedValues as readonly string[]).includes(rawValue)) {
+    return rawValue as T;
+  }
+  throw new DuckDBConfigValidationError(
+    `${fieldName} must be one of ${allowedValues
+      .map(v => `"${v}"`)
+      .join(' or ')}, got "${rawValue}"`
+  );
+}
+
+function readOptionalString(
+  config: ConnectionConfig,
+  fieldName: string
+): string | undefined {
+  const rawValue = config[fieldName];
+  if (rawValue === undefined) {
+    return undefined;
+  }
+  if (typeof rawValue !== 'string') {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be a string, got ${typeof rawValue}`
+    );
+  }
+  return rawValue;
+}
+
+function readOptionalBoolean(
+  config: ConnectionConfig,
+  fieldName: string
+): boolean | undefined {
+  const rawValue = config[fieldName];
+  if (rawValue === undefined) {
+    return undefined;
+  }
+  if (typeof rawValue !== 'boolean') {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be a boolean, got ${typeof rawValue}`
+    );
+  }
+  return rawValue;
+}
+
+function readOptionalInteger(
+  config: ConnectionConfig,
+  fieldName: string
+): number | undefined {
+  const rawValue = config[fieldName];
+  if (rawValue === undefined) {
+    return undefined;
+  }
+  if (typeof rawValue !== 'number' || !Number.isInteger(rawValue)) {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be an integer number`
+    );
+  }
+  return rawValue;
+}
+
+function readOptionalStringArray(
+  rawValue: ConnectionParameterValue | undefined,
+  fieldName: string
+): string[] | undefined {
+  if (rawValue === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(rawValue)) {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be a JSON array of strings`
+    );
+  }
+  if (!rawValue.every(value => typeof value === 'string')) {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be a JSON array of strings`
+    );
+  }
+  return rawValue;
+}
+
+function normalizeExtensions(
+  rawValue: ConnectionParameterValue | undefined,
+  fieldName: string
+): string[] {
+  if (rawValue === undefined) {
+    return [];
+  }
+
+  const parts = (() => {
+    if (typeof rawValue === 'string') {
+      return rawValue.split(',');
+    }
+    if (
+      Array.isArray(rawValue) &&
+      rawValue.every(value => typeof value === 'string')
+    ) {
+      return rawValue;
+    }
+    throw new DuckDBConfigValidationError(
+      `${fieldName} must be a comma-separated string or an array of strings`
+    );
+  })();
+
+  const normalized = parts
+    .map(value => value.trim())
+    .filter(value => value !== '');
+  return Array.from(new Set(normalized));
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : value;
+}
+
+function deriveRestrictedSecretDirectory({
+  requiresSecretNeutralization,
+  tempDirectory,
+  workingDirectory,
+}: {
+  requiresSecretNeutralization: boolean;
+  tempDirectory?: string;
+  workingDirectory?: string;
+}): string | undefined {
+  if (!requiresSecretNeutralization) {
+    return undefined;
+  }
+
+  if (tempDirectory !== undefined) {
+    return path.join(tempDirectory, DERIVED_SECRET_DIRECTORY_NAME);
+  }
+
+  if (workingDirectory !== undefined) {
+    return path.join(workingDirectory, DERIVED_SECRET_DIRECTORY_NAME);
+  }
+
+  throw new DuckDBConfigValidationError(
+    'restricted DuckDB policies require workingDirectory or tempDirectory so Malloy can isolate persistent DuckDB secrets'
+  );
+}
+
+function canonicalizeDatabasePath(databasePath: string): string {
+  if (databasePath === ':memory:' || isLikelyRemoteDatabasePath(databasePath)) {
+    return databasePath;
+  }
+  return canonicalizeConfigPath(databasePath, 'databasePath');
+}
+
+function canonicalizeConfigPath(
+  input: string,
+  fieldName: string,
+  options: pathSecurity.CanonicalPathOptions = {}
+): string {
+  try {
+    return pathSecurity.canonicalizePath(input, options);
+  } catch (error) {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} is invalid: ${errorMessage(error)}`
+    );
+  }
+}
+
+function canonicalizeConfigPathList(
+  paths: string[],
+  fieldName: string
+): string[] {
+  return Array.from(
+    new Set(paths.map(p => canonicalizeConfigPath(p, fieldName)).sort())
+  );
+}
+
+function isAllowedClosedNetworkDatabasePath(databasePath: string): boolean {
+  return (
+    databasePath === ':memory:' || !isLikelyRemoteDatabasePath(databasePath)
+  );
+}
+
+function isLikelyRemoteDatabasePath(databasePath: string): boolean {
+  return (
+    isMotherDuckPath(databasePath) ||
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(databasePath)
+  );
+}
+
+function isMotherDuckPath(databasePath: string): boolean {
+  return (
+    databasePath.startsWith('md:') || databasePath.startsWith('motherduck:')
+  );
+}
+
+function rejectConflictingBoolean(
+  actualValue: boolean | undefined,
+  fieldName: string,
+  forbiddenValue: boolean,
+  reason: string
+): void {
+  if (actualValue === forbiddenValue) {
+    throw new DuckDBConfigValidationError(
+      `${fieldName} cannot be ${forbiddenValue} when ${reason} is enabled`
+    );
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {MalloyConfig} from '@malloydata/malloy';
+import {DuckDBConnection} from './duckdb_connection';
+import './native';
+
+describe('DuckDB config lookup validation', () => {
+  afterEach(() => {
+    DuckDBConnection.closeAllInstances();
+  });
+
+  it('rejects reference-shaped filesystemPolicy before DuckDB construction', async () => {
+    const config = new MalloyConfig({
+      connections: {
+        duckdb: {
+          is: 'duckdb',
+          filesystemPolicy: {env: 'FS_POLICY'},
+        },
+      },
+    });
+
+    await expect(config.connections.lookupConnection('duckdb')).rejects.toThrow(
+      'Connection "duckdb" property "filesystemPolicy" must be a literal string'
+    );
+    expect(config.log.map(entry => entry.message)).toContain(
+      'connections.duckdb.filesystemPolicy: must be a literal string and cannot use an overlay reference'
+    );
+  });
+
+  it('rejects non-string networkPolicy before DuckDB construction', async () => {
+    const config = new MalloyConfig({
+      connections: {
+        duckdb: {
+          is: 'duckdb',
+          networkPolicy: 42,
+        },
+      },
+    });
+
+    await expect(config.connections.lookupConnection('duckdb')).rejects.toThrow(
+      'Connection "duckdb" property "networkPolicy" must be a literal string'
+    );
+    expect(config.log.map(entry => entry.message)).toContain(
+      'connections.duckdb.networkPolicy: must be a literal string, got number'
+    );
+  });
+});

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -32,14 +32,36 @@ import type {
 } from '@malloydata/malloy';
 import {makeDigest} from '@malloydata/malloy';
 import packageJson from '@malloydata/malloy/package.json';
+import {
+  buildDuckDBShareKey,
+  normalizeDuckDBConfig,
+  sqlStringListLiteral,
+  sqlStringLiteral,
+  stringifyDuckDBOption,
+  type NormalizedDuckDBConfig,
+} from './duckdb_config';
 
 export interface DuckDBConnectionOptions extends ConnectionConfig {
-  additionalExtensions?: string[];
+  additionalExtensions?: string[] | string;
   databasePath?: string;
   motherDuckToken?: string;
   workingDirectory?: string;
   readOnly?: boolean;
   setupSQL?: string;
+  filesystemPolicy?: 'open' | 'sandboxed';
+  networkPolicy?: 'open' | 'closed';
+  allowedDirectories?: string[];
+  enableExternalAccess?: boolean;
+  lockConfiguration?: boolean;
+  autoloadKnownExtensions?: boolean;
+  autoinstallKnownExtensions?: boolean;
+  allowCommunityExtensions?: boolean;
+  allowUnsignedExtensions?: boolean;
+  tempFileEncryption?: boolean;
+  threads?: number;
+  memoryLimit?: string;
+  tempDirectory?: string;
+  extensionDirectory?: string;
 }
 
 interface ActiveDB {
@@ -49,10 +71,11 @@ interface ActiveDB {
 
 export class DuckDBConnection extends DuckDBCommon {
   public readonly name: string;
-  private additionalExtensions: string[] = [];
-  private databasePath = ':memory:';
-  private workingDirectory = '.';
-  private readOnly = false;
+  private readonly normalized: NormalizedDuckDBConfig;
+  private readonly shareKey: string;
+  private readonly digestDatabasePath: string;
+  private readonly digestWorkingDirectory?: string;
+  private readonly digestSetupSQL?: string;
 
   connecting: Promise<void>;
   protected connection: DuckDBNodeConnection | null = null;
@@ -79,107 +102,65 @@ export class DuckDBConnection extends DuckDBCommon {
   ) {
     super();
 
+    const options =
+      typeof arg === 'string'
+        ? buildLegacyOptions(arg, arg2, workingDirectory)
+        : arg;
+    this.name = options.name;
+
     if (typeof arg === 'string') {
-      this.name = arg;
-      if (typeof arg2 === 'string') {
-        this.databasePath = arg2;
-      }
-      if (typeof workingDirectory === 'string') {
-        this.workingDirectory = workingDirectory;
-      }
       if (queryOptions) {
         this.queryOptions = queryOptions;
       }
-    } else {
-      this.name = arg.name;
-      if (arg2) {
-        this.queryOptions = arg2 as QueryOptionsReader;
-      }
-      if (typeof arg.readOnly === 'boolean') {
-        this.readOnly = arg.readOnly;
-      }
-      if (typeof arg.databasePath === 'string') {
-        this.databasePath = arg.databasePath;
-      }
-      if (typeof arg.workingDirectory === 'string') {
-        this.workingDirectory = arg.workingDirectory;
-      }
-      if (typeof arg.motherDuckToken === 'string') {
-        this.motherDuckToken = arg.motherDuckToken;
-      }
-      if (Array.isArray(arg.additionalExtensions)) {
-        this.additionalExtensions = arg.additionalExtensions;
-      }
-      if (typeof arg.setupSQL === 'string') {
-        this.setupSQL = arg.setupSQL;
-      }
+    } else if (arg2) {
+      this.queryOptions = arg2 as QueryOptionsReader;
     }
-    if (this.databasePath === ':memory:') {
-      this.readOnly = false;
-    }
+
+    this.digestDatabasePath = options.databasePath ?? ':memory:';
+    this.digestWorkingDirectory = options.workingDirectory;
+    this.digestSetupSQL =
+      typeof options.setupSQL === 'string' ? options.setupSQL : undefined;
+
+    this.normalized = normalizeDuckDBConfig(options);
+    this.shareKey = buildDuckDBShareKey(this.normalized);
     this.isMotherDuck =
-      this.databasePath.startsWith('md:') ||
-      this.databasePath.startsWith('motherduck:');
+      this.normalized.databasePath.startsWith('md:') ||
+      this.normalized.databasePath.startsWith('motherduck:');
+    this.motherDuckToken = this.normalized.motherDuckToken;
+    this.setupSQL = this.normalized.setupSQL;
     this.connecting = this.init();
   }
 
   public getDigest(): string {
     return makeDigest(
       'duckdb',
-      this.databasePath,
-      this.workingDirectory,
-      this.setupSQL
+      this.digestDatabasePath,
+      this.digestWorkingDirectory,
+      this.digestSetupSQL
     );
   }
 
   private async init(): Promise<void> {
     try {
-      if (this.databasePath in DuckDBConnection.activeDBs) {
-        const activeDB = DuckDBConnection.activeDBs[this.databasePath];
-        this.connection = await activeDB.instance.connect();
-        activeDB.connections.push(this.connection);
-      } else {
-        const config: Record<string, string> = {
-          custom_user_agent: `Malloy/${packageJson.version}`,
-        };
-        if (this.isMotherDuck) {
-          if (
-            !this.motherDuckToken &&
-            !process.env['motherduck_token'] &&
-            !process.env['MOTHERDUCK_TOKEN']
-          ) {
-            this.setupError = new Error('Please set your MotherDuck Token');
-            return;
-          }
-          if (this.motherDuckToken) {
-            config['motherduck_token'] = this.motherDuckToken;
-          }
-        }
-        if (this.readOnly) {
-          config['access_mode'] = 'READ_ONLY';
-        }
-
-        const instance = await DuckDBInstance.create(this.databasePath, config);
-        this.connection = await instance.connect();
-
-        const activeDB: ActiveDB = {
-          instance,
-          connections: [this.connection],
-        };
-        DuckDBConnection.activeDBs[this.databasePath] = activeDB;
+      const cached = DuckDBConnection.activeDBs[this.shareKey];
+      if (cached) {
+        this.connection = await cached.instance.connect();
+        cached.connections.push(this.connection);
+        return;
       }
+
+      const instance = await DuckDBInstance.create(
+        this.normalized.databasePath,
+        this.buildInstanceOptions()
+      );
+      this.connection = await instance.connect();
+
+      DuckDBConnection.activeDBs[this.shareKey] = {
+        instance,
+        connections: [this.connection],
+      };
     } catch (err) {
       this.setupError = err instanceof Error ? err : new Error(String(err));
-    }
-  }
-
-  async loadExtension(ext: string) {
-    try {
-      await this.runDuckDBQuery(`INSTALL '${ext}'`);
-      await this.runDuckDBQuery(`LOAD '${ext}'`);
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Unable to load ${ext} extension', error);
     }
   }
 
@@ -187,47 +168,200 @@ export class DuckDBConnection extends DuckDBCommon {
     if (this.setupError) {
       throw this.setupError;
     }
-    const doSetup = async () => {
-      if (this.workingDirectory) {
-        await this.runDuckDBQuery(
-          `SET FILE_SEARCH_PATH='${this.workingDirectory}'`
-        );
-      }
-      const extensions = [
-        'json',
-        'httpfs',
-        'icu',
-        ...this.additionalExtensions,
-      ];
-      if (this.databasePath.startsWith('md:')) {
-        extensions.push('motherduck');
-      }
-      for (const ext of extensions) {
-        await this.loadExtension(ext);
-      }
-      const setupCmds = ["SET TimeZone='UTC'"];
-      for (const cmd of setupCmds) {
-        try {
-          await this.runDuckDBQuery(cmd);
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.error(`duckdb setup ${cmd} => ${error}`);
-        }
-      }
-      if (this.setupSQL) {
-        for (const stmt of this.setupSQL.split(';\n')) {
-          const trimmed = stmt.trim();
-          if (trimmed) {
-            await this.runDuckDBQuery(trimmed);
-          }
-        }
-      }
-    };
+
     await this.connecting;
+    if (this.setupError) {
+      throw this.setupError;
+    }
+
     if (!this.isSetup) {
-      this.isSetup = doSetup();
+      this.isSetup = this.setupOnce();
     }
     await this.isSetup;
+  }
+
+  private async setupOnce(): Promise<void> {
+    await this.applyFinalBaseline();
+
+    if (this.normalized.setupSQL) {
+      for (const statement of splitSetupSQL(this.normalized.setupSQL)) {
+        await this.runDuckDBQuery(statement);
+      }
+    }
+
+    if (this.normalized.lockConfiguration) {
+      await this.runDuckDBQuery('SET lock_configuration=true');
+    }
+  }
+
+  private buildInstanceOptions(): Record<string, string> {
+    const options: Record<string, string> = {
+      custom_user_agent: `Malloy/${packageJson.version}`,
+    };
+
+    if (this.normalized.motherDuckToken !== undefined) {
+      options['motherduck_token'] = this.normalized.motherDuckToken;
+    }
+    if (this.normalized.readOnly) {
+      options['access_mode'] = 'READ_ONLY';
+    }
+    if (this.normalized.autoloadKnownExtensions !== undefined) {
+      options['autoload_known_extensions'] = stringifyDuckDBOption(
+        this.normalized.autoloadKnownExtensions
+      );
+    }
+    if (this.normalized.autoinstallKnownExtensions !== undefined) {
+      options['autoinstall_known_extensions'] = stringifyDuckDBOption(
+        this.normalized.autoinstallKnownExtensions
+      );
+    }
+    if (this.normalized.allowCommunityExtensions !== undefined) {
+      options['allow_community_extensions'] = stringifyDuckDBOption(
+        this.normalized.allowCommunityExtensions
+      );
+    }
+    if (this.normalized.allowUnsignedExtensions !== undefined) {
+      options['allow_unsigned_extensions'] = stringifyDuckDBOption(
+        this.normalized.allowUnsignedExtensions
+      );
+    }
+    if (this.normalized.tempFileEncryption !== undefined) {
+      options['temp_file_encryption'] = stringifyDuckDBOption(
+        this.normalized.tempFileEncryption
+      );
+    }
+    if (this.normalized.threads !== undefined) {
+      options['threads'] = stringifyDuckDBOption(this.normalized.threads);
+    }
+    if (this.normalized.memoryLimit !== undefined) {
+      options['memory_limit'] = this.normalized.memoryLimit;
+    }
+    if (this.normalized.tempDirectory !== undefined) {
+      options['temp_directory'] = this.normalized.tempDirectory;
+    }
+    if (this.normalized.extensionDirectory !== undefined) {
+      options['extension_directory'] = this.normalized.extensionDirectory;
+    }
+    if (this.shouldApplyEnableExternalAccessAtOpenTime()) {
+      options['enable_external_access'] = stringifyDuckDBOption(
+        this.normalized.enableExternalAccess!
+      );
+    }
+
+    return options;
+  }
+
+  private shouldApplyEnableExternalAccessAtOpenTime(): boolean {
+    // DuckDB's Node API does not currently accept allowed_directories as an
+    // open-time option, and DuckDB rejects SET allowed_directories after
+    // enable_external_access=false. Apply the disable at open time unless a
+    // post-connect allowlist SET is required.
+    return (
+      this.normalized.enableExternalAccess !== undefined &&
+      this.normalized.allowedDirectories === undefined
+    );
+  }
+
+  private async applyFinalBaseline(): Promise<void> {
+    if (this.normalized.allowedDirectories !== undefined) {
+      await this.runDuckDBQuery(
+        `SET allowed_directories=${sqlStringListLiteral(
+          this.normalized.allowedDirectories
+        )}`
+      );
+    }
+
+    if (
+      this.normalized.enableExternalAccess !== undefined &&
+      !this.shouldApplyEnableExternalAccessAtOpenTime()
+    ) {
+      await this.runDuckDBQuery(
+        `SET enable_external_access=${this.normalized.enableExternalAccess}`
+      );
+    }
+
+    if (this.normalized.workingDirectory !== undefined) {
+      await this.runDuckDBQuery(
+        `SET FILE_SEARCH_PATH=${sqlStringLiteral(
+          this.normalized.workingDirectory
+        )}`
+      );
+    }
+
+    if (this.normalized.secretDirectory !== undefined) {
+      await this.runDuckDBQuery(
+        `SET secret_directory=${sqlStringLiteral(
+          this.normalized.secretDirectory
+        )}`
+      );
+    }
+
+    await this.runDuckDBQuery("SET TimeZone='UTC'");
+    await this.loadBaselineExtensions();
+  }
+
+  private async loadBaselineExtensions(): Promise<void> {
+    if (this.normalized.networkPolicy === 'closed') {
+      await this.loadExtension('json', {allowInstall: false, required: true});
+      await this.loadExtension('icu', {allowInstall: false, required: true});
+      return;
+    }
+
+    const allowInstall = this.normalized.enableExternalAccess !== false;
+    await this.loadExtension('json', {allowInstall, required: false});
+    await this.loadExtension('icu', {allowInstall, required: false});
+
+    if (this.shouldLoadHttpfs()) {
+      await this.loadExtension('httpfs', {allowInstall, required: false});
+    }
+
+    for (const extension of this.normalized.additionalExtensions) {
+      await this.loadExtension(extension, {allowInstall, required: false});
+    }
+
+    if (this.isMotherDuck) {
+      await this.loadExtension('motherduck', {allowInstall, required: false});
+    }
+  }
+
+  private shouldLoadHttpfs(): boolean {
+    if (this.normalized.networkPolicy === 'closed') {
+      return false;
+    }
+    return this.normalized.enableExternalAccess !== false;
+  }
+
+  private async loadExtension(
+    extension: string,
+    options: {allowInstall: boolean; required: boolean}
+  ): Promise<void> {
+    try {
+      await this.runDuckDBQuery(`LOAD ${sqlStringLiteral(extension)}`);
+      return;
+    } catch (loadError) {
+      if (!options.allowInstall) {
+        if (options.required) {
+          throw loadError;
+        }
+        // eslint-disable-next-line no-console
+        console.error(
+          `Unable to load DuckDB extension "${extension}"`,
+          loadError
+        );
+        return;
+      }
+    }
+
+    try {
+      await this.runDuckDBQuery(`INSTALL ${sqlStringLiteral(extension)}`);
+      await this.runDuckDBQuery(`LOAD ${sqlStringLiteral(extension)}`);
+    } catch (error) {
+      if (options.required) {
+        throw error;
+      }
+      // eslint-disable-next-line no-console
+      console.error(`Unable to load DuckDB extension "${extension}"`, error);
+    }
   }
 
   protected async runDuckDBQuery(
@@ -238,7 +372,6 @@ export class DuckDBConnection extends DuckDBCommon {
     }
 
     const result = await this.connection.run(sql);
-    // getRowObjectsJson() converts nested types (LIST, STRUCT) to JS arrays/objects
     const rows = (await result.getRowObjectsJson()) as QueryRecord[];
 
     return {
@@ -283,14 +416,14 @@ export class DuckDBConnection extends DuckDBCommon {
   }
 
   async close(): Promise<void> {
-    const activeDB = DuckDBConnection.activeDBs[this.databasePath];
+    const activeDB = DuckDBConnection.activeDBs[this.shareKey];
     if (activeDB) {
       activeDB.connections = activeDB.connections.filter(
         connection => connection !== this.connection
       );
       if (activeDB.connections.length === 0) {
         activeDB.instance.closeSync();
-        delete DuckDBConnection.activeDBs[this.databasePath];
+        delete DuckDBConnection.activeDBs[this.shareKey];
       }
     }
   }
@@ -300,13 +433,33 @@ export class DuckDBConnection extends DuckDBCommon {
    * to release file locks between test runs.
    */
   static closeAllInstances(): void {
-    for (const path of Object.keys(DuckDBConnection.activeDBs)) {
+    for (const key of Object.keys(DuckDBConnection.activeDBs)) {
       try {
-        DuckDBConnection.activeDBs[path].instance.closeSync();
+        DuckDBConnection.activeDBs[key].instance.closeSync();
       } catch {
         // Ignore errors during cleanup
       }
     }
     DuckDBConnection.activeDBs = {};
   }
+}
+
+function buildLegacyOptions(
+  name: string,
+  databasePathOrQueryOptions?: string | QueryOptionsReader,
+  workingDirectory?: string
+): DuckDBConnectionOptions {
+  const options: DuckDBConnectionOptions = {name};
+  if (typeof databasePathOrQueryOptions === 'string') {
+    options.databasePath = databasePathOrQueryOptions;
+  }
+  options.workingDirectory = workingDirectory ?? '.';
+  return options;
+}
+
+function splitSetupSQL(setupSQL: string): string[] {
+  return setupSQL
+    .split(';\n')
+    .map(statement => statement.trim())
+    .filter(statement => statement !== '');
 }

--- a/packages/malloy-db-duckdb/src/duckdb_restricted.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_restricted.spec.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {DuckDBInstance} from '@duckdb/node-api';
+import type {QueryRecord} from '@malloydata/malloy';
+import {DuckDBConnection} from './duckdb_connection';
+import {DuckDBConfigValidationError} from './duckdb_config';
+
+type DuckDBConnectionWithRun = DuckDBConnection & {
+  runDuckDBQuery(
+    sql: string
+  ): Promise<{rows: QueryRecord[]; totalRows: number}>;
+};
+
+describe('DuckDB restricted configuration', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'malloy-duckdb-sec-'));
+  const workingDirectory = path.join(tempRoot, 'working');
+  const sharedDatabasePath = path.join(tempRoot, 'shared.duckdb');
+  const secondAllowedDirectory = path.join(tempRoot, 'allowed-b');
+  const canonical = (value: string) => fs.realpathSync.native(value);
+
+  beforeAll(() => {
+    fs.mkdirSync(workingDirectory, {recursive: true});
+    fs.mkdirSync(secondAllowedDirectory, {recursive: true});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    DuckDBConnection.closeAllInstances();
+  });
+
+  it('rejects setupSQL when a restricted policy requires a locked baseline', () => {
+    const createSpy = jest.spyOn(DuckDBInstance, 'create');
+
+    expect(
+      () =>
+        new DuckDBConnection({
+          name: 'duckdb',
+          filesystemPolicy: 'sandboxed',
+          workingDirectory,
+          setupSQL: 'SET FILE_SEARCH_PATH=/tmp',
+        })
+    ).toThrow(DuckDBConfigValidationError);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes enable_external_access=false at open time when no allowlist SET is needed', async () => {
+    const createSpy = jest.spyOn(DuckDBInstance, 'create');
+    const connection = new DuckDBConnection({
+      name: 'duckdb-network-closed',
+      networkPolicy: 'closed',
+      workingDirectory,
+    });
+
+    try {
+      await connection.runSQL('SELECT 1');
+
+      expect(createSpy).toHaveBeenCalledWith(
+        ':memory:',
+        expect.objectContaining({enable_external_access: 'false'})
+      );
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('does not share native instances when safety-relevant settings differ', async () => {
+    const openConnection = new DuckDBConnection({
+      name: 'duckdb-open',
+      databasePath: sharedDatabasePath,
+      workingDirectory,
+    });
+    let closedConnection: DuckDBConnection | undefined;
+
+    try {
+      await openConnection.runSQL('SELECT 1');
+      closedConnection = new DuckDBConnection({
+        name: 'duckdb-closed',
+        databasePath: sharedDatabasePath,
+        workingDirectory,
+        networkPolicy: 'closed',
+      });
+      await closedConnection.runSQL('SELECT 1');
+
+      expect(Object.keys(DuckDBConnection.activeDBs)).toHaveLength(2);
+    } finally {
+      await openConnection.close();
+      await closedConnection?.close();
+    }
+  });
+
+  it('does share native instances for semantically identical allowlists', async () => {
+    const firstConnection = new DuckDBConnection({
+      name: 'duckdb-first',
+      filesystemPolicy: 'sandboxed',
+      workingDirectory,
+      allowedDirectories: [workingDirectory, secondAllowedDirectory],
+    });
+    const secondConnection = new DuckDBConnection({
+      name: 'duckdb-second',
+      filesystemPolicy: 'sandboxed',
+      workingDirectory,
+      allowedDirectories: [
+        secondAllowedDirectory,
+        workingDirectory,
+        workingDirectory,
+      ],
+    });
+
+    try {
+      await firstConnection.runSQL('SELECT 1');
+      await secondConnection.runSQL('SELECT 1');
+
+      expect(Object.keys(DuckDBConnection.activeDBs)).toHaveLength(1);
+    } finally {
+      await firstConnection.close();
+      await secondConnection.close();
+    }
+  });
+
+  it('applies the restricted baseline before locking configuration', async () => {
+    const queries: string[] = [];
+    const prototype =
+      DuckDBConnection.prototype as unknown as DuckDBConnectionWithRun;
+    const originalRunDuckDBQuery = prototype.runDuckDBQuery;
+    jest.spyOn(prototype, 'runDuckDBQuery').mockImplementation(function (
+      this: DuckDBConnectionWithRun,
+      sql: string
+    ) {
+      queries.push(sql);
+      return originalRunDuckDBQuery.call(this, sql);
+    });
+
+    const connection = new DuckDBConnection({
+      name: 'duckdb-restricted',
+      filesystemPolicy: 'sandboxed',
+      networkPolicy: 'closed',
+      workingDirectory,
+    });
+
+    try {
+      await connection.runSQL('SELECT 1');
+
+      expect(queries).toContain(
+        `SET allowed_directories=['${canonical(workingDirectory)}']`
+      );
+      expect(queries).toContain('SET enable_external_access=false');
+      expect(queries).toContain("SET TimeZone='UTC'");
+      expect(queries).toContain("LOAD 'json'");
+      expect(queries).toContain("LOAD 'icu'");
+      expect(queries).toContain('SET lock_configuration=true');
+      expect(queries.some(query => query.startsWith('INSTALL '))).toBe(false);
+      expect(queries).not.toContain("LOAD 'httpfs'");
+
+      const lockIndex = queries.indexOf('SET lock_configuration=true');
+      const allowedIndex = queries.indexOf(
+        `SET allowed_directories=['${canonical(workingDirectory)}']`
+      );
+      const externalAccessIndex = queries.indexOf(
+        'SET enable_external_access=false'
+      );
+      expect(externalAccessIndex).toBeGreaterThan(allowedIndex);
+      expect(externalAccessIndex).toBeLessThan(queries.indexOf("LOAD 'json'"));
+      expect(lockIndex).toBeGreaterThan(queries.indexOf("LOAD 'json'"));
+      expect(lockIndex).toBeGreaterThan(queries.indexOf("LOAD 'icu'"));
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('locks down the session and keeps httpfs unloaded when networkPolicy is closed', async () => {
+    const connection = new DuckDBConnection({
+      name: 'duckdb-restricted',
+      filesystemPolicy: 'sandboxed',
+      networkPolicy: 'closed',
+      workingDirectory,
+    });
+
+    try {
+      const settings = await connection.runSQL(`
+        SELECT
+          current_setting('lock_configuration') AS lock_configuration,
+          current_setting('enable_external_access') AS enable_external_access,
+          current_setting('allowed_directories') AS allowed_directories,
+          current_setting('secret_directory') AS secret_directory,
+          current_setting('temp_directory') AS temp_directory
+      `);
+      expect(settings.rows[0]['lock_configuration']).toBe(true);
+      expect(settings.rows[0]['enable_external_access']).toBe(false);
+      expect(settings.rows[0]['allowed_directories']).toEqual(
+        expect.arrayContaining([
+          `${canonical(workingDirectory)}/`,
+          `${canonical(workingDirectory)}/.tmp/`,
+        ])
+      );
+      expect(settings.rows[0]['secret_directory']).toBe(
+        `${canonical(workingDirectory)}/.tmp/.duckdb-secrets`
+      );
+      expect(settings.rows[0]['temp_directory']).toBe(
+        `${canonical(workingDirectory)}/.tmp`
+      );
+
+      await expect(
+        connection.runRawSQL('SET enable_external_access=true')
+      ).rejects.toThrow('configuration has been locked');
+      await expect(connection.runRawSQL("LOAD 'httpfs'")).rejects.toThrow();
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('isolates secrets for network-only restricted mode', async () => {
+    const connection = new DuckDBConnection({
+      name: 'duckdb-network-closed',
+      networkPolicy: 'closed',
+      workingDirectory,
+    });
+
+    try {
+      const settings = await connection.runSQL(`
+        SELECT
+          current_setting('secret_directory') AS secret_directory,
+          current_setting('temp_directory') AS temp_directory,
+          current_setting('enable_external_access') AS enable_external_access,
+          current_setting('lock_configuration') AS lock_configuration
+      `);
+
+      expect(settings.rows[0]['secret_directory']).toBe(
+        `${canonical(workingDirectory)}/.duckdb-secrets`
+      );
+      expect(settings.rows[0]['temp_directory']).toBe('.tmp');
+      expect(settings.rows[0]['enable_external_access']).toBe(false);
+      expect(settings.rows[0]['lock_configuration']).toBe(true);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it('fails closed when a required restricted baseline extension is unavailable', async () => {
+    const prototype =
+      DuckDBConnection.prototype as unknown as DuckDBConnectionWithRun;
+    const originalRunDuckDBQuery = prototype.runDuckDBQuery;
+    jest.spyOn(prototype, 'runDuckDBQuery').mockImplementation(function (
+      this: DuckDBConnectionWithRun,
+      sql: string
+    ) {
+      if (sql === "LOAD 'json'") {
+        return Promise.reject(new Error('missing json extension'));
+      }
+      return originalRunDuckDBQuery.call(this, sql);
+    });
+
+    const connection = new DuckDBConnection({
+      name: 'duckdb-restricted',
+      networkPolicy: 'closed',
+      workingDirectory,
+    });
+
+    try {
+      await expect(connection.runSQL('SELECT 1')).rejects.toThrow(
+        'missing json extension'
+      );
+    } finally {
+      await connection.close();
+    }
+  });
+});

--- a/packages/malloy-db-duckdb/src/native.ts
+++ b/packages/malloy-db-duckdb/src/native.ts
@@ -16,13 +16,6 @@ registerConnectionType('duckdb', {
       options['databasePath'] = options['path'];
       delete options['path'];
     }
-    // Parse comma-separated extensions string into array
-    if (typeof options['additionalExtensions'] === 'string') {
-      options['additionalExtensions'] = options['additionalExtensions']
-        .split(',')
-        .map(s => s.trim())
-        .filter(s => s.length > 0);
-    }
     return new DuckDBConnection(options);
   },
   properties: [
@@ -44,6 +37,92 @@ registerConnectionType('duckdb', {
       // data paths that stay stable regardless of where the config file
       // happens to live inside the project.
       default: {config: 'rootDirectory'},
+    },
+    {
+      name: 'filesystemPolicy',
+      displayName: 'Filesystem Policy',
+      type: 'string',
+      optional: true,
+      requireLiteralString: true,
+    },
+    {
+      name: 'networkPolicy',
+      displayName: 'Network Policy',
+      type: 'string',
+      optional: true,
+      requireLiteralString: true,
+    },
+    {
+      name: 'allowedDirectories',
+      displayName: 'Allowed Directories',
+      type: 'json',
+      optional: true,
+    },
+    {
+      name: 'enableExternalAccess',
+      displayName: 'Enable External Access',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'lockConfiguration',
+      displayName: 'Lock Configuration',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'autoloadKnownExtensions',
+      displayName: 'Autoload Known Extensions',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'autoinstallKnownExtensions',
+      displayName: 'Autoinstall Known Extensions',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'allowCommunityExtensions',
+      displayName: 'Allow Community Extensions',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'allowUnsignedExtensions',
+      displayName: 'Allow Unsigned Extensions',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'tempFileEncryption',
+      displayName: 'Temp File Encryption',
+      type: 'boolean',
+      optional: true,
+    },
+    {
+      name: 'threads',
+      displayName: 'Threads',
+      type: 'number',
+      optional: true,
+    },
+    {
+      name: 'memoryLimit',
+      displayName: 'Memory Limit',
+      type: 'string',
+      optional: true,
+    },
+    {
+      name: 'tempDirectory',
+      displayName: 'Temp Directory',
+      type: 'file',
+      optional: true,
+    },
+    {
+      name: 'extensionDirectory',
+      displayName: 'Extension Directory',
+      type: 'file',
+      optional: true,
     },
     {
       name: 'motherDuckToken',

--- a/packages/malloy-db-duckdb/src/path_security.ts
+++ b/packages/malloy-db-duckdb/src/path_security.ts
@@ -79,8 +79,18 @@ function isENOENT(error: unknown): boolean {
 }
 
 function stripTrailingSeparator(value: string): string {
-  if (value === path.parse(value).root) {
+  const root = path.parse(value).root;
+  if (value === root) {
     return value;
   }
-  return value.replace(/[\\/]+$/, '');
+
+  let end = value.length;
+  while (end > root.length && isPathSeparator(value.charCodeAt(end - 1))) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function isPathSeparator(charCode: number): boolean {
+  return charCode === 47 || charCode === 92;
 }

--- a/packages/malloy-db-duckdb/src/path_security.ts
+++ b/packages/malloy-db-duckdb/src/path_security.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface CanonicalPathOptions {
+  mustExist?: boolean;
+}
+
+export function isPosixHost(): boolean {
+  return path.sep === '/';
+}
+
+export function canonicalizePath(
+  input: string,
+  {mustExist = false}: CanonicalPathOptions = {}
+): string {
+  if (input.trim() === '') {
+    throw new Error('path must not be empty');
+  }
+
+  const resolved = path.resolve(input);
+  const canonical = (() => {
+    try {
+      return fs.realpathSync.native(resolved);
+    } catch (error) {
+      if (mustExist || !isENOENT(error)) {
+        throw error;
+      }
+      return canonicalizeMissingPath(resolved);
+    }
+  })();
+
+  return stripTrailingSeparator(path.normalize(canonical));
+}
+
+export function canonicalizePathList(paths: string[]): string[] {
+  return Array.from(new Set(paths.map(p => canonicalizePath(p)).sort()));
+}
+
+export function isContainedPath(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  );
+}
+
+function canonicalizeMissingPath(resolved: string): string {
+  const parent = path.dirname(resolved);
+  if (parent === resolved) {
+    return resolved;
+  }
+
+  const realParent = (() => {
+    try {
+      return fs.realpathSync.native(parent);
+    } catch (error) {
+      if (!isENOENT(error)) {
+        throw error;
+      }
+      return canonicalizeMissingPath(parent);
+    }
+  })();
+
+  return path.join(realParent, path.basename(resolved));
+}
+
+function isENOENT(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  );
+}
+
+function stripTrailingSeparator(value: string): string {
+  if (value === path.parse(value).root) {
+    return value;
+  }
+  return value.replace(/[\\/]+$/, '');
+}

--- a/packages/malloy-db-snowflake/src/snowflake_table_name.ts
+++ b/packages/malloy-db-snowflake/src/snowflake_table_name.ts
@@ -81,14 +81,13 @@ class SnowflakeTableNameParser extends TinyParser {
 export function parseSnowflakeTableName(
   src: string
 ): ParsedSnowflakeTableName | undefined {
-  let parts: SnowflakeIdentPart[];
   try {
-    parts = new SnowflakeTableNameParser(src).parts();
+    const parts = new SnowflakeTableNameParser(src).parts();
+    if (parts.length < 1 || parts.length > 3) return undefined;
+    if (parts.length === 1) return {table: parts[0]};
+    if (parts.length === 2) return {schema: parts[0], table: parts[1]};
+    return {database: parts[0], schema: parts[1], table: parts[2]};
   } catch {
     return undefined;
   }
-  if (parts.length < 1 || parts.length > 3) return undefined;
-  if (parts.length === 1) return {table: parts[0]};
-  if (parts.length === 2) return {schema: parts[0], table: parts[1]};
-  return {database: parts[0], schema: parts[1], table: parts[2]};
 }

--- a/packages/malloy/src/api/foundation/config.spec.ts
+++ b/packages/malloy/src/api/foundation/config.spec.ts
@@ -6,9 +6,15 @@
 import {MalloyConfig} from './config';
 import {contextOverlay} from './config_overlays';
 import {discoverConfig} from './config_discover';
-import {registerConnectionType} from '../../connection/registry';
+import {
+  createConnectionsFromConfig,
+  registerConnectionType,
+} from '../../connection/registry';
 import type {ConnectionConfig, Connection} from '../../connection/types';
 import type {URLReader} from '../../runtime_types';
+
+let capturedStrictMode: unknown;
+let strictFactoryCalls = 0;
 
 function mockConnection(name: string, dialectName = 'mock'): Connection {
   return {
@@ -48,6 +54,8 @@ function mockReader(files: Record<string, unknown>): URLReader {
 }
 
 beforeEach(() => {
+  capturedStrictMode = undefined;
+  strictFactoryCalls = 0;
   registerConnectionType('mockdb', {
     displayName: 'MockDB',
     factory: async (config: ConnectionConfig) =>
@@ -70,6 +78,23 @@ beforeEach(() => {
     properties: [
       {name: 'host', displayName: 'Host', type: 'string', optional: true},
       {name: 'ssl', displayName: 'SSL', type: 'json', optional: true},
+    ],
+  });
+  registerConnectionType('strictdb', {
+    displayName: 'StrictDB',
+    factory: async (config: ConnectionConfig) => {
+      strictFactoryCalls += 1;
+      capturedStrictMode = config['mode'];
+      return mockConnection(config.name, 'strictdb-dialect');
+    },
+    properties: [
+      {
+        name: 'mode',
+        displayName: 'Mode',
+        type: 'string',
+        optional: true,
+        requireLiteralString: true,
+      },
     ],
   });
 });
@@ -672,5 +697,59 @@ describe('MalloyConfig property defaults and includeDefaultConnections', () => {
     await config.connections.lookupConnection('myref');
     expect(capturedRoot).toBeUndefined();
     expect(capturedFlavor).toBe('vanilla');
+  });
+});
+
+describe('MalloyConfig fail-closed literal string properties', () => {
+  it('passes through exact literal strings', async () => {
+    const config = new MalloyConfig({
+      connections: {strict: {is: 'strictdb', mode: 'sandboxed'}},
+    });
+
+    await config.connections.lookupConnection('strict');
+    expect(capturedStrictMode).toBe('sandboxed');
+    expect(strictFactoryCalls).toBe(1);
+  });
+
+  it('does not silently drop mistyped values', async () => {
+    const config = new MalloyConfig({
+      connections: {strict: {is: 'strictdb', mode: true}},
+    });
+
+    await expect(config.connections.lookupConnection('strict')).rejects.toThrow(
+      'Connection "strict" property "mode" must be a literal string'
+    );
+    expect(capturedStrictMode).toBeUndefined();
+    expect(strictFactoryCalls).toBe(0);
+    expect(config.log.map(entry => entry.message)).toContain(
+      'connections.strict.mode: must be a literal string, got boolean'
+    );
+  });
+
+  it('does not accept reference-shaped values', async () => {
+    const config = new MalloyConfig({
+      connections: {strict: {is: 'strictdb', mode: {env: 'STRICT_MODE'}}},
+    });
+
+    await expect(config.connections.lookupConnection('strict')).rejects.toThrow(
+      'Connection "strict" property "mode" must be a literal string'
+    );
+    expect(capturedStrictMode).toBeUndefined();
+    expect(strictFactoryCalls).toBe(0);
+    expect(config.log.map(entry => entry.message)).toContain(
+      'connections.strict.mode: must be a literal string and cannot use an overlay reference'
+    );
+  });
+
+  it('enforces literal string properties in resolved registry configs', async () => {
+    const lookup = createConnectionsFromConfig({
+      connections: {strict: {is: 'strictdb', mode: {env: 'STRICT_MODE'}}},
+    });
+
+    await expect(lookup.lookupConnection('strict')).rejects.toThrow(
+      'Connection "strict" property "mode" must be a literal string'
+    );
+    expect(capturedStrictMode).toBeUndefined();
+    expect(strictFactoryCalls).toBe(0);
   });
 });

--- a/packages/malloy/src/api/foundation/config_compile.ts
+++ b/packages/malloy/src/api/foundation/config_compile.ts
@@ -226,11 +226,29 @@ function compileConnectionProperty(
 
   const ref = asReferenceShape(value);
   if (ref !== undefined) {
+    if (propDef.requireLiteralString) {
+      log.push(
+        makeWarning(
+          path,
+          'must be a literal string and cannot use an overlay reference'
+        )
+      );
+      return {kind: 'value', value};
+    }
     return ref;
   }
 
   const typeError = checkValueType(value, propDef.type);
   if (typeError) {
+    if (propDef.requireLiteralString) {
+      log.push(
+        makeWarning(
+          path,
+          `must be a literal string, got ${describeConfigValue(value)}`
+        )
+      );
+      return {kind: 'value', value};
+    }
     log.push(makeWarning(path, `${typeError} (expected ${propDef.type})`));
     return undefined;
   }
@@ -312,6 +330,11 @@ function makeWarning(path: string, message: string): LogMessage {
     severity: 'warn',
     code: 'config-validation',
   };
+}
+
+function describeConfigValue(value: unknown): string {
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
 }
 
 function checkValueType(

--- a/packages/malloy/src/api/foundation/config_lookup.ts
+++ b/packages/malloy/src/api/foundation/config_lookup.ts
@@ -7,6 +7,7 @@ import type {LogMessage} from '../../lang/parse-log';
 import {
   getConnectionProperties,
   getConnectionTypeDef,
+  validateConnectionConfigProperties,
 } from '../../connection/registry';
 import type {
   ConnectionConfigEntry,
@@ -99,6 +100,11 @@ export function buildManagedLookup(
         }
       }
 
+      validateConnectionConfigProperties(
+        connectionName,
+        resolved.is,
+        connConfig
+      );
       const connection = await typeDef.factory(connConfig);
       cache.set(connectionName, connection);
       return connection;

--- a/packages/malloy/src/connection/registry.ts
+++ b/packages/malloy/src/connection/registry.ts
@@ -44,6 +44,13 @@ export interface ConnectionPropertyDefinition {
   description?: string;
   /** For type 'file': extension filters for picker dialogs. */
   fileFilters?: Record<string, string[]>;
+  /**
+   * For security-sensitive string slots, preserve malformed/reference-shaped
+   * raw values so registry lookup can fail closed instead of silently dropping
+   * the property during generic compilation. Factories must not rely on this
+   * metadata as their only validation layer.
+   */
+  requireLiteralString?: true;
 }
 
 /**
@@ -155,6 +162,27 @@ export function getConnectionTypeDef(
 }
 
 /**
+ * Enforce registry-level literal-string requirements after overlay resolution
+ * and before a connection factory sees the config.
+ */
+export function validateConnectionConfigProperties(
+  connectionName: string,
+  typeName: string,
+  config: ConnectionConfig
+): void {
+  const props = registry.get(typeName)?.properties ?? [];
+  for (const prop of props) {
+    if (!prop.requireLiteralString) continue;
+    const value = config[prop.name];
+    if (value !== undefined && typeof value !== 'string') {
+      throw new Error(
+        `Connection "${connectionName}" property "${prop.name}" must be a literal string`
+      );
+    }
+  }
+}
+
+/**
  * Parse a JSON config string into a ConnectionsConfig.
  * Entries without a valid `is` field are silently dropped.
  */
@@ -241,6 +269,7 @@ export function createConnectionsFromConfig(
         }
       }
 
+      validateConnectionConfigProperties(connectionName, entry.is, connConfig);
       const connection = await typeDef.factory(connConfig);
       if (onConnectionCreated) {
         onConnectionCreated(connectionName, connection);


### PR DESCRIPTION
Fixes #2752 

## Summary

Adds two user-facing policy properties to native DuckDB connections so hosts
running untrusted Malloy can describe, in the connection config, what that
Malloy is allowed to reach:

- `filesystemPolicy: "open" | "sandboxed"` — controls DuckDB's filesystem reach
- `networkPolicy: "open" | "closed"` — controls DuckDB's network reach

Also adds a curated set of DuckDB configuration properties
(`allowedDirectories`, `enableExternalAccess`, `lockConfiguration`,
`autoloadKnownExtensions`, `autoinstallKnownExtensions`,
`allowCommunityExtensions`, `allowUnsignedExtensions`, `tempFileEncryption`,
`threads`, `memoryLimit`, `tempDirectory`, `extensionDirectory`) so hosts can
harden a connection directly without opting into a policy.

Defaults are `"open"` on both axes. Nothing in ordinary DuckDB behavior
changes unless the user opts in.

## Reviewed Strict Recipe

```json
{
  "connections": {
    "duckdb": {
      "is": "duckdb",
      "databasePath": "data/app.duckdb",
      "workingDirectory": {"config": "rootDirectory"},
      "filesystemPolicy": "sandboxed",
      "networkPolicy": "closed"
    }
  }
}
```

The two axes also work independently (sandboxed files + open network, or
open files + closed network) for hosts that trust an external boundary on
one side.

## What The Policies Actually Do

`filesystemPolicy: "sandboxed"`:
- derives `allowedDirectories` from `workingDirectory` if omitted
- derives `tempDirectory` as `workingDirectory/.tmp` if omitted
- requires `tempDirectory` to sit inside `allowedDirectories`
- rejects non-POSIX hosts rather than approximating Windows semantics

`networkPolicy: "closed"`:
- forces `enableExternalAccess=false`
- refuses to load `httpfs`
- refuses to `INSTALL` extensions
- rejects remote `databasePath` values (including MotherDuck paths) and
  `motherDuckToken`

Either restricted axis additionally:
- forces `lockConfiguration=true` and `tempFileEncryption=true`
- rejects `setupSQL` and non-empty `additionalExtensions`
- neutralizes ambient persistent DuckDB secrets via a scoped
  `secret_directory`
- loads only the fixed Malloy baseline extensions `icu` and `json`

## Security Contract

- **Fail-closed validation.** Unknown policy values, conflicting explicit
  settings, missing required values, or inability to apply the baseline all
  fail connection creation. No silent downgrade.
- **Structural enforcement of policy values.** `filesystemPolicy` and
  `networkPolicy` are registered with `requireLiteralString: true` so
  mistyped or reference-shaped values fail at registry validation, before
  the DuckDB factory runs.
- **Path canonicalization as security logic.** `databasePath`,
  `workingDirectory`, `allowedDirectories`, `tempDirectory`, and
  `extensionDirectory` are canonicalized (symlinks resolved, `..` stripped,
  trailing separators removed, list values sorted and deduplicated) before
  containment checks and before identity comparison.
- **Share-key identity.** Native DuckDB instances are cached by a share
  key that includes every effective setting that can affect runtime
  behavior, safety, or semantics. A restricted connection cannot share a
  live instance with a less restrictive connection at the same path.
- **Enforced baseline ordering.**
  `SET allowed_directories` → `SET enable_external_access=false` →
  `FILE_SEARCH_PATH` / `secret_directory` → `TimeZone='UTC'` → baseline
  `LOAD` → optional `setupSQL` (unrestricted only) →
  `SET lock_configuration=true`. DuckDB rejects changing
  `allowed_directories` after `enable_external_access=false`, so this order
  is load-bearing. No Malloy-emitted `SET` runs after lock.

## Maintainer Handoff

`packages/malloy-db-duckdb/MAINTENANCE_NOTES.md` is the self-contained
maintainer contract: mental model, core invariants, normalization rules,
path handling, share-key inputs, baseline ordering, and a checklist for
adding new DuckDB config properties or changing policy behavior.
