### PR TITLE
feat(duckdb): replace filesystemPolicy/networkPolicy with securityPolicy

### DIFF
--- a/packages/malloy-db-duckdb/MAINTENANCE_NOTES.md
+++ b/packages/malloy-db-duckdb/MAINTENANCE_NOTES.md
@@ -10,20 +10,29 @@ must not depend on them for essential context.
 
 ## Mental Model
 
-Malloy exposes two user-facing policy axes for native DuckDB:
+Malloy exposes one user-facing policy property for native DuckDB:
 
-- `filesystemPolicy: "open" | "sandboxed"`
-- `networkPolicy: "open" | "closed"`
+- `securityPolicy: "none" | "local" | "sandboxed"`
 
-Those fields are Malloy policy controls. They are not raw DuckDB option names
-and they are not a general policy language.
+This field is a Malloy policy control. It is not a raw DuckDB option name
+and it is not a general policy language.
 
-The reviewed strict recipe for untrusted Malloy is:
+The three levels form a strict escalation:
 
-- `filesystemPolicy: "sandboxed"`
-- `networkPolicy: "closed"`
+- `"none"` — no security policy applied. Ordinary DuckDB behavior.
+- `"local"` — no network access. DuckDB cannot reach the network, but local
+  filesystem access is not sandboxed to specific directories.
+- `"sandboxed"` — no network access AND filesystem confined to
+  `allowedDirectories`. The reviewed strict recipe.
 
-The implementation compiles those public policy values into an internal
+DuckDB's `enable_external_access` is a single toggle that gates both filesystem
+reach beyond the working directory and network reach. Setting
+`allowed_directories` without disabling `enable_external_access` has no effect.
+This is why the policy is a single axis rather than two independent axes — the
+underlying DuckDB mechanism does not support independent filesystem and network
+control.
+
+The implementation compiles the public policy value into an internal
 `NormalizedDuckDBSafetyPolicy`. That internal object records the derived
 enforcement requirements, such as locked configuration, no setup SQL,
 temp-file encryption, extension restrictions, and secret neutralization. Keep
@@ -41,9 +50,9 @@ process isolation, query cancellation, and host-level quotas separately.
 
 - Native connection schema: `src/native.ts`
   - Registers native DuckDB properties.
-  - `filesystemPolicy` and `networkPolicy` are `requireLiteralString` so
-    invalid reference-shaped or non-string values reach registry validation
-    instead of being silently dropped by generic config compilation.
+  - `securityPolicy` is `requireLiteralString` so invalid reference-shaped or
+    non-string values reach registry validation instead of being silently
+    dropped by generic config compilation.
 - Config compiler literal guard: `../malloy/src/api/foundation/config_compile.ts`
   - Preserves invalid literal-required values as values after warning, allowing
     registry lookup to fail closed before the DuckDB factory runs.
@@ -72,7 +81,7 @@ process isolation, query cancellation, and host-level quotas separately.
   baseline must fail connection creation.
 - Policy validation must run early enough that invalid raw values such as
   `true`, `42`, or `{env: "POLICY"}` cannot be silently dropped and interpreted
-  as the default `"open"` policy.
+  as the default `"none"` policy.
 - A restricted DuckDB connection must never share a live instance with a less
   restrictive or otherwise semantically different connection.
 - The fixed baseline must be established before any Malloy-derived SQL runs.
@@ -85,22 +94,11 @@ process isolation, query cancellation, and host-level quotas separately.
 
 ## User-Facing Policy Behavior
 
-`filesystemPolicy: "open"` means Malloy does not derive a filesystem sandbox.
+`securityPolicy: "none"` means no security policy is applied. Ordinary DuckDB
+behavior.
 
-`filesystemPolicy: "sandboxed"` means Malloy derives and enforces a native
-DuckDB filesystem boundary:
-
-- `allowedDirectories` is required or derived.
-- `tempDirectory` is required or derived.
-- `workingDirectory`, when present, must be inside `allowedDirectories`.
-- `tempDirectory` must be inside `allowedDirectories`.
-- Non-POSIX hosts are rejected. Do not approximate Windows path behavior for
-  the current policy.
-
-`networkPolicy: "open"` means network-capable DuckDB behavior may remain
-available.
-
-`networkPolicy: "closed"` means Malloy disables network-capable DuckDB behavior:
+`securityPolicy: "local"` means Malloy disables network-capable DuckDB
+behavior:
 
 - `enableExternalAccess` is forced to `false`.
 - `httpfs` must not load.
@@ -108,14 +106,20 @@ available.
 - network-requiring `databasePath` values, including MotherDuck paths, are
   rejected.
 - `motherDuckToken` is rejected.
+- configuration is locked after baseline setup.
+- `setupSQL` is not allowed.
+- temp-file encryption is required.
+- secrets are neutralized.
 
-The two axes can be used independently:
+`securityPolicy: "sandboxed"` means everything in `"local"`, plus Malloy
+derives and enforces a native DuckDB filesystem boundary:
 
-- sandboxed filesystem plus open network is allowed, but it is not the reviewed
-  strict recipe.
-- open filesystem plus closed network is allowed, for hosts that trust an
-  external filesystem/container boundary but want Malloy to close DuckDB's
-  network-capable surface.
+- `allowedDirectories` is required or derived.
+- `tempDirectory` is required or derived.
+- `workingDirectory`, when present, must be inside `allowedDirectories`.
+- `tempDirectory` must be inside `allowedDirectories`.
+- Non-POSIX hosts are rejected. Do not approximate Windows path behavior for
+  the current policy.
 
 ## Registered Config Surface
 
@@ -128,10 +132,9 @@ Native DuckDB supports the existing Malloy-facing properties:
 - `readOnly`
 - `setupSQL`
 
-The config extension adds policy properties:
+The config extension adds the policy property:
 
-- `filesystemPolicy`
-- `networkPolicy`
+- `securityPolicy`
 
 It also adds curated DuckDB-level properties:
 
@@ -153,7 +156,7 @@ connection property model does not yet have a first-class string-array type.
 Even though the registry metadata says `json`, DuckDB normalization must require
 the value to be a JSON array of strings. Do not add a registry default for
 `allowedDirectories`; its only defaulting behavior belongs to
-`filesystemPolicy: "sandboxed"` normalization.
+`securityPolicy: "sandboxed"` normalization.
 
 `workingDirectory` defaults to `{config: "rootDirectory"}` in the native DuckDB
 registry. Hosts that know the project root should populate `config.rootDirectory`
@@ -171,28 +174,28 @@ All policy reasoning belongs in `normalizeDuckDBConfig()`.
 
 Policy parsing:
 
-- Missing `filesystemPolicy` defaults to `"open"`.
-- Missing `networkPolicy` defaults to `"open"`.
-- Accepted policy values are exact documented strings only.
+- Missing `securityPolicy` defaults to `"none"`.
+- Accepted policy values are exact documented strings only: `"none"`, `"local"`,
+  `"sandboxed"`.
 - Unknown strings, strings with whitespace or different casing, non-strings,
   and reference-shaped values must fail closed.
 
 Derived safety policy:
 
-- If either policy is restricted, derive:
+- If `securityPolicy` is `"local"` or `"sandboxed"` (i.e., restricted), derive:
   - `requiresLockedConfiguration: true`
   - `requiresNoSetupSQL: true`
   - `requiresTempFileEncryption: true`
   - `requiresSecretNeutralization: true`
   - `forbidAdditionalExtensions: true`
+  - `allowHttpfs: false`
+  - `enableExternalAccess: false`
   - required baseline extensions `icu` and `json`
-- If `filesystemPolicy === "sandboxed"`, also derive:
+  - no extension install or auto-install/autoload expansion
+- If `securityPolicy === "sandboxed"`, also derive:
   - POSIX host required
   - sandboxed path validation required
   - derived temp directory name `.tmp`
-- If `networkPolicy === "closed"`, also derive:
-  - `allowHttpfs: false`
-  - no extension install or auto-install/autoload expansion
 
 Conflict checks:
 
@@ -201,7 +204,7 @@ Conflict checks:
   extension broadening.
 - Reject `lockConfiguration: false` under any restricted policy.
 - Reject `tempFileEncryption: false` under any restricted policy.
-- Under `networkPolicy: "closed"`, reject:
+- Under any restricted policy, reject:
   - `enableExternalAccess: true`
   - `autoloadKnownExtensions: true`
   - `autoinstallKnownExtensions: true`
@@ -210,26 +213,25 @@ Conflict checks:
   - `motherDuckToken`
   - remote or network-requiring `databasePath`
 - Redundant matching values are allowed. For example,
-  `networkPolicy: "closed"` plus `enableExternalAccess: false` is valid.
+  `securityPolicy: "local"` plus `enableExternalAccess: false` is valid.
 
 Derived defaults:
 
-- Under `networkPolicy: "closed"`, force:
+- Under any restricted policy, force:
   - `enableExternalAccess = false`
+  - `lockConfiguration = true`
+  - `tempFileEncryption = true`
   - `autoloadKnownExtensions = false`
   - `autoinstallKnownExtensions = false`
   - `allowCommunityExtensions = false`
   - `allowUnsignedExtensions = false`
-- Under any restricted policy, force:
-  - `lockConfiguration = true`
-  - `tempFileEncryption = true`
-- Under `filesystemPolicy: "sandboxed"`:
+- Under `securityPolicy: "sandboxed"`:
   - If `allowedDirectories` is omitted, derive it to exactly the canonical
     `workingDirectory`, and nothing broader.
   - If `tempDirectory` is omitted, derive it to `workingDirectory/.tmp`.
   - If Malloy cannot derive the required paths safely, fail closed with a
     field-specific error.
-- Outside `filesystemPolicy: "sandboxed"`, do not invent an
+- Outside `securityPolicy: "sandboxed"`, do not invent an
   `allowedDirectories` default.
 - With `databasePath: ":memory:"`, normalize `readOnly` to `false`.
   This intentionally preserves existing behavior. A user-facing warning for
@@ -278,8 +280,7 @@ effective setting that can affect runtime behavior, safety, or semantics:
 
 - `databasePath`
 - `readOnly`
-- `filesystemPolicy`
-- `networkPolicy`
+- `securityPolicy`
 - `setupSQL`
 - canonicalized `allowedDirectories`
 - `enableExternalAccess`
@@ -346,7 +347,7 @@ Current baseline mapping:
   - must be established before lock
 - built-in extension loading
   - preserve ordinary compatibility outside restricted modes
-  - under `networkPolicy: "closed"`, do not `INSTALL`, do not load `httpfs`,
+  - under any restricted policy, do not `INSTALL`, do not load `httpfs`,
     and load only the fixed Malloy baseline extensions
 - `setupSQL`
   - preserve outside restricted modes
@@ -361,9 +362,9 @@ configuration after `lock_configuration=true`.
 `icu` and `json` are part of the fixed Malloy DuckDB baseline.
 
 `httpfs` is not part of that baseline. It broadens remote/network-capable
-behavior and is controlled by `networkPolicy`.
+behavior and is controlled by `securityPolicy`.
 
-Under `networkPolicy: "closed"`:
+Under any restricted policy (`"local"` or `"sandboxed"`):
 
 - do not load `httpfs`
 - do not `INSTALL` extensions
@@ -371,7 +372,7 @@ Under `networkPolicy: "closed"`:
 - load only fixed baseline extensions `icu` and `json`
 - fail closed if a required baseline extension is unavailable locally
 
-Outside `networkPolicy: "closed"`, preserve ordinary compatibility unless a
+Outside restricted policies, preserve ordinary compatibility unless a
 separate product decision changes it.
 
 ## Secrets
@@ -400,11 +401,10 @@ restricted-mode tests.
 
 The policy system described here targets native DuckDB.
 
-Do not register native-only policy fields in the `duckdb_wasm` connection
+Do not register the native-only policy field in the `duckdb_wasm` connection
 schema in this pass:
 
-- `filesystemPolicy`
-- `networkPolicy`
+- `securityPolicy`
 - native-only hardening properties
 
 Do not add native restricted-policy behavior to `DuckDBWASMConnection` as a
@@ -422,7 +422,7 @@ When adding a new native DuckDB config property, update all relevant layers:
 
 - Register the property in `src/native.ts` with the correct config metadata.
 - Parse and validate it in `normalizeDuckDBConfig()`.
-- Decide whether it conflicts with `filesystemPolicy` or `networkPolicy`.
+- Decide whether it conflicts with `securityPolicy`.
 - Decide whether any restricted policy must derive or force a value.
 - If it is path-like, canonicalize it before validation and identity
   comparison.
@@ -440,8 +440,8 @@ forced to a safe value under restricted policies.
 
 ## Changing Policy Behavior
 
-When changing `filesystemPolicy`, `networkPolicy`, or
-`NormalizedDuckDBSafetyPolicy`, review these together:
+When changing `securityPolicy` or `NormalizedDuckDBSafetyPolicy`, review these
+together:
 
 - user-facing policy contract
 - normalizer parsing and conflict checks
@@ -468,8 +468,7 @@ Keep focused tests for:
 - `allowedDirectories` accepted as a JSON array of strings
 - `allowedDirectories` rejected for non-array or non-string JSON values
 - exact policy value parsing
-- policy fields rejected when provided as non-literal or reference-shaped
-  values
+- policy field rejected when provided as non-literal or reference-shaped value
 - missing policy-required values failing closed
 - conflict checks
 - redundant matching explicit values accepted
@@ -478,10 +477,11 @@ Keep focused tests for:
 - network-requiring `databasePath` rejection
 - `readOnly: true` with `:memory:` normalizing to `false`
 - share keys differing when safety-relevant settings differ
+- different `securityPolicy` values producing different share keys
 - semantically identical allowlists sharing
 - restricted baseline order
-- `networkPolicy: "closed"` not loading `httpfs`
-- `networkPolicy: "closed"` not running `INSTALL`
+- restricted policies not loading `httpfs`
+- restricted policies not running `INSTALL`
 - required baseline extensions loaded or failing closed
 - later config-changing `SET` statements failing after lock
 - `closeAllInstances()` clearing all share-keyed native instances

--- a/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.spec.ts
@@ -83,7 +83,7 @@ describe('normalizeDuckDBConfig', () => {
   it('derives sandboxed defaults from workingDirectory', () => {
     const normalized = normalizeDuckDBConfig(
       baseConfig({
-        filesystemPolicy: 'sandboxed',
+        securityPolicy: 'sandboxed',
         workingDirectory,
       })
     );
@@ -99,12 +99,28 @@ describe('normalizeDuckDBConfig', () => {
     );
     expect(normalized.lockConfiguration).toBe(true);
     expect(normalized.tempFileEncryption).toBe(true);
+    expect(normalized.enableExternalAccess).toBe(false);
   });
 
-  it('derives a working-directory scoped secret directory for network-only restricted mode', () => {
+  it('derives enableExternalAccess=false and lockConfiguration=true for local mode', () => {
     const normalized = normalizeDuckDBConfig(
       baseConfig({
-        networkPolicy: 'closed',
+        securityPolicy: 'local',
+        workingDirectory,
+      })
+    );
+
+    expect(normalized.enableExternalAccess).toBe(false);
+    expect(normalized.lockConfiguration).toBe(true);
+    expect(normalized.tempFileEncryption).toBe(true);
+    expect(normalized.allowedDirectories).toBeUndefined();
+    expect(normalized.tempDirectory).toBeUndefined();
+  });
+
+  it('derives a working-directory scoped secret directory for local mode', () => {
+    const normalized = normalizeDuckDBConfig(
+      baseConfig({
+        securityPolicy: 'local',
         workingDirectory,
       })
     );
@@ -119,7 +135,7 @@ describe('normalizeDuckDBConfig', () => {
     expect(() =>
       normalizeDuckDBConfig(
         baseConfig({
-          networkPolicy: 'closed',
+          securityPolicy: 'local',
         })
       )
     ).toThrow(
@@ -131,11 +147,11 @@ describe('normalizeDuckDBConfig', () => {
     expect(() =>
       normalizeDuckDBConfig(
         baseConfig({
-          filesystemPolicy: 'sandboxed',
+          securityPolicy: 'sandboxed',
         })
       )
     ).toThrow(
-      'filesystemPolicy "sandboxed" requires either allowedDirectories or workingDirectory'
+      'securityPolicy "sandboxed" requires either allowedDirectories or workingDirectory'
     );
   });
 
@@ -145,86 +161,101 @@ describe('normalizeDuckDBConfig', () => {
     expect(() =>
       normalizeDuckDBConfig(
         baseConfig({
-          filesystemPolicy: 'sandboxed',
+          securityPolicy: 'sandboxed',
           workingDirectory,
         })
       )
-    ).toThrow('filesystemPolicy "sandboxed" is only supported on POSIX hosts');
+    ).toThrow('securityPolicy "sandboxed" is only supported on POSIX hosts');
   });
 
   it('rejects tempDirectory outside the sandbox boundary', () => {
     expect(() =>
       normalizeDuckDBConfig(
         baseConfig({
-          filesystemPolicy: 'sandboxed',
+          securityPolicy: 'sandboxed',
           workingDirectory,
           allowedDirectories: [workingDirectory],
           tempDirectory: allowedA,
         })
       )
     ).toThrow(
-      'tempDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+      'tempDirectory must be contained within allowedDirectories when securityPolicy is "sandboxed"'
     );
   });
 
-  it('rejects network-requiring database paths when networkPolicy is closed', () => {
+  it('rejects network-requiring database paths when securityPolicy is local', () => {
     expect(() =>
       normalizeDuckDBConfig(
         baseConfig({
-          networkPolicy: 'closed',
+          securityPolicy: 'local',
+          workingDirectory,
           databasePath: 'md:malloy',
         })
       )
     ).toThrow(
-      'databasePath "md:malloy" is not allowed when networkPolicy is "closed"'
+      'databasePath "md:malloy" is not allowed when securityPolicy is "local"'
+    );
+  });
+
+  it('rejects network-requiring database paths when securityPolicy is sandboxed', () => {
+    expect(() =>
+      normalizeDuckDBConfig(
+        baseConfig({
+          securityPolicy: 'sandboxed',
+          workingDirectory,
+          databasePath: 'md:malloy',
+        })
+      )
+    ).toThrow(
+      'databasePath "md:malloy" is not allowed when securityPolicy is "sandboxed"'
     );
   });
 
   it.each([
     [
       'enableExternalAccess',
-      {networkPolicy: 'closed', enableExternalAccess: true},
-      'enableExternalAccess cannot be true when networkPolicy "closed" is enabled',
+      {securityPolicy: 'local', enableExternalAccess: true},
+      'enableExternalAccess cannot be true when securityPolicy "local" is enabled',
     ],
     [
       'autoloadKnownExtensions',
-      {networkPolicy: 'closed', autoloadKnownExtensions: true},
-      'autoloadKnownExtensions cannot be true when networkPolicy "closed" is enabled',
+      {securityPolicy: 'local', autoloadKnownExtensions: true},
+      'autoloadKnownExtensions cannot be true when securityPolicy "local" is enabled',
     ],
     [
       'autoinstallKnownExtensions',
-      {networkPolicy: 'closed', autoinstallKnownExtensions: true},
-      'autoinstallKnownExtensions cannot be true when networkPolicy "closed" is enabled',
+      {securityPolicy: 'local', autoinstallKnownExtensions: true},
+      'autoinstallKnownExtensions cannot be true when securityPolicy "local" is enabled',
     ],
     [
       'allowCommunityExtensions',
-      {networkPolicy: 'closed', allowCommunityExtensions: true},
-      'allowCommunityExtensions cannot be true when networkPolicy "closed" is enabled',
+      {securityPolicy: 'local', allowCommunityExtensions: true},
+      'allowCommunityExtensions cannot be true when securityPolicy "local" is enabled',
     ],
     [
       'allowUnsignedExtensions',
-      {networkPolicy: 'closed', allowUnsignedExtensions: true},
-      'allowUnsignedExtensions cannot be true when networkPolicy "closed" is enabled',
+      {securityPolicy: 'local', allowUnsignedExtensions: true},
+      'allowUnsignedExtensions cannot be true when securityPolicy "local" is enabled',
     ],
     [
       'lockConfiguration',
-      {filesystemPolicy: 'sandboxed', lockConfiguration: false},
-      'lockConfiguration cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+      {securityPolicy: 'sandboxed', lockConfiguration: false},
+      'lockConfiguration cannot be false when securityPolicy is "sandboxed"',
     ],
     [
       'tempFileEncryption',
-      {filesystemPolicy: 'sandboxed', tempFileEncryption: false},
-      'tempFileEncryption cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+      {securityPolicy: 'sandboxed', tempFileEncryption: false},
+      'tempFileEncryption cannot be false when securityPolicy is "sandboxed"',
     ],
     [
       'additionalExtensions',
-      {filesystemPolicy: 'sandboxed', additionalExtensions: ['spatial']},
-      'additionalExtensions is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline',
+      {securityPolicy: 'sandboxed', additionalExtensions: ['spatial']},
+      'additionalExtensions is not allowed when securityPolicy is "sandboxed"',
     ],
     [
       'motherDuckToken',
-      {networkPolicy: 'closed', motherDuckToken: 'token'},
-      'motherDuckToken is not allowed when networkPolicy is "closed"',
+      {securityPolicy: 'local', motherDuckToken: 'token'},
+      'motherDuckToken is not allowed when securityPolicy is "local"',
     ],
   ] satisfies Array<[string, Partial<ConnectionConfig>, string]>)(
     'rejects conflicting restricted setting %s',
@@ -249,19 +280,36 @@ describe('normalizeDuckDBConfig', () => {
   it('builds the same share key for semantically identical allowedDirectories lists', () => {
     const configA = normalizeDuckDBConfig(
       baseConfig({
-        filesystemPolicy: 'sandboxed',
+        securityPolicy: 'sandboxed',
         workingDirectory,
         allowedDirectories: [workingDirectory, allowedA, allowedB],
       })
     );
     const configB = normalizeDuckDBConfig(
       baseConfig({
-        filesystemPolicy: 'sandboxed',
+        securityPolicy: 'sandboxed',
         workingDirectory,
         allowedDirectories: [allowedB, allowedA, workingDirectory, allowedA],
       })
     );
 
     expect(buildDuckDBShareKey(configA)).toBe(buildDuckDBShareKey(configB));
+  });
+
+  it('builds different share keys for different securityPolicy values', () => {
+    const configNone = normalizeDuckDBConfig(baseConfig());
+    const configLocal = normalizeDuckDBConfig(
+      baseConfig({securityPolicy: 'local', workingDirectory})
+    );
+    const configSandboxed = normalizeDuckDBConfig(
+      baseConfig({securityPolicy: 'sandboxed', workingDirectory})
+    );
+
+    const keys = new Set([
+      buildDuckDBShareKey(configNone),
+      buildDuckDBShareKey(configLocal),
+      buildDuckDBShareKey(configSandboxed),
+    ]);
+    expect(keys.size).toBe(3);
   });
 });

--- a/packages/malloy-db-duckdb/src/duckdb_config.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config.ts
@@ -11,8 +11,7 @@ import type {
 } from '@malloydata/malloy';
 import * as pathSecurity from './path_security';
 
-export type DuckDBFilesystemPolicy = 'open' | 'sandboxed';
-export type DuckDBNetworkPolicy = 'open' | 'closed';
+export type DuckDBSecurityPolicy = 'none' | 'local' | 'sandboxed';
 
 export interface NormalizedDuckDBSafetyPolicy {
   requiresPosixHost: boolean;
@@ -22,7 +21,6 @@ export interface NormalizedDuckDBSafetyPolicy {
   requiresTempFileEncryption: boolean;
   requiresSecretNeutralization: boolean;
   requiredBaselineExtensions: readonly ['icu', 'json'];
-  allowHttpfs: boolean;
   forbidAdditionalExtensions: boolean;
   derivedTempDirectoryName: '.tmp';
 }
@@ -32,8 +30,7 @@ export interface NormalizedDuckDBConfig {
   databasePath: string;
   readOnly: boolean;
   workingDirectory?: string;
-  filesystemPolicy: DuckDBFilesystemPolicy;
-  networkPolicy: DuckDBNetworkPolicy;
+  securityPolicy: DuckDBSecurityPolicy;
   safetyPolicy?: NormalizedDuckDBSafetyPolicy;
   allowedDirectories?: string[];
   enableExternalAccess?: boolean;
@@ -67,20 +64,11 @@ const DERIVED_SECRET_DIRECTORY_NAME = '.duckdb-secrets' as const;
 export function normalizeDuckDBConfig(
   config: ConnectionConfig
 ): NormalizedDuckDBConfig {
-  const filesystemPolicy = parsePolicyValue(
-    config['filesystemPolicy'],
-    'filesystemPolicy',
-    ['open', 'sandboxed']
-  );
-  const networkPolicy = parsePolicyValue(
-    config['networkPolicy'],
-    'networkPolicy',
-    ['open', 'closed']
-  );
+  const securityPolicy = parseSecurityPolicy(config['securityPolicy']);
 
-  if (filesystemPolicy === 'sandboxed' && !pathSecurity.isPosixHost()) {
+  if (securityPolicy === 'sandboxed' && !pathSecurity.isPosixHost()) {
     throw new DuckDBConfigValidationError(
-      'filesystemPolicy "sandboxed" is only supported on POSIX hosts'
+      'securityPolicy "sandboxed" is only supported on POSIX hosts'
     );
   }
 
@@ -134,18 +122,16 @@ export function normalizeDuckDBConfig(
     'allowedDirectories'
   );
 
-  const restricted =
-    filesystemPolicy === 'sandboxed' || networkPolicy === 'closed';
+  const restricted = securityPolicy !== 'none';
   const safetyPolicy = restricted
     ? {
-        requiresPosixHost: filesystemPolicy === 'sandboxed',
+        requiresPosixHost: securityPolicy === 'sandboxed',
         requiresLockedConfiguration: true,
         requiresNoSetupSQL: true,
-        requiresSandboxedPaths: filesystemPolicy === 'sandboxed',
+        requiresSandboxedPaths: securityPolicy === 'sandboxed',
         requiresTempFileEncryption: true,
         requiresSecretNeutralization: true,
         requiredBaselineExtensions: REQUIRED_BASELINE_EXTENSIONS,
-        allowHttpfs: networkPolicy === 'open',
         forbidAdditionalExtensions: true,
         derivedTempDirectoryName: DERIVED_TEMP_DIRECTORY_NAME,
       }
@@ -153,7 +139,7 @@ export function normalizeDuckDBConfig(
 
   if (safetyPolicy?.requiresNoSetupSQL && rawSetupSQL !== undefined) {
     throw new DuckDBConfigValidationError(
-      'setupSQL is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+      `setupSQL is not allowed when securityPolicy is "${securityPolicy}"`
     );
   }
 
@@ -162,56 +148,56 @@ export function normalizeDuckDBConfig(
     additionalExtensions.length > 0
   ) {
     throw new DuckDBConfigValidationError(
-      'additionalExtensions is not allowed when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+      `additionalExtensions is not allowed when securityPolicy is "${securityPolicy}"`
     );
   }
 
   if (restricted && lockConfiguration === false) {
     throw new DuckDBConfigValidationError(
-      'lockConfiguration cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+      `lockConfiguration cannot be false when securityPolicy is "${securityPolicy}"`
     );
   }
 
   if (restricted && tempFileEncryption === false) {
     throw new DuckDBConfigValidationError(
-      'tempFileEncryption cannot be false when filesystemPolicy or networkPolicy requires a locked DuckDB baseline'
+      `tempFileEncryption cannot be false when securityPolicy is "${securityPolicy}"`
     );
   }
 
-  if (networkPolicy === 'closed') {
+  if (restricted) {
     rejectConflictingBoolean(
       enableExternalAccess,
       'enableExternalAccess',
       true,
-      'networkPolicy "closed"'
+      `securityPolicy "${securityPolicy}"`
     );
     rejectConflictingBoolean(
       autoloadKnownExtensions,
       'autoloadKnownExtensions',
       true,
-      'networkPolicy "closed"'
+      `securityPolicy "${securityPolicy}"`
     );
     rejectConflictingBoolean(
       autoinstallKnownExtensions,
       'autoinstallKnownExtensions',
       true,
-      'networkPolicy "closed"'
+      `securityPolicy "${securityPolicy}"`
     );
     rejectConflictingBoolean(
       allowCommunityExtensions,
       'allowCommunityExtensions',
       true,
-      'networkPolicy "closed"'
+      `securityPolicy "${securityPolicy}"`
     );
     rejectConflictingBoolean(
       allowUnsignedExtensions,
       'allowUnsignedExtensions',
       true,
-      'networkPolicy "closed"'
+      `securityPolicy "${securityPolicy}"`
     );
     if (rawMotherDuckToken !== undefined) {
       throw new DuckDBConfigValidationError(
-        'motherDuckToken is not allowed when networkPolicy is "closed"'
+        `motherDuckToken is not allowed when securityPolicy is "${securityPolicy}"`
       );
     }
   }
@@ -222,25 +208,22 @@ export function normalizeDuckDBConfig(
       rawWorkingDirectory,
       'workingDirectory',
       {
-        mustExist: filesystemPolicy === 'sandboxed',
+        mustExist: securityPolicy === 'sandboxed',
       }
     );
   }
 
   const databasePath = canonicalizeDatabasePath(rawDatabasePath);
   const isMotherDuck = isMotherDuckPath(databasePath);
-  if (
-    networkPolicy === 'closed' &&
-    !isAllowedClosedNetworkDatabasePath(databasePath)
-  ) {
+  if (restricted && !isAllowedClosedNetworkDatabasePath(databasePath)) {
     throw new DuckDBConfigValidationError(
-      `databasePath "${rawDatabasePath}" is not allowed when networkPolicy is "closed"`
+      `databasePath "${rawDatabasePath}" is not allowed when securityPolicy is "${securityPolicy}"`
     );
   }
 
-  if (networkPolicy === 'closed' && isMotherDuck) {
+  if (restricted && isMotherDuck) {
     throw new DuckDBConfigValidationError(
-      'MotherDuck database paths are not allowed when networkPolicy is "closed"'
+      `MotherDuck database paths are not allowed when securityPolicy is "${securityPolicy}"`
     );
   }
 
@@ -250,11 +233,11 @@ export function normalizeDuckDBConfig(
       : canonicalizeConfigPathList(rawAllowedDirectories, 'allowedDirectories');
 
   let allowedDirectories = normalizedAllowedDirectories;
-  if (filesystemPolicy === 'sandboxed') {
+  if (securityPolicy === 'sandboxed') {
     if (allowedDirectories === undefined) {
       if (workingDirectory === undefined) {
         throw new DuckDBConfigValidationError(
-          'filesystemPolicy "sandboxed" requires either allowedDirectories or workingDirectory. If you expected workingDirectory to come from config.rootDirectory, verify that overlay is available.'
+          'securityPolicy "sandboxed" requires either allowedDirectories or workingDirectory. If you expected workingDirectory to come from config.rootDirectory, verify that overlay is available.'
         );
       }
       allowedDirectories = [workingDirectory];
@@ -266,7 +249,7 @@ export function normalizeDuckDBConfig(
       )
     ) {
       throw new DuckDBConfigValidationError(
-        'workingDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+        'workingDirectory must be contained within allowedDirectories when securityPolicy is "sandboxed"'
       );
     }
   }
@@ -274,24 +257,24 @@ export function normalizeDuckDBConfig(
   let tempDirectory: string | undefined;
   if (rawTempDirectory !== undefined) {
     tempDirectory = canonicalizeConfigPath(rawTempDirectory, 'tempDirectory');
-  } else if (filesystemPolicy === 'sandboxed') {
+  } else if (securityPolicy === 'sandboxed') {
     if (workingDirectory === undefined) {
       throw new DuckDBConfigValidationError(
-        'filesystemPolicy "sandboxed" requires tempDirectory or workingDirectory so Malloy can derive a safe temp directory'
+        'securityPolicy "sandboxed" requires tempDirectory or workingDirectory so Malloy can derive a safe temp directory'
       );
     }
     tempDirectory = path.join(workingDirectory, DERIVED_TEMP_DIRECTORY_NAME);
   }
 
-  if (filesystemPolicy === 'sandboxed') {
+  if (securityPolicy === 'sandboxed') {
     if (allowedDirectories === undefined) {
       throw new DuckDBConfigValidationError(
-        'filesystemPolicy "sandboxed" requires allowedDirectories'
+        'securityPolicy "sandboxed" requires allowedDirectories'
       );
     }
     if (tempDirectory === undefined) {
       throw new DuckDBConfigValidationError(
-        'filesystemPolicy "sandboxed" requires tempDirectory'
+        'securityPolicy "sandboxed" requires tempDirectory'
       );
     }
     if (
@@ -300,7 +283,7 @@ export function normalizeDuckDBConfig(
       )
     ) {
       throw new DuckDBConfigValidationError(
-        'tempDirectory must be contained within allowedDirectories when filesystemPolicy is "sandboxed"'
+        'tempDirectory must be contained within allowedDirectories when securityPolicy is "sandboxed"'
       );
     }
   }
@@ -322,23 +305,17 @@ export function normalizeDuckDBConfig(
     databasePath,
     readOnly: databasePath === ':memory:' ? false : readOnly,
     workingDirectory,
-    filesystemPolicy,
-    networkPolicy,
+    securityPolicy,
     safetyPolicy,
     allowedDirectories,
-    enableExternalAccess:
-      networkPolicy === 'closed' ? false : enableExternalAccess,
+    enableExternalAccess: restricted ? false : enableExternalAccess,
     lockConfiguration: safetyPolicy?.requiresLockedConfiguration
       ? true
       : lockConfiguration,
-    autoloadKnownExtensions:
-      networkPolicy === 'closed' ? false : autoloadKnownExtensions,
-    autoinstallKnownExtensions:
-      networkPolicy === 'closed' ? false : autoinstallKnownExtensions,
-    allowCommunityExtensions:
-      networkPolicy === 'closed' ? false : allowCommunityExtensions,
-    allowUnsignedExtensions:
-      networkPolicy === 'closed' ? false : allowUnsignedExtensions,
+    autoloadKnownExtensions: restricted ? false : autoloadKnownExtensions,
+    autoinstallKnownExtensions: restricted ? false : autoinstallKnownExtensions,
+    allowCommunityExtensions: restricted ? false : allowCommunityExtensions,
+    allowUnsignedExtensions: restricted ? false : allowUnsignedExtensions,
     tempFileEncryption: safetyPolicy?.requiresTempFileEncryption
       ? true
       : tempFileEncryption,
@@ -357,11 +334,10 @@ export function buildDuckDBShareKey(config: NormalizedDuckDBConfig): string {
   // secretDirectory is derived from policy + workingDirectory/tempDirectory,
   // which already participate in the share key.
   return makeDigest(
-    'duckdb-share-key-v1',
+    'duckdb-share-key-v2',
     config.databasePath,
     String(config.readOnly),
-    config.filesystemPolicy,
-    config.networkPolicy,
+    config.securityPolicy,
     config.setupSQL ?? '',
     ...(config.allowedDirectories ?? []),
     config.enableExternalAccess === undefined
@@ -409,28 +385,32 @@ export function stringifyDuckDBOption(
   return String(value);
 }
 
-function parsePolicyValue<T extends string>(
-  rawValue: ConnectionParameterValue | undefined,
-  fieldName: string,
-  allowedValues: readonly T[]
-): T | 'open' {
+const SECURITY_POLICY_VALUES: readonly string[] = [
+  'none',
+  'local',
+  'sandboxed',
+];
+
+function isSecurityPolicy(value: string): value is DuckDBSecurityPolicy {
+  return SECURITY_POLICY_VALUES.includes(value);
+}
+
+function parseSecurityPolicy(
+  rawValue: ConnectionParameterValue | undefined
+): DuckDBSecurityPolicy {
   if (rawValue === undefined) {
-    return 'open';
+    return 'none';
   }
   if (typeof rawValue !== 'string') {
     throw new DuckDBConfigValidationError(
-      `${fieldName} must be one of ${allowedValues
-        .map(v => `"${v}"`)
-        .join(' or ')}, got ${typeof rawValue}`
+      `securityPolicy must be one of ${SECURITY_POLICY_VALUES.map(v => `"${v}"`).join(', ')}, got ${typeof rawValue}`
     );
   }
-  if ((allowedValues as readonly string[]).includes(rawValue)) {
-    return rawValue as T;
+  if (isSecurityPolicy(rawValue)) {
+    return rawValue;
   }
   throw new DuckDBConfigValidationError(
-    `${fieldName} must be one of ${allowedValues
-      .map(v => `"${v}"`)
-      .join(' or ')}, got "${rawValue}"`
+    `securityPolicy must be one of ${SECURITY_POLICY_VALUES.map(v => `"${v}"`).join(', ')}, got "${rawValue}"`
   );
 }
 

--- a/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_config_lookup.spec.ts
@@ -12,39 +12,39 @@ describe('DuckDB config lookup validation', () => {
     DuckDBConnection.closeAllInstances();
   });
 
-  it('rejects reference-shaped filesystemPolicy before DuckDB construction', async () => {
+  it('rejects reference-shaped securityPolicy before DuckDB construction', async () => {
     const config = new MalloyConfig({
       connections: {
         duckdb: {
           is: 'duckdb',
-          filesystemPolicy: {env: 'FS_POLICY'},
+          securityPolicy: {env: 'SECURITY_POLICY'},
         },
       },
     });
 
     await expect(config.connections.lookupConnection('duckdb')).rejects.toThrow(
-      'Connection "duckdb" property "filesystemPolicy" must be a literal string'
+      'Connection "duckdb" property "securityPolicy" must be a literal string'
     );
     expect(config.log.map(entry => entry.message)).toContain(
-      'connections.duckdb.filesystemPolicy: must be a literal string and cannot use an overlay reference'
+      'connections.duckdb.securityPolicy: must be a literal string and cannot use an overlay reference'
     );
   });
 
-  it('rejects non-string networkPolicy before DuckDB construction', async () => {
+  it('rejects non-string securityPolicy before DuckDB construction', async () => {
     const config = new MalloyConfig({
       connections: {
         duckdb: {
           is: 'duckdb',
-          networkPolicy: 42,
+          securityPolicy: 42,
         },
       },
     });
 
     await expect(config.connections.lookupConnection('duckdb')).rejects.toThrow(
-      'Connection "duckdb" property "networkPolicy" must be a literal string'
+      'Connection "duckdb" property "securityPolicy" must be a literal string'
     );
     expect(config.log.map(entry => entry.message)).toContain(
-      'connections.duckdb.networkPolicy: must be a literal string, got number'
+      'connections.duckdb.securityPolicy: must be a literal string, got number'
     );
   });
 });

--- a/packages/malloy-db-duckdb/src/duckdb_connection.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_connection.ts
@@ -48,8 +48,7 @@ export interface DuckDBConnectionOptions extends ConnectionConfig {
   workingDirectory?: string;
   readOnly?: boolean;
   setupSQL?: string;
-  filesystemPolicy?: 'open' | 'sandboxed';
-  networkPolicy?: 'open' | 'closed';
+  securityPolicy?: 'none' | 'local' | 'sandboxed';
   allowedDirectories?: string[];
   enableExternalAccess?: boolean;
   lockConfiguration?: boolean;
@@ -301,7 +300,7 @@ export class DuckDBConnection extends DuckDBCommon {
   }
 
   private async loadBaselineExtensions(): Promise<void> {
-    if (this.normalized.networkPolicy === 'closed') {
+    if (this.normalized.securityPolicy !== 'none') {
       await this.loadExtension('json', {allowInstall: false, required: true});
       await this.loadExtension('icu', {allowInstall: false, required: true});
       return;
@@ -311,7 +310,7 @@ export class DuckDBConnection extends DuckDBCommon {
     await this.loadExtension('json', {allowInstall, required: false});
     await this.loadExtension('icu', {allowInstall, required: false});
 
-    if (this.shouldLoadHttpfs()) {
+    if (this.normalized.enableExternalAccess !== false) {
       await this.loadExtension('httpfs', {allowInstall, required: false});
     }
 
@@ -322,13 +321,6 @@ export class DuckDBConnection extends DuckDBCommon {
     if (this.isMotherDuck) {
       await this.loadExtension('motherduck', {allowInstall, required: false});
     }
-  }
-
-  private shouldLoadHttpfs(): boolean {
-    if (this.normalized.networkPolicy === 'closed') {
-      return false;
-    }
-    return this.normalized.enableExternalAccess !== false;
   }
 
   private async loadExtension(

--- a/packages/malloy-db-duckdb/src/duckdb_restricted.spec.ts
+++ b/packages/malloy-db-duckdb/src/duckdb_restricted.spec.ts
@@ -34,14 +34,14 @@ describe('DuckDB restricted configuration', () => {
     DuckDBConnection.closeAllInstances();
   });
 
-  it('rejects setupSQL when a restricted policy requires a locked baseline', () => {
+  it('rejects setupSQL when securityPolicy requires a locked baseline', () => {
     const createSpy = jest.spyOn(DuckDBInstance, 'create');
 
     expect(
       () =>
         new DuckDBConnection({
           name: 'duckdb',
-          filesystemPolicy: 'sandboxed',
+          securityPolicy: 'sandboxed',
           workingDirectory,
           setupSQL: 'SET FILE_SEARCH_PATH=/tmp',
         })
@@ -49,11 +49,23 @@ describe('DuckDB restricted configuration', () => {
     expect(createSpy).not.toHaveBeenCalled();
   });
 
-  it('passes enable_external_access=false at open time when no allowlist SET is needed', async () => {
+  it('rejects setupSQL for local securityPolicy too', () => {
+    expect(
+      () =>
+        new DuckDBConnection({
+          name: 'duckdb',
+          securityPolicy: 'local',
+          workingDirectory,
+          setupSQL: 'SET FILE_SEARCH_PATH=/tmp',
+        })
+    ).toThrow(DuckDBConfigValidationError);
+  });
+
+  it('passes enable_external_access=false at open time for local policy when no allowlist SET is needed', async () => {
     const createSpy = jest.spyOn(DuckDBInstance, 'create');
     const connection = new DuckDBConnection({
-      name: 'duckdb-network-closed',
-      networkPolicy: 'closed',
+      name: 'duckdb-local',
+      securityPolicy: 'local',
       workingDirectory,
     });
 
@@ -83,7 +95,7 @@ describe('DuckDB restricted configuration', () => {
         name: 'duckdb-closed',
         databasePath: sharedDatabasePath,
         workingDirectory,
-        networkPolicy: 'closed',
+        securityPolicy: 'local',
       });
       await closedConnection.runSQL('SELECT 1');
 
@@ -97,13 +109,13 @@ describe('DuckDB restricted configuration', () => {
   it('does share native instances for semantically identical allowlists', async () => {
     const firstConnection = new DuckDBConnection({
       name: 'duckdb-first',
-      filesystemPolicy: 'sandboxed',
+      securityPolicy: 'sandboxed',
       workingDirectory,
       allowedDirectories: [workingDirectory, secondAllowedDirectory],
     });
     const secondConnection = new DuckDBConnection({
       name: 'duckdb-second',
-      filesystemPolicy: 'sandboxed',
+      securityPolicy: 'sandboxed',
       workingDirectory,
       allowedDirectories: [
         secondAllowedDirectory,
@@ -138,8 +150,7 @@ describe('DuckDB restricted configuration', () => {
 
     const connection = new DuckDBConnection({
       name: 'duckdb-restricted',
-      filesystemPolicy: 'sandboxed',
-      networkPolicy: 'closed',
+      securityPolicy: 'sandboxed',
       workingDirectory,
     });
 
@@ -173,11 +184,10 @@ describe('DuckDB restricted configuration', () => {
     }
   });
 
-  it('locks down the session and keeps httpfs unloaded when networkPolicy is closed', async () => {
+  it('locks down the session and keeps httpfs unloaded for sandboxed policy', async () => {
     const connection = new DuckDBConnection({
       name: 'duckdb-restricted',
-      filesystemPolicy: 'sandboxed',
-      networkPolicy: 'closed',
+      securityPolicy: 'sandboxed',
       workingDirectory,
     });
 
@@ -214,10 +224,10 @@ describe('DuckDB restricted configuration', () => {
     }
   });
 
-  it('isolates secrets for network-only restricted mode', async () => {
+  it('locks down the session for local policy without filesystem sandbox', async () => {
     const connection = new DuckDBConnection({
-      name: 'duckdb-network-closed',
-      networkPolicy: 'closed',
+      name: 'duckdb-local',
+      securityPolicy: 'local',
       workingDirectory,
     });
 
@@ -225,7 +235,6 @@ describe('DuckDB restricted configuration', () => {
       const settings = await connection.runSQL(`
         SELECT
           current_setting('secret_directory') AS secret_directory,
-          current_setting('temp_directory') AS temp_directory,
           current_setting('enable_external_access') AS enable_external_access,
           current_setting('lock_configuration') AS lock_configuration
       `);
@@ -233,9 +242,12 @@ describe('DuckDB restricted configuration', () => {
       expect(settings.rows[0]['secret_directory']).toBe(
         `${canonical(workingDirectory)}/.duckdb-secrets`
       );
-      expect(settings.rows[0]['temp_directory']).toBe('.tmp');
       expect(settings.rows[0]['enable_external_access']).toBe(false);
       expect(settings.rows[0]['lock_configuration']).toBe(true);
+
+      await expect(
+        connection.runRawSQL('SET enable_external_access=true')
+      ).rejects.toThrow('configuration has been locked');
     } finally {
       await connection.close();
     }
@@ -257,7 +269,7 @@ describe('DuckDB restricted configuration', () => {
 
     const connection = new DuckDBConnection({
       name: 'duckdb-restricted',
-      networkPolicy: 'closed',
+      securityPolicy: 'local',
       workingDirectory,
     });
 

--- a/packages/malloy-db-duckdb/src/native.ts
+++ b/packages/malloy-db-duckdb/src/native.ts
@@ -39,15 +39,8 @@ registerConnectionType('duckdb', {
       default: {config: 'rootDirectory'},
     },
     {
-      name: 'filesystemPolicy',
-      displayName: 'Filesystem Policy',
-      type: 'string',
-      optional: true,
-      requireLiteralString: true,
-    },
-    {
-      name: 'networkPolicy',
-      displayName: 'Network Policy',
+      name: 'securityPolicy',
+      displayName: 'Security Policy',
       type: 'string',
       optional: true,
       requireLiteralString: true,


### PR DESCRIPTION
The four-state setting is the duckdb helper policy turns out to be not implementable.

We we replace the two policy settings with one, to get the implementable tri state.

## Summary

- Replace `filesystemPolicy` + `networkPolicy` (two axes, four combinations) with `securityPolicy: "none" | "local" | "sandboxed"` (one axis, three levels)
- Fixes a bug where `filesystemPolicy: "sandboxed"` with `networkPolicy: "open"` set `allowed_directories` but never disabled `enable_external_access`, making the sandbox a no-op — DuckDB's `allowed_directories` only takes effect when `enable_external_access` is false
- The two-axis model presented an impossible fourth state ("sandboxed filesystem with open network") because DuckDB's `enable_external_access` is a single toggle gating both filesystem and network reach

### Policy levels

| Level | Network | Filesystem | Use case |
|-------|---------|------------|----------|
| `"none"` | open | open | Default, ordinary DuckDB |
| `"local"` | disabled | open | Host provides filesystem isolation (e.g. container) |
| `"sandboxed"` | disabled | sandboxed to `allowedDirectories` | Reviewed strict recipe for untrusted Malloy |

- Updated MAINTENANCE_NOTES.md
