### PR TITLE
fix(render): allow # y tag on numeric dimensions in line charts

### DIFF
--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -201,11 +201,17 @@ export function getLineChartSettings(
   if (vizTag.text('x')) {
     xChannel.fields.push(getField(vizTag.text('x')!));
   }
+  const isValidYField = (path: string) => {
+    const f = explore.fieldAt(path);
+    return f.isNumber() || f.wasCalculation();
+  };
   if (vizTag.text('y')) {
-    yChannel.fields.push(getField(vizTag.text('y')!));
+    const path = getField(vizTag.text('y')!);
+    if (isValidYField(path)) yChannel.fields.push(path);
   } else if (vizTag.textArray('y')) {
     vizTag.textArray('y')!.forEach(ref => {
-      yChannel.fields.push(getField(ref));
+      const path = getField(ref);
+      if (isValidYField(path)) yChannel.fields.push(path);
     });
   }
   if (vizTag.text('series')) {
@@ -225,7 +231,7 @@ export function getLineChartSettings(
       if (tag.has('x')) {
         embeddedX.push(pathTo);
       }
-      if (tag.has('y')) {
+      if (tag.has('y') && (field.isNumber() || field.wasCalculation())) {
         embeddedY.push(pathTo);
       }
       if (tag.has('series')) {

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -202,9 +202,29 @@ export function getLineChartSettings(
     xChannel.fields.push(getField(vizTag.text('x')!));
   }
   if (vizTag.text('y')) {
-    yChannel.fields.push(getField(vizTag.text('y')!));
+    const yFieldRef = vizTag.text('y')!;
+    const yFieldPath = getField(yFieldRef);
+    const yField = explore.fieldAt(yFieldPath);
+
+    if (!yField.isNumber() && !yField.wasCalculation()) {
+      throw new Error(
+        `Malloy Line Chart: Field "${yField.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
+      );
+    }
+    yChannel.fields.push(yFieldPath);
   } else if (vizTag.textArray('y')) {
-    yChannel.fields.push(...vizTag.textArray('y')!.map(getField));
+    const yFieldRefs = vizTag.textArray('y')!;
+    yFieldRefs.forEach(ref => {
+      const fieldPath = getField(ref);
+      const field = explore.fieldAt(fieldPath);
+
+      if (!field.isNumber() && !field.wasCalculation()) {
+        throw new Error(
+          `Malloy Line Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
+        );
+      }
+      yChannel.fields.push(fieldPath);
+    });
   }
   if (vizTag.text('series')) {
     seriesChannel.fields.push(getField(vizTag.text('series')!));
@@ -224,6 +244,11 @@ export function getLineChartSettings(
         embeddedX.push(pathTo);
       }
       if (tag.has('y')) {
+        if (!field.isNumber() && !field.wasCalculation()) {
+          throw new Error(
+            `Malloy Line Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
+          );
+        }
         embeddedY.push(pathTo);
       }
       if (tag.has('series')) {
@@ -251,8 +276,6 @@ export function getLineChartSettings(
     f => f.isBasic() && f.wasDimension()
   );
 
-  const measures = explore.fields.filter(f => f.wasCalculation());
-
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {
     // Pick date/time field first if it exists
@@ -273,29 +296,38 @@ export function getLineChartSettings(
     if (numberField) yChannel.fields.push(explore.pathTo(numberField));
   }
   // If no series defined and multiple dimensions, use leftover dimension
+  // (one not already assigned to x or y channels)
   if (seriesChannel.fields.length === 0 && dimensions.length > 1) {
     const dimension = dimensions.find(d => {
       const path = explore.pathTo(d);
-      return !xChannel.fields.includes(path);
+      return (
+        !xChannel.fields.includes(path) && !yChannel.fields.includes(path)
+      );
     });
     if (dimension) {
       seriesChannel.fields.push(explore.pathTo(dimension));
     }
   }
 
-  if (dimensions.length > 2) {
+  // Account for dimensions explicitly assigned to y channel
+  const yDimensionsCount = yChannel.fields.filter(path => {
+    const field = explore.fieldAt(path);
+    return field.wasDimension();
+  }).length;
+
+  if (dimensions.length - yDimensionsCount > 2) {
     throw new Error(
       'Malloy Line Chart: Too many dimensions. A line chart can have at most 2 dimensions: 1 for the x axis, and 1 for the series.'
     );
   }
-  if (dimensions.length === 0) {
+  if (dimensions.length - yDimensionsCount === 0) {
     throw new Error(
       'Malloy Line Chart: No dimensions found. A line chart must have at least 1 dimension for the x axis.'
     );
   }
-  if (measures.length === 0) {
+  if (yChannel.fields.length === 0) {
     throw new Error(
-      'Malloy Line Chart: No measures found. A line chart must have at least 1 measure for the y axis.'
+      'Malloy Line Chart: No measures found and no y channel specified. A line chart must have at least 1 measure or explicitly tagged numeric dimension for the y axis.'
     );
   }
 

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -202,28 +202,10 @@ export function getLineChartSettings(
     xChannel.fields.push(getField(vizTag.text('x')!));
   }
   if (vizTag.text('y')) {
-    const yFieldRef = vizTag.text('y')!;
-    const yFieldPath = getField(yFieldRef);
-    const yField = explore.fieldAt(yFieldPath);
-
-    if (!yField.isNumber() && !yField.wasCalculation()) {
-      throw new Error(
-        `Malloy Line Chart: Field "${yField.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-      );
-    }
-    yChannel.fields.push(yFieldPath);
+    yChannel.fields.push(getField(vizTag.text('y')!));
   } else if (vizTag.textArray('y')) {
-    const yFieldRefs = vizTag.textArray('y')!;
-    yFieldRefs.forEach(ref => {
-      const fieldPath = getField(ref);
-      const field = explore.fieldAt(fieldPath);
-
-      if (!field.isNumber() && !field.wasCalculation()) {
-        throw new Error(
-          `Malloy Line Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-        );
-      }
-      yChannel.fields.push(fieldPath);
+    vizTag.textArray('y')!.forEach(ref => {
+      yChannel.fields.push(getField(ref));
     });
   }
   if (vizTag.text('series')) {
@@ -244,11 +226,6 @@ export function getLineChartSettings(
         embeddedX.push(pathTo);
       }
       if (tag.has('y')) {
-        if (!field.isNumber() && !field.wasCalculation()) {
-          throw new Error(
-            `Malloy Line Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-          );
-        }
         embeddedY.push(pathTo);
       }
       if (tag.has('series')) {
@@ -278,14 +255,21 @@ export function getLineChartSettings(
 
   // If still no x or y, attempt to pick the best choice
   if (xChannel.fields.length === 0) {
+    const isClaimed = (f: (typeof explore.fields)[number]) => {
+      const path = explore.pathTo(f);
+      return (
+        yChannel.fields.includes(path) || seriesChannel.fields.includes(path)
+      );
+    };
     // Pick date/time field first if it exists
     const dateTimeField = explore.fields.find(
-      f => f.wasDimension() && f.isTime()
+      f => f.wasDimension() && f.isTime() && !isClaimed(f)
     );
     if (dateTimeField) xChannel.fields.push(explore.pathTo(dateTimeField));
-    // Pick first dimension field for x
-    else if (dimensions.length > 0) {
-      xChannel.fields.push(explore.pathTo(dimensions[0]));
+    // Pick first dimension field not already claimed by y or series
+    else {
+      const firstFree = dimensions.find(d => !isClaimed(d));
+      if (firstFree) xChannel.fields.push(explore.pathTo(firstFree));
     }
   }
   if (yChannel.fields.length === 0) {

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -317,21 +317,51 @@ export class RenderFieldMetadata {
     if (field.isNest()) {
       const vizTag = tag.tag('viz');
       if (vizTag) {
-        const childNames = new Set(field.fields.map(f => f.name));
+        const childByName = new Map(field.fields.map(f => [f.name, f]));
+        const isLineChart = vizTag.text() === 'line';
         for (const channelName of ['x', 'y', 'series'] as const) {
           const refArray = vizTag.textArray(channelName);
           const refs = refArray ?? [];
           const singleRef = vizTag.text(channelName);
           if (singleRef && !refArray) refs.push(singleRef);
           for (const ref of refs) {
-            if (!childNames.has(ref)) {
+            const child = childByName.get(ref);
+            if (!child) {
               log.error(
-                `Chart field reference '${ref}' for '${channelName}' on '${field.name}' does not match any field. Available fields: ${[...childNames].join(', ')}`,
+                `Chart field reference '${ref}' for '${channelName}' on '${field.name}' does not match any field. Available fields: ${[...childByName.keys()].join(', ')}`,
                 vizTag.tag(channelName)
+              );
+              continue;
+            }
+            if (
+              channelName === 'y' &&
+              isLineChart &&
+              !child.isNumber() &&
+              !child.wasCalculation()
+            ) {
+              log.error(
+                `Field '${ref}' tagged as y on '${field.name}' is not numeric. Only numeric fields can be used as y channel.`,
+                vizTag.tag('y')
               );
             }
           }
         }
+      }
+    }
+
+    // --- Embedded `# y` tag on non-numeric dimension ---
+    if (
+      field.isBasic() &&
+      tag.has('y') &&
+      !field.isNumber() &&
+      !field.wasCalculation()
+    ) {
+      const parentVizTag = field.parent?.tag.tag('viz');
+      if (parentVizTag?.text() === 'line') {
+        log.error(
+          `Field '${field.name}' tagged as y but is not numeric. Only numeric fields can be used as y channel.`,
+          tag.tag('y')
+        );
       }
     }
 

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -456,6 +456,33 @@ source: products is duckdb.table("static/data/products.parquet") extend {
       order_by: `date`
     }
 
+  #(story)
+  view: numeric_dimensions_as_y is {
+    # viz=line
+    nest:
+      tagged is {
+        group_by: brand
+        aggregate: total_sales
+        limit: 10
+      } -> {
+        group_by:
+          brand
+          # y
+          # number
+          total_sales
+      }
+      misconfigured is {
+        group_by:
+          brand
+          # y
+          department
+      }
+      not_tagged is {
+        group_by: brand, department
+        limit: 10
+      }
+  }
+
     #(story)
   # viz=line {mode=yoy}
   view: month_yoy_NOT_IMPLEMENTED is {

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -471,6 +471,17 @@ source: products is duckdb.table("static/data/products.parquet") extend {
           # number
           total_sales
       }
+      y_tagged_first is {
+        group_by: brand
+        aggregate: total_sales
+        limit: 10
+      } -> {
+        group_by:
+          # y
+          # number
+          total_sales
+          brand
+      }
       misconfigured is {
         group_by:
           brand


### PR DESCRIPTION
## Summary

Match bar chart behavior so a numeric dimension (e.g. from a pipeline or `select`) can be assigned to the y-axis with the `# y` tag in line charts.

Previously, the line chart had a separate `measures.length === 0` guard that rejected any query without a true measure (calculation field), even if a numeric dimension had been explicitly tagged with `# y`. The bar chart already supported this pattern; this change brings the line chart in line.

## Changes

- Validate `# y` tagged fields are numeric or calculations (viz-level and embedded), matching bar chart behavior.
- Replace `measures.length === 0` guard with `yChannel.fields.length === 0` so a y-tagged numeric dimension satisfies the y-axis requirement.
- Subtract dimensions used as y from the dimension-count check to avoid false "too many dimensions" errors.
- Exclude dimensions already in `yChannel` from the auto-series fallback so a y-tagged dimension is not also re-assigned as the series field (which previously caused each value to render as its own series).
- Add `numeric_dimensions_as_y` story mirroring the existing bar chart equivalent.

## Test plan

- [x] Existing line chart unit tests pass (`npx jest --testPathPattern='line-chart-plugin'`)
- [x] Verify storybook story `Line Charts > numeric dimensions as y` renders a single line (not one series per data point)
- [x] Verify `misconfigured` case (non-numeric dimension tagged `# y`) shows a clear validation error
- [x] Verify `not_tagged` case (no `# y`, no measures) shows the "no measures" error
