### PR TITLE
feat(bigquery,snowflake): inline credential config properties

### DIFF
--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -85,7 +85,7 @@ interface BigQueryConnectionConfiguration {
   maximumBytesBilled?: string;
   timeoutMs?: string;
   billingProjectId?: string;
-  credentials?: CredentialBody;
+  credentials?: CredentialBody | Record<string, unknown>;
   setupSQL?: string;
 }
 
@@ -93,6 +93,7 @@ interface BigQueryConnectionOptions extends ConnectionConfig {
   /** This ID is used for Bigquery Table Normalization */
   projectId?: string;
   serviceAccountKeyPath?: string;
+  serviceAccountKey?: Record<string, unknown>;
   location?: string;
   maximumBytesBilled?: string;
   timeoutMs?: string;
@@ -193,10 +194,12 @@ export class BigQueryConnection
     if (typeof arg === 'string') {
       this.name = arg;
     } else {
-      const {name, client_email, private_key, ...args} = arg;
+      const {name, client_email, private_key, serviceAccountKey, ...args} = arg;
       this.name = name;
       config = args;
-      if (client_email || private_key) {
+      if (serviceAccountKey) {
+        config.credentials = serviceAccountKey;
+      } else if (client_email || private_key) {
         config.credentials = {
           client_email,
           private_key,

--- a/packages/malloy-db-bigquery/src/bigquery_connection.ts
+++ b/packages/malloy-db-bigquery/src/bigquery_connection.ts
@@ -36,6 +36,7 @@ import {GaxiosError} from 'gaxios';
 import type {
   Connection,
   ConnectionConfig,
+  ConnectionParameterValue,
   MalloyQueryData,
   PersistSQLResults,
   QueryData,
@@ -85,7 +86,7 @@ interface BigQueryConnectionConfiguration {
   maximumBytesBilled?: string;
   timeoutMs?: string;
   billingProjectId?: string;
-  credentials?: CredentialBody | Record<string, unknown>;
+  credentials?: CredentialBody | {[key: string]: ConnectionParameterValue};
   setupSQL?: string;
 }
 
@@ -93,7 +94,7 @@ interface BigQueryConnectionOptions extends ConnectionConfig {
   /** This ID is used for Bigquery Table Normalization */
   projectId?: string;
   serviceAccountKeyPath?: string;
-  serviceAccountKey?: Record<string, unknown>;
+  serviceAccountKey?: {[key: string]: ConnectionParameterValue};
   location?: string;
   maximumBytesBilled?: string;
   timeoutMs?: string;

--- a/packages/malloy-db-bigquery/src/index.ts
+++ b/packages/malloy-db-bigquery/src/index.ts
@@ -41,10 +41,16 @@ registerConnectionType('bigquery', {
     },
     {
       name: 'serviceAccountKeyPath',
-      displayName: 'Service Account Key',
+      displayName: 'Service Account Key Path',
       type: 'file',
       optional: true,
       fileFilters: {JSON: ['json']},
+    },
+    {
+      name: 'serviceAccountKey',
+      displayName: 'Service Account Key',
+      type: 'json',
+      optional: true,
     },
     {
       name: 'location',

--- a/packages/malloy-db-snowflake/src/index.ts
+++ b/packages/malloy-db-snowflake/src/index.ts
@@ -105,6 +105,12 @@ registerConnectionType('snowflake', {
       },
     },
     {
+      name: 'privateKey',
+      displayName: 'Private Key',
+      type: 'password',
+      optional: true,
+    },
+    {
       name: 'privateKeyPass',
       displayName: 'Private Key Passphrase',
       type: 'password',


### PR DESCRIPTION
## Summary

- **BigQuery**: Add `serviceAccountKey` property (`type: json`) so hosts can pass the full service account key object directly as credentials, instead of writing a temp file for `serviceAccountKeyPath`. The object is forwarded to the Google auth SDK's `credentials` option, which dispatches on the `type` field to handle service accounts, user refresh tokens, external accounts, etc.
- **Snowflake**: Add `privateKey` property (`type: password`) so hosts can pass the PEM string inline instead of requiring `privateKeyPath`. The snowflake-sdk already supports this natively; only the property registration was missing.
- Renamed BigQuery's `serviceAccountKeyPath` displayName from "Service Account Key" to "Service Account Key Path" to disambiguate.

Both changes support publisher and other hosts that receive credentials over the wire and shouldn't need to write temp files.
