### PR TITLE
docs: cross-link translator and compiler CONTEXT.md files

### DIFF
--- a/packages/malloy/src/lang/CONTEXT.md
+++ b/packages/malloy/src/lang/CONTEXT.md
@@ -1,6 +1,8 @@
 # Malloy Translator
 
-The translator is the first phase of the Malloy compiler. It transforms Malloy source code into an Intermediate Representation (IR) that is independent of any specific SQL dialect.
+Malloy compilation has two phases: the **translator** (this document — `src/lang/`, source → IR) and the **compiler** ([`../model/CONTEXT.md`](../model/CONTEXT.md) — `src/model/`, IR → SQL). They live in sibling directories and communicate only through the IR.
+
+This document covers the translator: it transforms Malloy source code into an Intermediate Representation (IR) that is independent of any specific SQL dialect.
 
 ## Translation Pipeline
 
@@ -102,7 +104,7 @@ src/lang/
 
 ## Important Notes
 
-- The translator produces IR but does NOT generate SQL - that's the compiler's job
+- The translator produces IR but does NOT generate SQL — that's the job of the [compiler](../model/CONTEXT.md)
 - IR is deliberately database-agnostic
 - The translator handles all language-level semantics (scoping, type checking, name resolution)
 - Error messages and warnings are generated during translation

--- a/packages/malloy/src/model/CONTEXT.md
+++ b/packages/malloy/src/model/CONTEXT.md
@@ -1,6 +1,8 @@
 # Malloy Compiler
 
-The compiler is the second phase of the Malloy compilation process. It takes the Intermediate Representation (IR) produced by the translator and generates executable SQL for specific database dialects.
+Malloy compilation has two phases: the **translator** ([`../lang/CONTEXT.md`](../lang/CONTEXT.md) — `src/lang/`, source → IR) and the **compiler** (this document — `src/model/`, IR → SQL). They live in sibling directories and communicate only through the IR.
+
+This document covers the compiler: it takes the Intermediate Representation (IR) produced by the translator and generates executable SQL for specific database dialects.
 
 ## Intermediate Representation (IR)
 


### PR DESCRIPTION
## Summary
- Each of `src/lang/CONTEXT.md` (translator) and `src/model/CONTEXT.md` (compiler) now opens with a short paragraph linking to its sibling, so readers landing in one can discover the other without needing to know the directory split.
- Tightened a `- ` into an em-dash in one bullet for consistency.

## Test plan
- [x] No code changes; docs render correctly on GitHub.