### PR TITLE
refactor(render): renderer validation contract

### DIFF
--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -211,127 +211,14 @@ getLogs()
 
 For headless validation workflows, `setResult()` + `getLogs()` can be used without rendering.
 
-### Error Handling: Renderable vs Loggable
+### Validation
 
-Plugins produce two kinds of errors. The distinction is simple: **can the component still produce output?**
+Renderer tags are validated during `setResult()` and the resulting log messages drive the VS Code Problems panel and the headless `@malloydata/render-validator` package. **Before adding tags, validation rules, or plugin error throws, read [docs/validation.md](docs/validation.md).** It covers what validation is, how it works, where new checks go, and the pre-PR checklist that keeps the validator honest.
 
-#### Renderable Errors (throw in `matches()` or `create()`)
-
-The component **cannot render** — the data is fundamentally incompatible. Throw an error and the `ErrorPlugin` will replace the visualization with an error message in its place.
-
-Use for:
-- Missing required fields (e.g. bar chart has no x dimension)
-- Wrong data shape (e.g. chart tag on a scalar field that isn't a nested query)
-- Too many/few dimensions for the chart type
-
-```typescript
-matches: (field, fieldTag, fieldType) => {
-  const hasTag = fieldTag.has('my_chart');
-  if (hasTag && fieldType !== FieldType.RepeatedRecord) {
-    // Can't render — show error where the chart would be
-    throw new Error('My Chart: field must be a nested query');
-  }
-  return hasTag;
-},
-```
-
-#### Loggable Errors (via `logCollector`)
-
-The component **can still render** but a tag was wrong, ignored, or didn't do what the author intended. The visualization degrades gracefully (falls back to defaults). The log tells the author what to fix.
-
-Use for:
-- Invalid enum values (e.g. `# currency=yen` — unknown code, ignored)
-- Tags on wrong field types (e.g. `# link` on a number — ignored)
-- Misspelled tag properties (detected automatically via unread tag tracking)
-- Invalid combinations (e.g. `# big_value` with `group_by` fields)
-
-Loggable validation is centralized in `RenderFieldMetadata.validateFieldTags()` in `render-field-metadata.ts`, not in individual plugins. This keeps validation consistent and runs during `setResult()`, before rendering.
-
-### Tag Validation
-
-Tag validation runs in `validateFieldTags()` during `setResult()`. To add new validations:
-
-```typescript
-// In render-field-metadata.ts, inside validateFieldTags():
-
-// 1. Tag on wrong field type
-if (tag.has('my_tag') && fieldType !== FieldType.String) {
-  log.error(
-    `Tag 'my_tag' on field '${field.name}' requires a string field, but field is ${fieldType}`,
-    tag.tag('my_tag')  // pass the tag for source location
-  );
-}
-
-// 2. Invalid enum value
-const modeVal = tag.text('my_tag', 'mode');
-if (modeVal !== undefined) {
-  const validModes = ['a', 'b', 'c'];
-  if (!validModes.includes(modeVal)) {
-    log.error(
-      `Invalid my_tag mode '${modeVal}' on field '${field.name}'. Valid modes: ${validModes.join(', ')}`,
-      tag.tag('my_tag')
-    );
-  }
-}
-
-// 3. Detect original literal type (e.g. bare number vs quoted string)
-const myTag = tag.tag('my_tag');
-if (myTag?.scalarType() === 'number') {
-  log.error(
-    `Tag 'my_tag' expects a quoted string, not a bare number`,
-    myTag
-  );
-}
-```
-
-Always pass the relevant `Tag` object as the second argument to `log.error()` / `log.warn()` — it carries source location information that helps the author find the problem in their Malloy source.
-
-### Tag Read Pattern for Components (Important)
-
-Unread-tag warnings are part of typo/unknown-tag detection, so tag access patterns matter.
-
-Preferred pattern:
-1. Read/resolve tags during `setResult()` setup (for built-ins, use `resolveBuiltInTags()` in `tag-configs.ts` and/or `validateFieldTags()` in `render-field-metadata.ts`).
-2. Store resolved values on fields (`setTagConfig`, `setResolvedLabel`, `setColumnConfig`).
-3. In components, read resolved values (`getTagConfig`, `getLabel`, `getColumnConfig`) instead of reading `field.tag.*` directly at render time.
-
-If a renderer owns tags that may only be read later during render/interaction, declare them in `getValidationSpec()` so they are marked as consumed based on ownership.
-
-`getDeclaredTagPaths()` still exists only as a compatibility fallback for older plugins. Using it now emits a warning during validation so plugin authors migrate to `getValidationSpec()`.
-
-This is intentionally not a full read schema. `RendererValidationSpec` is for semantic ownership:
-- tags this renderer gives meaning to
-- tags this renderer validates
-- tags that should not trigger unknown-tag warnings when this renderer is active
-
-It is not for:
-- every incidental `field.tag.*` read in implementation code
-- globally meaningful tags that many renderers may read
-
-### Unread Tag Detection
-
-Tags track whether they've been accessed. Unread properties are logged as warnings to catch misspellings and unknown tags.
-
-Current lifecycle:
-1. `setResult()` builds `RenderFieldMetadata`, which runs setup-time resolution/validation and marks renderer-owned paths via `RendererValidationSpec`.
-2. `getLogs()` and `onReady` both trigger unread-tag collection in `MalloyViz` (collection is one-time and idempotent).
-3. Logs include semantic validation messages plus unread-tag warnings.
-
-Notes:
-- For built-in renderer tags, prefer setup-time reads in `resolveBuiltInTags()` over component-time reads.
-- Child-owned paths are applied during the parent field's registration pass, before recursing into children. This lets a parent renderer claim direct-child tags like dashboard `break` or chart child `tooltip`.
-- `onReady` is useful for UI flow completeness, but it is not strictly required to include unread-tag warnings in logs.
-
-### Error Message Pattern (LLM-Friendly Guideline)
-
-For validation errors, include explicit fix hints when possible. A useful guideline:
-
-`Invalid <tag-path> on '<field>': expected <constraint>, got <value>. Fix: <example> (or <fallback>).`
-
-Example:
-- `Invalid # dashboard.gap on 'sales_dashboard': expected number >= 0, got -2. Fix: use '# dashboard { gap = 0 }' (or remove 'gap').`
-
-Keep using `log.error(..., tagRef)` / `log.warn(..., tagRef)` with the relevant `Tag` object so source locations are preserved.
+The short version for plugin authors:
+- Tag-quality errors (wrong type, invalid enum, structural rule) belong in `validateFieldTags()` with `log.error(msg, tagRef)` so source locations survive.
+- `throw` from `matches()` / `create()` only when the plugin literally cannot produce output; throws are wrapped and **lose the `Tag` reference**.
+- Any tag read after `setResult()` returns must be in a setup-time resolver (`tag-configs.ts`) or in `getValidationSpec().ownedPaths` / `childOwnedPaths`, or it will trigger false unread-tag warnings.
 
 ### Rendering Modes
 

--- a/packages/malloy-render/docs/plugin-api-reference.md
+++ b/packages/malloy-render/docs/plugin-api-reference.md
@@ -7,6 +7,7 @@
 ```typescript
 interface RenderPluginFactory<TInstance extends RenderPluginInstance> {
   readonly name: string;
+  getValidationSpec?(): RendererValidationSpec;
   matches(field: Field, fieldTag: Tag, fieldType: FieldType): boolean;
   create(field: Field, pluginOptions?: unknown, modelTag?: Tag): TInstance;
 }
@@ -16,17 +17,33 @@ interface RenderPluginFactory<TInstance extends RenderPluginInstance> {
 - `name`: Unique identifier for the plugin
 
 #### Methods
+- `getValidationSpec()`: Declares which tag paths this plugin semantically owns, so the unread-tag detector does not false-warn on valid uses. Required for plugins that read tags at render time. See [validation.md](validation.md) for the ownership model.
+
 - `matches()`: Determines if plugin should handle a field
   - `field`: Field metadata and structure
   - `fieldTag`: Field annotations/tags
   - `fieldType`: Enumerated field type
   - Returns: `boolean`
+  - Throw when the user's tag asks for this plugin but the field cannot support it — the user sees a red error tile. See [validation.md](validation.md) for the throw-vs-log rule.
 
 - `create()`: Instantiates plugin for a matched field
   - `field`: Field to render
   - `pluginOptions`: Configuration from renderer options
   - `modelTag`: Model-level annotations
   - Returns: Plugin instance
+  - Do all tag reads here (setup time), not in `renderComponent()` or `beforeRender()` — setup-time reads are validated and marked as consumed automatically.
+
+### RendererValidationSpec
+
+```typescript
+interface RendererValidationSpec {
+  readonly renderer: string;
+  readonly ownedPaths?: string[][];
+  readonly childOwnedPaths?: string[][];
+}
+```
+
+Declares the tag paths a renderer owns — tags whose meaning depends on this renderer being active. See [validation.md](validation.md) for when to declare ownership.
 
 ### RenderPluginInstance
 

--- a/packages/malloy-render/docs/plugin-quick-start.md
+++ b/packages/malloy-render/docs/plugin-quick-start.md
@@ -97,3 +97,7 @@ const renderer = new MalloyRenderer({
   plugins: [MinimalPluginFactory],
 });
 ```
+
+## Next steps
+
+Once your plugin reads tags beyond just the one that triggers `matches()`, read [validation.md](validation.md). It covers when to throw (red error tile), when to log (source-located validation error), and how to declare tag ownership so valid tag uses don't trigger unread-tag warnings.

--- a/packages/malloy-render/docs/plugin-system.md
+++ b/packages/malloy-render/docs/plugin-system.md
@@ -249,7 +249,7 @@ source: users is table('users') {
 ## Best Practices
 
 ### 1. Field Type Validation
-Always validate field types in `matches()` to prevent runtime errors:
+Throw from `matches()` when the user asked for this plugin (tag present) but the field cannot support it — the user sees a red error tile in place of the visualization:
 
 ```typescript
 matches: (field, fieldTag, fieldType) => {
@@ -259,6 +259,8 @@ matches: (field, fieldTag, fieldType) => {
   return fieldTag.has('my_chart') && fieldType === FieldType.RepeatedRecord;
 }
 ```
+
+For tag-setting errors that shouldn't fail the whole render (e.g. invalid enum value, wrong field type for one setting), use `validateFieldTags()` with `log.error(msg, tagRef)` instead so the user gets a source-located error and the plugin still renders with defaults. See [validation.md](validation.md) for the full throw-vs-log rule.
 
 ### 2. Efficient Data Processing
 Use `processData()` for expensive computations to avoid re-processing during re-renders:
@@ -275,7 +277,7 @@ processData: (field, cell) => {
 - Use `'fill'` for plugins that adapt to container size
 
 ### 4. Error Handling
-Implement robust error handling to prevent breaking the entire visualization:
+The right place to catch tag/configuration mistakes is setup time (in `create()` or in a resolver), not render time. A try/catch in `renderComponent()` is a last resort for defensive coverage of unexpected runtime failures — see [validation.md](validation.md) for the setup-time pattern.
 
 ```typescript
 renderComponent: (props) => {
@@ -308,12 +310,7 @@ These serve as excellent examples for creating custom plugins.
 
 ## Debugging
 
-Enable console warnings to see plugin matching and instantiation issues:
-
-```typescript
-// Plugin instantiation failures are logged to console
-console.warn(`Plugin ${factory.name} failed to instantiate for field ${field.key}:`, error);
-```
+Plugin throws from `matches()` and `create()` are caught by `RenderFieldMetadata.instantiatePluginsForField` and rendered as red error tiles (via `ErrorPlugin`). They also appear in `MalloyViz.getLogs()` as errors. Tag validation errors emitted via `log.error(msg, tagRef)` appear in the same log stream with source locations. See [validation.md](validation.md) for the full error flow.
 
 ## Future Considerations
 

--- a/packages/malloy-render/docs/validation.md
+++ b/packages/malloy-render/docs/validation.md
@@ -1,0 +1,137 @@
+# Renderer Validation
+
+## What validation is
+
+Renderer tags (`# bar_chart`, `# viz.x = ...`, `# currency=usd`, etc.) are a DSL embedded in Malloy annotations. The renderer interprets that DSL to decide what to draw and how. Validation is the layer that catches DSL mistakes — wrong tag on wrong field type, invalid enum values, bad field references, structural conflicts — and surfaces them as errors with source locations the user can act on.
+
+Two things consume validation:
+
+- **The VS Code Problems panel.** Validation runs during `setResult()` so logs are available synchronously after the result lands.
+- **`@malloydata/render-validator`.** A headless wrapper that runs the validator in Node.js (no DOM, no Solid.js) so MCP pipelines and CI can validate a query's renderer tags without a browser.
+
+Validation only needs the result **schema** (field names, types, annotations). It does not need data rows. Anything that requires inspecting rows (e.g., "transpose column limit exceeded") cannot be validated this way and must remain a render-time check.
+
+## The design principle
+
+> Push tag interpretation as far toward setup-time as possible. Anything resolved at setup-time can be validated at setup-time.
+
+Concretely, this means:
+
+- **Do tag reads in `create()` or in a `tag-configs.ts` resolver**, not in `renderComponent()`, `beforeRender()`, or any shared code they call into. Setup-time reads are automatically marked-as-read by the tag API, and their results are available for validation.
+- **Store resolved values on the plugin instance or via `setTagConfig` / `setColumnConfig`**, and have render-time code consume the resolved values. Render-time code should never call `field.tag.*` directly.
+- **When a render-time read is unavoidable** (e.g., a context-sensitive per-child tag like dashboard's `break`, where setup-time resolution would be materially worse than ownership), declare the path in `getValidationSpec().ownedPaths` or `childOwnedPaths` so unread-tag detection doesn't warn on valid uses.
+
+If you internalize one thing from this document: **setup-time is the default; render-time reads are exceptions that must be declared**.
+
+## How it works
+
+### Pipeline
+
+```
+setResult(result)
+  → new RenderFieldMetadata(result, plugins)
+      → registerFields(rootField)               // recursive, depth-first
+          for each field:
+            instantiatePluginsForField(field)   // factory.matches + factory.create — may throw
+            resolveBuiltInTags(field)           // typed config resolvers (image, link, ...)
+            validateFieldTags(field)            // semantic checks → logCollector
+            markOwnedTagPaths(field, ...)       // mark renderer-owned tag paths as read
+getLogs()
+  → semantic logs (from validateFieldTags + resolvers + plugin-error wrappers)
+  → unread-tag warnings (collected once, idempotent)
+```
+
+### The four producers of log entries
+
+1. **Semantic validation in `validateFieldTags()`** (`src/render-field-metadata.ts`) — The central place for "this tag is wrong" checks. Calls `log.error(msg, tagRef)` / `log.warn(msg, tagRef)`. The `tagRef` carries a source location so VS Code can underline the offending tag.
+
+2. **Built-in tag config resolvers in `tag-configs.ts`** — Read tags at setup time, return typed configs, optionally log issues with the same `tagRef` pattern. Components consume the typed config rather than re-reading the tag.
+
+3. **Plugin throws from `matches()` / `create()`** — Caught in `instantiatePluginsForField` and routed to `ErrorPlugin`, which renders a red error tile in place of the visualization with the thrown message. This is the correct UX when the user asked for a specific renderer (e.g., `# bar_chart`) and the renderer literally cannot produce output (wrong field shape, missing required structure). The thrown message gets wrapped as `"Plugin <name> failed for field '<key>': <msg>"` so the source location of the offending tag is **not** preserved — see "Throw vs log" below for when this trade-off is right.
+
+4. **Unread-tag detection** — After validation, any tag property the user wrote that no resolver, validator, or ownership spec touched becomes a warning. This is the safety net for misspellings and unknown tags.
+
+### Tag ownership
+
+A renderer "owns" a tag when removing the renderer would make the tag meaningless (e.g., `viz.x` only matters when a chart is active). Ownership is declared on the factory:
+
+```typescript
+getValidationSpec: (): RendererValidationSpec => ({
+  renderer: 'bar',
+  ownedPaths:      [['viz', 'x'], ['viz', 'y'], ['bar_chart'], ...],
+  childOwnedPaths: [['tooltip']],   // claimed on direct children
+}),
+```
+
+`markOwnedTagPaths` walks these declarations and calls `tag.find(path)` on each one, marking the path as read so unread-tag detection won't false-warn. Built-in renderers use the same mechanism via `renderer-validation-specs.ts`.
+
+Ownership is **bookkeeping**, not validation. It tells the framework "these tag paths are legitimate when this renderer is active." It does not check whether the values are sane — that is `validateFieldTags`'s job.
+
+Ownership is a manual list with no compile-time check. Adding a new render-time tag read without updating `getValidationSpec()` produces false unread-tag warnings on valid input. Keeping the list in sync with actual render-time reads is the author's responsibility.
+
+### Why a tag path needs ownership
+
+A tag path needs to be in an ownership spec **only if it is read after `setResult()` returns** (i.e., at render time or interaction time) and is not consumed by a setup-time resolver. Setup-time reads already mark the tag as read; ownership specs cover the gap for tags that are still render-time-only.
+
+When a tag migrates from render-time to a setup-time typed config, its entry in `ownedPaths` becomes redundant and should be removed.
+
+## How to validate well
+
+### Throw vs log — when you actually want each
+
+This is the rule that matters most and is easiest to get wrong.
+
+**Throw** from `matches()` / `create()` **when the user asked for a specific renderer and that renderer cannot produce output for this field.** The thrown message replaces the visualization with a red error tile (via `ErrorPlugin`). **That red tile is the feature, not a workaround** — it tells the author, visibly and unmissably: "you asked for X, here's why X can't happen." Examples:
+
+- `# bar_chart` on a scalar field → throw. Bar chart was requested; can't deliver.
+- `# big_value` on a non-record → throw. Big value was requested; can't deliver.
+- `# bar_chart` on a nested query with zero dimensions → throw. Bar chart needs an x axis; can't deliver.
+
+**Log** via `validateFieldTags()` with `log.error(msg, tagRef)` **when a renderer is still going to render, but one tag or setting is wrong.** The render proceeds with defaults; the log tells the author their setting was ignored. Examples:
+
+- `# currency=yen` on a number → log. Table still renders, currency tag ignored.
+- `# big_value { comparison_format=yuh }` → log. Big value still renders, bad format defaults to `pct`.
+- `# viz.x = nonexistent_field` on a bar chart → log. Chart still renders, chooses x differently.
+- `# y` on a non-numeric dimension → log. Chart still renders, chooses y from measures instead.
+
+**The hinge:** *is the plugin unable to produce output at all, or just unable to apply this one setting?*
+
+- Unable at all → red box. Throw.
+- One setting wrong, main render still works → log + default.
+
+A second way to check: **would the author prefer a red box, or a silently-defaulted render with a line in the Problems panel?** A whole failed viz deserves a red box. One ignored setting deserves a log.
+
+### The source-location caveat
+
+Thrown errors do not carry their `Tag` reference through `instantiatePluginsForField`, so red-box messages do not get a clickable source location. The red-box UX is still the right choice when the plugin can't produce output — do not route a whole-renderer failure through `validateFieldTags()` just to get a source location, since that produces a warning in the Problems panel while rendering the broken chart, which is worse UX than the red box.
+
+### The ownership test
+
+Separately from throw-vs-log: **if a tag gets read after `setResult()` returns**, its path must be in `getValidationSpec().ownedPaths` (or `childOwnedPaths` for direct children). Otherwise the unread-tag detector will warn about it on every valid use. Better still: move the read into a setup-time resolver (see `tag-configs.ts`) and drop the ownership entry.
+
+### What the validator can't catch
+
+- Anything that needs actual data rows (transpose limit exceeded, empty result handling).
+- Anything that depends on layout measurements (sizing fallbacks).
+- Logic errors in renderer code that produce a wrong-but-rendered chart.
+
+For these, a Storybook case is the regression net. If you are adding a validation rule, also add a story exercising the bad input — the story exercises the validator path, and visual regressions cover what validation can't.
+
+### Pre-PR checklist
+
+- [ ] New tag or property a renderer reads → it is consumed by a setup-time resolver in `tag-configs.ts` **or** declared in the relevant plugin's `getValidationSpec().ownedPaths` / `childOwnedPaths`.
+- [ ] New constraint on a tag value (enum members, type compatibility, structural rule) → encoded in `validateFieldTags()` with `log.error(msg, tagRef)` so the user sees a source-located error.
+- [ ] New throw in `matches()` / `create()` → the failure is "this plugin cannot produce output for this field," and a red-box tile is the UX you want. If the main renderer would still work fine and only one tag-setting is wrong, use `validateFieldTags()` with a logged error instead.
+- [ ] New plugin factory → defines `getValidationSpec()` on the factory (not on the instance).
+- [ ] Storybook case added or updated to exercise the new tag/validation path.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `src/render-field-metadata.ts` | Validation engine — `validateFieldTags`, `markOwnedTagPaths`, plugin instantiation |
+| `src/component/render-log-collector.ts` | Log collection, unread-tag walking |
+| `src/component/tag-configs.ts` | Setup-time resolvers for built-in renderers (image, link, list, cell format, table nest, dashboard) |
+| `src/component/renderer-validation-specs.ts` | Built-in renderer ownership specs |
+| `src/api/plugin-types.ts` | `RenderPluginFactory`, `RendererValidationSpec` interfaces |
+| `packages/malloy-render-validator/src/index.ts` | Headless wrapper — `validateRenderTags(result)` |

--- a/packages/malloy-render/src/api/plugin-types.ts
+++ b/packages/malloy-render/src/api/plugin-types.ts
@@ -38,13 +38,6 @@ interface BaseRenderPluginInstance<TMetadata = unknown> {
     options: GetResultMetadataOptions
   ): void;
   getStyleOverrides?(): Record<string, string>;
-
-  /**
-   * Legacy compatibility for plugins that still declare self-owned paths
-   * from the instance. New code should use factory.getValidationSpec().
-   * @deprecated Use RenderPluginFactory.getValidationSpec() instead.
-   */
-  getDeclaredTagPaths?(): string[][];
 }
 
 export interface SolidJSRenderPluginInstance<TMetadata = unknown>

--- a/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/component/bar-chart/generate-bar_chart-vega-spec.ts
@@ -197,7 +197,18 @@ export function generateBarChartVegaSpec(
   //   - determine x axis available space
   //   - get max string (this is where data limits code comes in to play? is it just a callback fn for getMaxString() to be passed in?)
   //   - calculate xAxisSettings correctly
-  const chartSettings = getChartLayoutSettings(explore, chartTag, {
+  const chartSettings = getChartLayoutSettings(explore, {
+    size: {
+      width:
+        chartTag.numeric('size', 'width') ??
+        explore.tag.numeric('size', 'width') ??
+        undefined,
+      height:
+        chartTag.numeric('size', 'height') ??
+        explore.tag.numeric('size', 'height') ??
+        undefined,
+      preset: chartTag.text('size') ?? explore.tag.text('size') ?? undefined,
+    },
     metadata,
     xField,
     yField,
@@ -956,7 +967,8 @@ export function generateBarChartVegaSpec(
     totalWidth: chartSettings.totalWidth,
     totalHeight: chartSettings.totalHeight,
     chartType: 'bar',
-    chartTag,
+    title: chartTag.text('title'),
+    subtitle: chartTag.text('subtitle'),
     mapMalloyDataToChartData,
     getTooltipData: (item: Item, view: View) => {
       if (tooltipEntryMemo.has(item)) {

--- a/packages/malloy-render/src/component/chart/chart-layout-settings.ts
+++ b/packages/malloy-render/src/component/chart/chart-layout-settings.ts
@@ -21,7 +21,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type {Tag} from '@malloydata/malloy-tag';
 import type {
   AlignValue,
   TextBaselineValue,
@@ -33,6 +32,7 @@ import {getTextWidthDOM, getTextHeightDOM} from '@/component/util';
 import {renderNumericField} from '@/component/render-numeric-field';
 import type {Field, NestField} from '@/data_tree';
 import type {RenderMetadata} from '@/component/render-result-metadata';
+import type {ChartSizeConfig} from '@/component/chart/resolve-chart-display';
 
 type XAxisSettings = {
   labelAngle: number;
@@ -329,8 +329,8 @@ const ROW_HEIGHT = 28;
 
 export function getChartLayoutSettings(
   field: NestField,
-  chartTag: Tag,
   options: {
+    size: ChartSizeConfig;
     metadata: RenderMetadata;
     xField?: Field;
     yField?: Field;
@@ -345,14 +345,10 @@ export function getChartLayoutSettings(
   // may not need this anymore if we enforce the options, so each chart passes its specific needs for calculating layout
   const xField = options?.xField ?? field.fields[0];
   const yField = options?.yField ?? field.fields[1];
-  const tag = field.tag;
 
-  // For now, support legacy API of size being its own tag
-  const taggedWidth =
-    chartTag.numeric('size', 'width') ?? tag.numeric('size', 'width');
-  const taggedHeight =
-    chartTag.numeric('size', 'height') ?? tag.numeric('size', 'height');
-  const taggedPresetSize = chartTag.text('size') ?? tag.text('size');
+  const taggedWidth = options.size.width;
+  const taggedHeight = options.size.height;
+  const taggedPresetSize = options.size.preset;
   const hasNoDefinedSize = !taggedWidth && !taggedHeight && !taggedPresetSize;
   const isFillMode =
     taggedPresetSize === 'fill' || (hasNoDefinedSize && field.isRoot());
@@ -484,8 +480,7 @@ export function getChartLayoutSettings(
     }
   }
 
-  const isSpark =
-    tag.text('viz', 'size') === 'spark' || tag.text('size') === 'spark';
+  const isSpark = options.size.preset === 'spark';
 
   const xAxisSettings = getXAxisSettings({
     maxString: xField.maxString!,

--- a/packages/malloy-render/src/component/chart/chart-v2.tsx
+++ b/packages/malloy-render/src/component/chart/chart-v2.tsx
@@ -43,7 +43,8 @@ export type ChartV2Props = {
   plotHeight: number;
   totalWidth: number;
   totalHeight: number;
-  chartTag?: {text?: (key: string) => string | undefined}; // For title/subtitle support
+  title?: string;
+  subtitle?: string;
   getTooltipData?: (item: Item, view: View) => ChartTooltipEntry | null;
   isDataLimited?: boolean;
   dataLimitMessage?: string;
@@ -183,8 +184,8 @@ export function ChartV2Inner(props: ChartV2Props) {
 
   const showTooltip = createMemo(() => Boolean(tooltipData()));
 
-  const chartTitle = props.chartTag?.text?.('title');
-  const chartSubtitle = props.chartTag?.text?.('subtitle');
+  const chartTitle = props.title;
+  const chartSubtitle = props.subtitle;
   const isDataLimited = props.isDataLimited || false;
   const dataLimitMessage = props.dataLimitMessage || 'Showing limited results';
   const hasTitleBar = chartTitle || chartSubtitle || isDataLimited;

--- a/packages/malloy-render/src/component/chart/chart.tsx
+++ b/packages/malloy-render/src/component/chart/chart.tsx
@@ -217,8 +217,8 @@ export function ChartInner(props: {
 
   const showTooltip = createMemo(() => Boolean(tooltipData()));
 
-  const chartTitle = props.chartProps.chartTag.text('title');
-  const chartSubtitle = props.chartProps.chartTag.text('subtitle');
+  const chartTitle = props.chartProps.title;
+  const chartSubtitle = props.chartProps.subtitle;
   const hasTitleBar = chartTitle || chartSubtitle || isDataLimited;
 
   const [chartSpace, setChartSpace] = createSignal({

--- a/packages/malloy-render/src/component/chart/resolve-chart-display.ts
+++ b/packages/malloy-render/src/component/chart/resolve-chart-display.ts
@@ -40,10 +40,6 @@ export function resolveChartDisplayConfig(
   return {
     title: chartTag.text('title'),
     subtitle: chartTag.text('subtitle'),
-    size: {
-      width: width ?? undefined,
-      height: height ?? undefined,
-      preset: preset ?? undefined,
-    },
+    size: {width, height, preset},
   };
 }

--- a/packages/malloy-render/src/component/chart/resolve-chart-display.ts
+++ b/packages/malloy-render/src/component/chart/resolve-chart-display.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import type {Tag} from '@malloydata/malloy-tag';
+import type {NestField} from '@/data_tree';
+
+export interface ChartSizeConfig {
+  width?: number;
+  height?: number;
+  preset?: string;
+}
+
+export interface ChartDisplayConfig {
+  title?: string;
+  subtitle?: string;
+  size: ChartSizeConfig;
+}
+
+/**
+ * Setup-time resolver for chart display tags (title, subtitle, size).
+ *
+ * Reads the `viz.title`, `viz.subtitle`, `viz.size.*` properties plus the
+ * legacy top-level `size.*` fallback. Called from each chart plugin's
+ * `create()` so the reads happen during `setResult()` — no tag access
+ * needed at render time for these paths.
+ */
+export function resolveChartDisplayConfig(
+  field: NestField,
+  chartTag: Tag
+): ChartDisplayConfig {
+  const fieldTag = field.tag;
+  const width =
+    chartTag.numeric('size', 'width') ?? fieldTag.numeric('size', 'width');
+  const height =
+    chartTag.numeric('size', 'height') ?? fieldTag.numeric('size', 'height');
+  const preset = chartTag.text('size') ?? fieldTag.text('size');
+
+  return {
+    title: chartTag.text('title'),
+    subtitle: chartTag.text('subtitle'),
+    size: {
+      width: width ?? undefined,
+      height: height ?? undefined,
+      preset: preset ?? undefined,
+    },
+  };
+}

--- a/packages/malloy-render/src/component/types.ts
+++ b/packages/malloy-render/src/component/types.ts
@@ -6,7 +6,6 @@
  */
 
 import type * as Malloy from '@malloydata/malloy-interfaces';
-import type {Tag} from '@malloydata/malloy-tag';
 import type {Item, Spec, View} from 'vega';
 import type {JSX} from 'solid-js';
 import type {
@@ -41,7 +40,8 @@ export type VegaChartProps = {
   totalWidth: number;
   totalHeight: number;
   chartType: string;
-  chartTag: Tag;
+  title?: string;
+  subtitle?: string;
   mapMalloyDataToChartData: MalloyDataToChartDataHandler;
   getTooltipData?: (item: Item, view: View) => ChartTooltipEntry | null;
 };
@@ -89,6 +89,10 @@ export type Channel = {
   fields: string[];
   type: ScaleType | null;
   independent: boolean | 'auto';
+};
+
+export type XChannel = Channel & {
+  limit: number | 'auto';
 };
 
 export type YChannel = {

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
@@ -21,6 +21,11 @@ import {
 } from '@/plugins/bar-chart/get-bar_chart-settings';
 import {generateBarChartVegaSpecV2} from '@/plugins/bar-chart/generate-bar_chart-vega-spec';
 import {type VegaChartProps} from '@/component/types';
+import {
+  resolveChartDisplayConfig,
+  type ChartDisplayConfig,
+} from '@/component/chart/resolve-chart-display';
+import {convertLegacyToVizTag} from '@/component/tag-utils';
 import {type Config, parse, type Runtime} from 'vega';
 import 'vega-interpreter';
 import {mergeVegaConfigs} from '@/component/vega/merge-vega-configs';
@@ -40,6 +45,7 @@ export interface BarChartPluginInstance
   extends CoreVizPluginInstance<BarChartPluginMetadata> {
   getTopNSeries?: (maxSeries: number) => (string | number | boolean)[];
   field: NestField;
+  chartDisplay: ChartDisplayConfig;
   syntheticSeriesField?: Field;
   hasMultipleSeriesFields?: boolean;
 }
@@ -96,11 +102,19 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
       const settings = getBarChartSettings(field);
       const hasMultipleSeriesFields = settings.seriesChannel.fields.length > 1;
 
+      // Resolve chart display tags (title, subtitle, size) at setup time so
+      // chart.tsx and chart-layout-settings.ts don't need to read tags at
+      // render time.
+      const normalizedTag = convertLegacyToVizTag(field.tag);
+      const vizTag = normalizedTag.tag('viz')!;
+      const chartDisplay = resolveChartDisplayConfig(field, vizTag);
+
       const pluginInstance: BarChartPluginInstance = {
         name: 'bar',
         field,
         renderMode: 'solidjs',
         sizingStrategy: 'fill',
+        chartDisplay,
         hasMultipleSeriesFields,
 
         renderComponent: (props: RenderProps): JSXElement => {
@@ -127,7 +141,8 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
               plotHeight={vegaProps.plotHeight}
               totalWidth={vegaProps.totalWidth}
               totalHeight={vegaProps.totalHeight}
-              chartTag={vegaProps.chartTag}
+              title={vegaProps.title}
+              subtitle={vegaProps.subtitle}
               getTooltipData={vegaProps.getTooltipData}
               isDataLimited={mappedData.isDataLimited}
               dataLimitMessage={mappedData.dataLimitMessage}
@@ -279,23 +294,8 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
  * time, preventing false-positive unread-tag warnings.
  */
 const BAR_CHART_TAG_PATHS: string[][] = [
-  // viz sub-properties read by chart.tsx and spec generators
-  ['viz', 'title'],
-  ['viz', 'subtitle'],
-  ['viz', 'mode'],
-  ['viz', 'size'],
-  ['viz', 'stack'],
-  ['viz', 'disable_embedded'],
-  ['viz', 'disableEmbedded'],
-  // Channel settings
-  ['viz', 'x'],
-  ['viz', 'x', 'independent'],
-  ['viz', 'x', 'limit'],
-  ['viz', 'y'],
-  ['viz', 'y', 'independent'],
-  ['viz', 'series'],
-  ['viz', 'series', 'independent'],
-  ['viz', 'series', 'limit'],
-  // Legacy tag equivalents (read by convertLegacyToVizTag)
+  // Legacy tag form (read by convertLegacyToVizTag)
   ['bar_chart'],
+  // Legacy camelCase alias for disable_embedded
+  ['viz', 'disableEmbedded'],
 ];

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-plugin.tsx
@@ -296,6 +296,4 @@ export const BarChartPluginFactory: RenderPluginFactory<BarChartPluginInstance> 
 const BAR_CHART_TAG_PATHS: string[][] = [
   // Legacy tag form (read by convertLegacyToVizTag)
   ['bar_chart'],
-  // Legacy camelCase alias for disable_embedded
-  ['viz', 'disableEmbedded'],
 ];

--- a/packages/malloy-render/src/plugins/bar-chart/bar-chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/bar-chart-settings.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Channel, SeriesChannel, YChannel} from '@/component/types';
+import type {XChannel, SeriesChannel, YChannel} from '@/component/types';
 import type {
   JSONSchemaObject,
   JSONSchemaArray,
@@ -16,7 +16,7 @@ import type {
 
 // TypeScript type definition
 export interface BarChartSettings extends Record<string, unknown> {
-  xChannel: Channel;
+  xChannel: XChannel;
   yChannel: YChannel;
   seriesChannel: SeriesChannel;
   isStack: boolean;
@@ -31,6 +31,7 @@ export const defaultBarChartSettings: BarChartSettings = {
     fields: [],
     type: 'nominal',
     independent: 'auto',
+    limit: 'auto',
   },
   yChannel: {
     fields: [],
@@ -59,6 +60,7 @@ export interface IBarChartSettingsSchema extends JSONSchemaObject {
         };
         type: JSONSchemaString;
         independent: JSONSchemaString;
+        limit: JSONSchemaOneOf;
       };
     };
     yChannel: JSONSchemaObject & {
@@ -119,6 +121,23 @@ export const barChartSettingsSchema: IBarChartSettingsSchema = {
             'Whether X-axis domains should be independent across chart rows. "auto" means shared when ≤20 distinct values',
           type: 'string',
           enum: ['auto', 'true', 'false'],
+          default: 'auto',
+        },
+        limit: {
+          title: 'X-Axis Limit',
+          description:
+            'Maximum number of x-axis values to display. "auto" means chart determines optimal limit from plot width',
+          type: 'oneOf',
+          oneOf: [
+            {
+              type: 'string',
+              enum: ['auto'],
+            },
+            {
+              type: 'number',
+              minimum: 1,
+            },
+          ],
           default: 'auto',
         },
       },

--- a/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/generate-bar_chart-vega-spec.ts
@@ -41,9 +41,7 @@ import {getMarkName} from '@/component/vega/vega-utils';
 import type {CellValue, RecordCell} from '@/data_tree';
 import {Field} from '@/data_tree';
 import {NULL_SYMBOL} from '@/util';
-import {convertLegacyToVizTag} from '@/component/tag-utils';
 import type {RenderMetadata} from '@/component/render-result-metadata';
-import type {Tag} from '@malloydata/malloy-tag';
 import type {BarChartPluginInstance} from './bar-chart-plugin';
 
 type BarDataRecord = {
@@ -74,7 +72,8 @@ function getLimitedData({
   maxSizePerBar,
   isGrouping,
   chartSettings,
-  chartTag,
+  seriesLimitSetting,
+  xLimitSetting,
 }: {
   xField: Field;
   seriesField?: Field | null;
@@ -82,12 +81,14 @@ function getLimitedData({
   maxSizePerBar?: number;
   isGrouping: boolean;
   chartSettings: ChartLayoutSettings;
-  chartTag: Tag;
+  seriesLimitSetting: number | 'auto';
+  xLimitSetting: number | 'auto';
 }) {
   // Limit series values shown
   const seriesLimit =
-    chartTag.numeric('series', 'limit') ??
-    Math.min(maxSeries, seriesField?.valueSet.size ?? 1);
+    typeof seriesLimitSetting === 'number'
+      ? seriesLimitSetting
+      : Math.min(maxSeries, seriesField?.valueSet.size ?? 1);
   const seriesValuesToPlot = seriesField
     ? [...seriesField.valueSet.values()].slice(0, seriesLimit)
     : [];
@@ -100,9 +101,10 @@ function getLimitedData({
   const maxSizePerXGroup = chartSettings.isSpark
     ? 2
     : Math.floor(refinedMaxSizePerBar * subGroupBars);
-  const barLimitTag = chartTag.numeric('x', 'limit');
   const barLimit =
-    barLimitTag ?? Math.floor(chartSettings.plotWidth / maxSizePerXGroup);
+    typeof xLimitSetting === 'number'
+      ? xLimitSetting
+      : Math.floor(chartSettings.plotWidth / maxSizePerXGroup);
   const barValuesToPlot = [...xField.valueSet.values()].slice(0, barLimit);
 
   return {
@@ -121,12 +123,6 @@ export function generateBarChartVegaSpecV2(
   const pluginMetadata = plugin.getMetadata();
   const settings = pluginMetadata.settings;
   const {getTopNSeries, field: explore} = plugin;
-  const tag = convertLegacyToVizTag(explore.tag);
-  const chartTag = tag.tag('viz');
-  if (!chartTag)
-    throw new Error(
-      'Malloy Bar Chart: Tried to render a bar chart, but no viz=bar tag was found'
-    );
 
   /**************************************
    *
@@ -201,18 +197,22 @@ export function generateBarChartVegaSpecV2(
   const yDomainMin = Math.min(0, yMin);
   const yDomainMax = Math.max(0, yMax);
 
-  const maxSeries = chartTag.numeric('series', 'limit') ?? DEFAULT_MAX_SERIES;
+  const maxSeries =
+    typeof settings.seriesChannel.limit === 'number'
+      ? settings.seriesChannel.limit
+      : DEFAULT_MAX_SERIES;
   const isLimitingSeries = Boolean(
     seriesField && seriesField.valueSet.size > maxSeries
   );
 
-  const chartSettings = getChartLayoutSettings(explore, chartTag, {
+  const chartSettings = getChartLayoutSettings(explore, {
+    size: plugin.chartDisplay.size,
     metadata,
     xField,
     yField,
     chartType: 'bar',
     getYMinMax: () => [yDomainMin, yDomainMax],
-    independentY: chartTag.has('y', 'independent') || isLimitingSeries,
+    independentY: settings.yChannel.independent || isLimitingSeries,
     vegaConfig,
   });
 
@@ -222,7 +222,8 @@ export function generateBarChartVegaSpecV2(
     seriesField,
     isGrouping,
     chartSettings,
-    chartTag,
+    seriesLimitSetting: settings.seriesChannel.limit,
+    xLimitSetting: settings.xChannel.limit,
   });
 
   let maxString = '';
@@ -246,17 +247,18 @@ export function generateBarChartVegaSpecV2(
 
   // x axes across rows should auto share when distinct values <=20, unless user has explicitly set independent setting
   const autoSharedX = dataLimits.barValuesToPlot.length <= 20;
-  const forceSharedX = chartTag.text('x', 'independent') === 'false';
-  const forceIndependentX = chartTag.has('x', 'independent') && !forceSharedX;
+  const forceSharedX = settings.xChannel.independent === false;
+  const forceIndependentX =
+    settings.xChannel.independent === true && !forceSharedX;
   const shouldShareXDomain =
     forceSharedX || (autoSharedX && !forceIndependentX);
 
   // series legends across rows should auto share when distinct values <=20, unless user has explicitly set independent setting
   const autoSharedSeries =
     seriesField && dataLimits.seriesValuesToPlot.length <= 20;
-  const forceSharedSeries = chartTag.text('series', 'independent') === 'false';
+  const forceSharedSeries = settings.seriesChannel.independent === false;
   const forceIndependentSeries =
-    chartTag.has('series', 'independent') && !forceSharedSeries;
+    settings.seriesChannel.independent === true && !forceSharedSeries;
   const shouldShareSeriesDomain =
     forceSharedSeries || (autoSharedSeries && !forceIndependentSeries);
 
@@ -979,7 +981,8 @@ export function generateBarChartVegaSpecV2(
     totalWidth: chartSettings.totalWidth,
     totalHeight: chartSettings.totalHeight,
     chartType: 'bar',
-    chartTag,
+    title: plugin.chartDisplay.title,
+    subtitle: plugin.chartDisplay.subtitle,
     mapMalloyDataToChartData,
     getTooltipData: (item: Item, view: View) => {
       if (tooltipEntryMemo.has(item)) {

--- a/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Tag} from '@malloydata/malloy-tag';
-import type {Channel, SeriesChannel, YChannel} from '@/component/types';
+import type {XChannel, SeriesChannel, YChannel} from '@/component/types';
 import type {Field, NestField} from '@/data_tree';
 import {walkFields} from '@/util';
 import {convertLegacyToVizTag} from '@/component/tag-utils';
@@ -69,14 +69,19 @@ export function getBarChartSettings(
     vizTag.numeric('series', 'limit') ??
     defaultBarChartSettings.seriesChannel.limit;
 
+  // X-axis limit
+  const xLimit: number | 'auto' =
+    vizTag.numeric('x', 'limit') ?? defaultBarChartSettings.xChannel.limit;
+
   // Disable embedded field tags
   const disableEmbedded =
     vizTag.has('disable_embedded') || defaultBarChartSettings.disableEmbedded;
 
-  const xChannel: Channel = {
+  const xChannel: XChannel = {
     fields: [],
     type: defaultBarChartSettings.xChannel.type,
     independent: xIndependent,
+    limit: xLimit,
   };
 
   const yChannel: YChannel = {
@@ -107,25 +112,20 @@ export function getBarChartSettings(
     const yFieldPath = getField(yFieldRef);
     const yField = explore.fieldAt(yFieldPath);
 
-    // Validate Y field
-    if (!yField.isNumber() && !yField.wasCalculation()) {
-      throw new Error(
-        `Malloy Bar Chart: Field "${yField.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-      );
+    // Non-numeric y fields are skipped here and logged as validation errors
+    // in RenderFieldMetadata.validateFieldTags() so the user gets a
+    // source-located error instead of the red-box tile.
+    if (yField.isNumber() || yField.wasCalculation()) {
+      yChannel.fields.push(yFieldPath);
     }
-    yChannel.fields.push(yFieldPath);
   } else if (vizTag.textArray('y')) {
     const yFieldRefs = vizTag.textArray('y')!;
     yFieldRefs.forEach(ref => {
       const fieldPath = getField(ref);
       const field = explore.fieldAt(fieldPath);
-
-      if (!field.isNumber() && !field.wasCalculation()) {
-        throw new Error(
-          `Malloy Bar Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-        );
+      if (field.isNumber() || field.wasCalculation()) {
+        yChannel.fields.push(fieldPath);
       }
-      yChannel.fields.push(fieldPath);
     });
   }
   if (vizTag.text('series')) {
@@ -146,13 +146,10 @@ export function getBarChartSettings(
         embeddedX.push(pathTo);
       }
       if (tag.has('y')) {
-        // Validate y field
-        if (!field.isNumber() && !field.wasCalculation()) {
-          throw new Error(
-            `Malloy Bar Chart: Field "${field.name}" is tagged as y but is not numeric. Only numeric fields can be used as y channel.`
-          );
+        // Non-numeric y fields skipped here; logged in validateFieldTags.
+        if (field.isNumber() || field.wasCalculation()) {
+          embeddedY.push(pathTo);
         }
-        embeddedY.push(pathTo);
       }
       if (tag.has('series')) {
         embeddedSeries.push(pathTo);
@@ -179,21 +176,26 @@ export function getBarChartSettings(
     f => f.isBasic() && f.wasDimension()
   );
 
-  // If still no x or y, attempt to pick the best choice
+  // If still no x, attempt to pick the best choice — skipping any field
+  // the user has already claimed for another channel either by # y / # series
+  // tag or by viz.y / viz.series reference.
   if (xChannel.fields.length === 0) {
-    let fieldToUse: Field | undefined;
+    const isClaimed = (f: Field): boolean => {
+      const path = explore.pathTo(f);
+      if (yChannel.fields.includes(path)) return true;
+      if (seriesChannel.fields.includes(path)) return true;
+      if (f.tag.has('y') || f.tag.has('series')) return true;
+      return false;
+    };
     // Pick date/time field first if it exists
-    const dateTimeField = explore.fields.find(
-      f => f.wasDimension() && f.isTime()
+    let fieldToUse: Field | undefined = explore.fields.find(
+      f => f.wasDimension() && f.isTime() && !isClaimed(f)
     );
-    if (dateTimeField) fieldToUse = dateTimeField;
-    // Pick first dimension field for x
-    else if (dimensions.length > 0) {
-      fieldToUse = dimensions[0];
+    // Pick first unclaimed dimension field for x
+    if (!fieldToUse) {
+      fieldToUse = dimensions.find(f => !isClaimed(f));
     }
-    const fieldToUseTags = fieldToUse?.tag;
-    const isSeries = fieldToUseTags?.has('series');
-    if (fieldToUse && !isSeries) {
+    if (fieldToUse) {
       xChannel.fields.push(explore.pathTo(fieldToUse));
     }
   }

--- a/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/get-bar_chart-settings.ts
@@ -97,31 +97,42 @@ export function getBarChartSettings(
     limit: seriesLimit,
   };
 
-  function getField(ref: string) {
-    return explore.pathTo(explore.fieldAt([ref]));
+  // Returns undefined for unknown field refs instead of throwing so bad
+  // references are silently skipped here and reported by
+  // RenderFieldMetadata.validateFieldTags() with a source location.
+  function getField(ref: string): string | undefined {
+    try {
+      return explore.pathTo(explore.fieldAt([ref]));
+    } catch {
+      return undefined;
+    }
   }
 
   const isStack = vizTag.has('stack');
 
   // Parse top level tags from viz properties
   if (vizTag.text('x')) {
-    xChannel.fields.push(getField(vizTag.text('x')!));
+    const xPath = getField(vizTag.text('x')!);
+    if (xPath !== undefined) xChannel.fields.push(xPath);
   }
   if (vizTag.text('y')) {
     const yFieldRef = vizTag.text('y')!;
     const yFieldPath = getField(yFieldRef);
-    const yField = explore.fieldAt(yFieldPath);
 
     // Non-numeric y fields are skipped here and logged as validation errors
     // in RenderFieldMetadata.validateFieldTags() so the user gets a
     // source-located error instead of the red-box tile.
-    if (yField.isNumber() || yField.wasCalculation()) {
-      yChannel.fields.push(yFieldPath);
+    if (yFieldPath !== undefined) {
+      const yField = explore.fieldAt(yFieldPath);
+      if (yField.isNumber() || yField.wasCalculation()) {
+        yChannel.fields.push(yFieldPath);
+      }
     }
   } else if (vizTag.textArray('y')) {
     const yFieldRefs = vizTag.textArray('y')!;
     yFieldRefs.forEach(ref => {
       const fieldPath = getField(ref);
+      if (fieldPath === undefined) return;
       const field = explore.fieldAt(fieldPath);
       if (field.isNumber() || field.wasCalculation()) {
         yChannel.fields.push(fieldPath);
@@ -129,7 +140,8 @@ export function getBarChartSettings(
     });
   }
   if (vizTag.text('series')) {
-    seriesChannel.fields.push(getField(vizTag.text('series')!));
+    const seriesPath = getField(vizTag.text('series')!);
+    if (seriesPath !== undefined) seriesChannel.fields.push(seriesPath);
   }
 
   // Parse embedded tags

--- a/packages/malloy-render/src/plugins/bar-chart/settings-to-tag.ts
+++ b/packages/malloy-render/src/plugins/bar-chart/settings-to-tag.ts
@@ -101,5 +101,10 @@ export function barChartSettingsToTag(settings: BarChartSettings): Tag {
     );
   }
 
+  // Add x-axis limit if different from default
+  if (settings.xChannel?.limit !== defaultBarChartSettings.xChannel.limit) {
+    tag = tag.set(['viz', 'x', 'limit'], settings.xChannel.limit.toString());
+  }
+
   return tag;
 }

--- a/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
+++ b/packages/malloy-render/src/plugins/line-chart/generate-line_chart-vega-spec.ts
@@ -37,7 +37,6 @@ import {getCustomTooltipEntries} from '@/component/bar-chart/get-custom-tooltips
 import type {CellValue, RecordCell} from '@/data_tree';
 import {Field} from '@/data_tree';
 import {NULL_SYMBOL, type RenderTimeStringOptions} from '@/util';
-import {convertLegacyToVizTag} from '@/component/tag-utils';
 import type {RenderMetadata} from '@/component/render-result-metadata';
 import type {LineChartPluginInstance} from '@/plugins/line-chart/line-chart-plugin';
 
@@ -96,13 +95,6 @@ export function generateLineChartVegaSpecV2(
   const pluginMetadata = plugin.getMetadata();
   const settings = pluginMetadata.settings;
   const {getTopNSeries, field: explore} = plugin;
-  const tag = convertLegacyToVizTag(explore.tag);
-  const chartTag = tag.tag('viz');
-
-  if (!chartTag)
-    throw new Error(
-      'Malloy Line Chart: Tried to render a line chart, but no viz=line tag was found'
-    );
 
   /**************************************
    *
@@ -193,7 +185,8 @@ export function generateLineChartVegaSpecV2(
     seriesField && seriesField.valueSet.size > maxSeries
   );
 
-  const chartSettings = getChartLayoutSettings(explore, chartTag, {
+  const chartSettings = getChartLayoutSettings(explore, {
+    size: plugin.chartDisplay.size,
     metadata, // No legacy metadata in V2
     xField,
     yField,
@@ -1086,7 +1079,8 @@ export function generateLineChartVegaSpecV2(
     totalWidth: chartSettings.totalWidth,
     totalHeight: chartSettings.totalHeight,
     chartType: 'line',
-    chartTag,
+    title: plugin.chartDisplay.title,
+    subtitle: plugin.chartDisplay.subtitle,
     mapMalloyDataToChartData,
     getTooltipData(item, view) {
       if (tooltipEntryMemo.has(item)) {

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -193,13 +193,21 @@ export function getLineChartSettings(
     limit: seriesLimit,
   };
 
-  function getField(ref: string) {
-    return explore.pathTo(explore.fieldAt([ref]));
+  // Returns undefined for unknown field refs instead of throwing so bad
+  // references are silently skipped here and reported by
+  // RenderFieldMetadata.validateFieldTags() with a source location.
+  function getField(ref: string): string | undefined {
+    try {
+      return explore.pathTo(explore.fieldAt([ref]));
+    } catch {
+      return undefined;
+    }
   }
 
   // Parse top level tags
   if (vizTag.text('x')) {
-    xChannel.fields.push(getField(vizTag.text('x')!));
+    const xPath = getField(vizTag.text('x')!);
+    if (xPath !== undefined) xChannel.fields.push(xPath);
   }
   // Non-numeric y fields are skipped here and logged as validation errors
   // in RenderFieldMetadata.validateFieldTags() so the user gets a
@@ -210,15 +218,16 @@ export function getLineChartSettings(
   };
   if (vizTag.text('y')) {
     const path = getField(vizTag.text('y')!);
-    if (isValidYField(path)) yChannel.fields.push(path);
+    if (path !== undefined && isValidYField(path)) yChannel.fields.push(path);
   } else if (vizTag.textArray('y')) {
     vizTag.textArray('y')!.forEach(ref => {
       const path = getField(ref);
-      if (isValidYField(path)) yChannel.fields.push(path);
+      if (path !== undefined && isValidYField(path)) yChannel.fields.push(path);
     });
   }
   if (vizTag.text('series')) {
-    seriesChannel.fields.push(getField(vizTag.text('series')!));
+    const seriesPath = getField(vizTag.text('series')!);
+    if (seriesPath !== undefined) seriesChannel.fields.push(seriesPath);
   }
 
   // Parse embedded tags

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -7,7 +7,7 @@
 
 import type {Tag} from '@malloydata/malloy-tag';
 import type {Channel, YChannel, SeriesChannel} from '@/component/types';
-import type {NestField} from '@/data_tree';
+import type {Field, NestField} from '@/data_tree';
 import {walkFields, deepMerge} from '@/util';
 import {convertLegacyToVizTag} from '@/component/tag-utils';
 import {
@@ -253,16 +253,25 @@ export function getLineChartSettings(
 
   const measures = explore.fields.filter(f => f.wasCalculation());
 
-  // If still no x or y, attempt to pick the best choice
+  // If still no x, attempt to pick the best choice — skipping any field
+  // the user has already claimed for another channel either by # y / # series
+  // tag or by viz.y / viz.series reference.
   if (xChannel.fields.length === 0) {
-    // Pick date/time field first if it exists
-    const dateTimeField = explore.fields.find(
-      f => f.wasDimension() && f.isTime()
+    const isClaimed = (f: Field): boolean => {
+      const path = explore.pathTo(f);
+      if (yChannel.fields.includes(path)) return true;
+      if (seriesChannel.fields.includes(path)) return true;
+      if (f.tag.has('y') || f.tag.has('series')) return true;
+      return false;
+    };
+    let fieldToUse = explore.fields.find(
+      f => f.wasDimension() && f.isTime() && !isClaimed(f)
     );
-    if (dateTimeField) xChannel.fields.push(explore.pathTo(dateTimeField));
-    // Pick first dimension field for x
-    else if (dimensions.length > 0) {
-      xChannel.fields.push(explore.pathTo(dimensions[0]));
+    if (!fieldToUse) {
+      fieldToUse = dimensions.find(f => !isClaimed(f));
+    }
+    if (fieldToUse) {
+      xChannel.fields.push(explore.pathTo(fieldToUse));
     }
   }
   if (yChannel.fields.length === 0) {

--- a/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
+++ b/packages/malloy-render/src/plugins/line-chart/get-line_chart-settings.ts
@@ -201,10 +201,21 @@ export function getLineChartSettings(
   if (vizTag.text('x')) {
     xChannel.fields.push(getField(vizTag.text('x')!));
   }
+  // Non-numeric y fields are skipped here and logged as validation errors
+  // in RenderFieldMetadata.validateFieldTags() so the user gets a
+  // source-located error instead of the red-box tile.
+  const isValidYField = (path: string) => {
+    const f = explore.fieldAt(path);
+    return f.isNumber() || f.wasCalculation();
+  };
   if (vizTag.text('y')) {
-    yChannel.fields.push(getField(vizTag.text('y')!));
+    const path = getField(vizTag.text('y')!);
+    if (isValidYField(path)) yChannel.fields.push(path);
   } else if (vizTag.textArray('y')) {
-    yChannel.fields.push(...vizTag.textArray('y')!.map(getField));
+    vizTag.textArray('y')!.forEach(ref => {
+      const path = getField(ref);
+      if (isValidYField(path)) yChannel.fields.push(path);
+    });
   }
   if (vizTag.text('series')) {
     seriesChannel.fields.push(getField(vizTag.text('series')!));
@@ -224,7 +235,10 @@ export function getLineChartSettings(
         embeddedX.push(pathTo);
       }
       if (tag.has('y')) {
-        embeddedY.push(pathTo);
+        // Non-numeric y fields skipped here; logged in validateFieldTags.
+        if (field.isNumber() || field.wasCalculation()) {
+          embeddedY.push(pathTo);
+        }
       }
       if (tag.has('series')) {
         embeddedSeries.push(pathTo);
@@ -250,8 +264,6 @@ export function getLineChartSettings(
   const dimensions = explore.fields.filter(
     f => f.isBasic() && f.wasDimension()
   );
-
-  const measures = explore.fields.filter(f => f.wasCalculation());
 
   // If still no x, attempt to pick the best choice — skipping any field
   // the user has already claimed for another channel either by # y / # series
@@ -282,29 +294,37 @@ export function getLineChartSettings(
     if (numberField) yChannel.fields.push(explore.pathTo(numberField));
   }
   // If no series defined and multiple dimensions, use leftover dimension
+  // (one not already assigned to x or y channels)
   if (seriesChannel.fields.length === 0 && dimensions.length > 1) {
     const dimension = dimensions.find(d => {
       const path = explore.pathTo(d);
-      return !xChannel.fields.includes(path);
+      return !xChannel.fields.includes(path) && !yChannel.fields.includes(path);
     });
     if (dimension) {
       seriesChannel.fields.push(explore.pathTo(dimension));
     }
   }
 
-  if (dimensions.length > 2) {
+  // Dimensions explicitly assigned to the y channel don't count against the
+  // x+series dimension budget.
+  const yDimensionsCount = yChannel.fields.filter(path => {
+    const field = explore.fieldAt(path);
+    return field.wasDimension();
+  }).length;
+
+  if (dimensions.length - yDimensionsCount > 2) {
     throw new Error(
       'Malloy Line Chart: Too many dimensions. A line chart can have at most 2 dimensions: 1 for the x axis, and 1 for the series.'
     );
   }
-  if (dimensions.length === 0) {
+  if (dimensions.length - yDimensionsCount === 0) {
     throw new Error(
       'Malloy Line Chart: No dimensions found. A line chart must have at least 1 dimension for the x axis.'
     );
   }
-  if (measures.length === 0) {
+  if (yChannel.fields.length === 0) {
     throw new Error(
-      'Malloy Line Chart: No measures found. A line chart must have at least 1 measure for the y axis.'
+      'Malloy Line Chart: No measures found and no y channel specified. A line chart must have at least 1 measure or explicitly tagged numeric dimension for the y axis.'
     );
   }
 

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -338,8 +338,6 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
 const LINE_CHART_TAG_PATHS: string[][] = [
   // Legacy tag form (read by convertLegacyToVizTag)
   ['line_chart'],
-  // Legacy snake_case alias for disableEmbedded
-  ['viz', 'disable_embedded'],
 ];
 
 export type {LineChartPluginInstance};

--- a/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
+++ b/packages/malloy-render/src/plugins/line-chart/line-chart-plugin.tsx
@@ -22,6 +22,11 @@ import {
 } from '@/plugins/line-chart/get-line_chart-settings';
 import {generateLineChartVegaSpecV2} from '@/plugins/line-chart/generate-line_chart-vega-spec';
 import {type VegaChartProps} from '@/component/types';
+import {
+  resolveChartDisplayConfig,
+  type ChartDisplayConfig,
+} from '@/component/chart/resolve-chart-display';
+import {convertLegacyToVizTag} from '@/component/tag-utils';
 import {type Config, parse, type Runtime} from 'vega';
 import 'vega-interpreter';
 import {mergeVegaConfigs} from '@/component/vega/merge-vega-configs';
@@ -52,6 +57,7 @@ interface SeriesStats {
 interface LineChartPluginInstance
   extends CoreVizPluginInstance<LineChartPluginMetadata> {
   field: NestField;
+  chartDisplay: ChartDisplayConfig;
   seriesStats: Map<string, SeriesStats>;
   getTopNSeries: (maxSeries: number) => (string | number | boolean)[];
   syntheticSeriesField?: Field;
@@ -114,11 +120,19 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
         throw new Error(`Line chart settings error: ${error.message}`);
       }
 
+      // Resolve chart display tags (title, subtitle, size) at setup time so
+      // chart.tsx and chart-layout-settings.ts don't need to read tags at
+      // render time.
+      const normalizedTag = convertLegacyToVizTag(field.tag);
+      const vizTag = normalizedTag.tag('viz')!;
+      const chartDisplay = resolveChartDisplayConfig(field, vizTag);
+
       const pluginInstance: LineChartPluginInstance = {
         name: 'line',
         field,
         renderMode: 'solidjs',
         sizingStrategy: 'fill',
+        chartDisplay,
         seriesStats,
 
         renderComponent: (props: RenderProps): JSXElement => {
@@ -145,7 +159,8 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
               plotHeight={vegaProps.plotHeight}
               totalWidth={vegaProps.totalWidth}
               totalHeight={vegaProps.totalHeight}
-              chartTag={vegaProps.chartTag}
+              title={vegaProps.title}
+              subtitle={vegaProps.subtitle}
               getTooltipData={vegaProps.getTooltipData}
               isDataLimited={mappedData.isDataLimited}
               dataLimitMessage={mappedData.dataLimitMessage}
@@ -321,21 +336,10 @@ export const LineChartPluginFactory: RenderPluginFactory<LineChartPluginInstance
  * Tag paths read by the line chart plugin during render/interaction.
  */
 const LINE_CHART_TAG_PATHS: string[][] = [
-  ['viz', 'title'],
-  ['viz', 'subtitle'],
-  ['viz', 'mode'],
-  ['viz', 'size'],
-  ['viz', 'zero_baseline'],
-  ['viz', 'disableEmbedded'],
-  ['viz', 'disable_embedded'],
-  ['viz', 'x'],
-  ['viz', 'x', 'independent'],
-  ['viz', 'y'],
-  ['viz', 'y', 'independent'],
-  ['viz', 'series'],
-  ['viz', 'series', 'independent'],
-  ['viz', 'series', 'limit'],
+  // Legacy tag form (read by convertLegacyToVizTag)
   ['line_chart'],
+  // Legacy snake_case alias for disableEmbedded
+  ['viz', 'disable_embedded'],
 ];
 
 export type {LineChartPluginInstance};

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -12,6 +12,7 @@ import type {
 import {RenderLogCollector} from '@/component/render-log-collector';
 import {resolveBuiltInTags} from '@/component/tag-configs';
 import {getBuiltInRendererValidationSpec} from '@/component/renderer-validation-specs';
+import {convertLegacyToVizTag} from '@/component/tag-utils';
 
 import type * as Malloy from '@malloydata/malloy-interfaces';
 
@@ -313,8 +314,12 @@ export class RenderFieldMetadata {
     }
 
     // --- Chart field references ---
+    // Normalize legacy # bar_chart { ... } / # line_chart { ... } into the
+    // viz namespace so this check catches both old and new tag forms —
+    // matching what the chart settings builders do.
     if (field.isNest()) {
-      const vizTag = tag.tag('viz');
+      const normalizedTag = convertLegacyToVizTag(tag);
+      const vizTag = normalizedTag.tag('viz');
       if (vizTag) {
         const childByName = new Map(field.fields.map(f => [f.name, f]));
         for (const channelName of ['x', 'y', 'series'] as const) {
@@ -394,8 +399,10 @@ export class RenderFieldMetadata {
     }
 
     // --- Chart mode ---
+    // Normalize legacy # bar_chart / # line_chart so mode validation
+    // catches both old and new tag forms.
     if (field.isNest()) {
-      const vizTag = tag.tag('viz');
+      const vizTag = convertLegacyToVizTag(tag).tag('viz');
       if (vizTag) {
         const modeVal = vizTag.text('mode');
         if (modeVal !== undefined) {

--- a/packages/malloy-render/src/render-field-metadata.ts
+++ b/packages/malloy-render/src/render-field-metadata.ts
@@ -25,7 +25,6 @@ export type OnPluginCreateError = (
 export class RenderFieldMetadata {
   private registry: RenderFieldRegistry;
   private rootField: RootField;
-  private warnedLegacyDeclaredPathPlugins = new Set<string>();
   readonly logCollector: RenderLogCollector;
 
   constructor(
@@ -130,7 +129,7 @@ export class RenderFieldMetadata {
 
       // Mark renderer-owned tag paths as read so semantic ownership,
       // not literal render-time access, drives unread-tag warnings.
-      this.markOwnedTagPaths(field, plugins, matchingFactories);
+      this.markOwnedTagPaths(field, matchingFactories);
     }
     // Recurse for nested fields
     if (field.isNest()) {
@@ -317,21 +316,53 @@ export class RenderFieldMetadata {
     if (field.isNest()) {
       const vizTag = tag.tag('viz');
       if (vizTag) {
-        const childNames = new Set(field.fields.map(f => f.name));
+        const childByName = new Map(field.fields.map(f => [f.name, f]));
         for (const channelName of ['x', 'y', 'series'] as const) {
           const refArray = vizTag.textArray(channelName);
           const refs = refArray ?? [];
           const singleRef = vizTag.text(channelName);
           if (singleRef && !refArray) refs.push(singleRef);
           for (const ref of refs) {
-            if (!childNames.has(ref)) {
+            const child = childByName.get(ref);
+            if (!child) {
               log.error(
-                `Chart field reference '${ref}' for '${channelName}' on '${field.name}' does not match any field. Available fields: ${[...childNames].join(', ')}`,
+                `Chart field reference '${ref}' for '${channelName}' on '${field.name}' does not match any field. Available fields: ${[...childByName.keys()].join(', ')}`,
+                vizTag.tag(channelName)
+              );
+              continue;
+            }
+            if (
+              channelName === 'y' &&
+              child.isBasic() &&
+              !child.isNumber() &&
+              !child.wasCalculation()
+            ) {
+              log.error(
+                `Chart y-channel field '${ref}' on '${field.name}' must be numeric or a measure; got ${getFieldType(child)}.`,
                 vizTag.tag(channelName)
               );
             }
           }
         }
+      }
+    }
+
+    // --- Embedded # y tag on child field must be numeric or a measure ---
+    if (
+      field.isBasic() &&
+      tag.has('y') &&
+      !field.isNumber() &&
+      !field.wasCalculation()
+    ) {
+      const parent = field.parent;
+      const parentIsChart = parent
+        ?.getPlugins()
+        .some(plugin => plugin.name === 'bar' || plugin.name === 'line');
+      if (parentIsChart) {
+        log.error(
+          `Field '${field.name}' is tagged '# y' but is not numeric or a measure; the chart will pick y from the available measures instead.`,
+          tag.tag('y')
+        );
       }
     }
 
@@ -491,26 +522,9 @@ export class RenderFieldMetadata {
    */
   private markOwnedTagPaths(
     field: Field,
-    plugins: RenderPluginInstance[],
     matchingFactories: RenderPluginFactory[]
   ): void {
     const tag = field.tag;
-
-    for (const plugin of plugins) {
-      const declaredPaths = plugin.getDeclaredTagPaths?.() ?? [];
-      if (
-        declaredPaths.length > 0 &&
-        !this.warnedLegacyDeclaredPathPlugins.has(plugin.name)
-      ) {
-        this.warnedLegacyDeclaredPathPlugins.add(plugin.name);
-        this.logCollector.warn(
-          `Plugin '${plugin.name}' uses deprecated getDeclaredTagPaths(); migrate to getValidationSpec().`
-        );
-      }
-      for (const path of declaredPaths) {
-        tag.find(path);
-      }
-    }
 
     const specs: RendererValidationSpec[] = matchingFactories
       .map(factory => factory.getValidationSpec?.())

--- a/packages/malloy-render/src/stories/line_charts.stories.malloy
+++ b/packages/malloy-render/src/stories/line_charts.stories.malloy
@@ -456,6 +456,44 @@ source: products is duckdb.table("static/data/products.parquet") extend {
       order_by: `date`
     }
 
+  #(story)
+  view: numeric_dimensions_as_y is {
+    # viz=line
+    nest:
+      tagged is {
+        group_by: brand
+        aggregate: total_sales
+        limit: 10
+      } -> {
+        group_by:
+          brand
+          # y
+          # number
+          total_sales
+      }
+      y_tagged_first is {
+        group_by: brand
+        aggregate: total_sales
+        limit: 10
+      } -> {
+        group_by:
+          # y
+          # number
+          total_sales
+          brand
+      }
+      misconfigured is {
+        group_by:
+          brand
+          # y
+          department
+      }
+      not_tagged is {
+        group_by: brand, department
+        limit: 10
+      }
+  }
+
     #(story)
   # viz=line {mode=yoy}
   view: month_yoy_NOT_IMPLEMENTED is {

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -385,6 +385,126 @@ describe('render tag validation', () => {
     });
   });
 
+  describe('chart y-channel must be numeric', () => {
+    it('errors when # y is on a non-numeric dimension in a bar chart', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 'B' as label, 1 as val") extend {
+          # viz=bar
+          view: q is {
+            group_by:
+              cat
+              # y
+              label
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "Field 'label' is tagged '# y'");
+    });
+
+    it('errors when # y is on a non-numeric dimension in a line chart', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as x_val, 'B' as label, 1 as val") extend {
+          # viz=line
+          view: q is {
+            group_by:
+              x_val
+              # y
+              label
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "Field 'label' is tagged '# y'");
+    });
+
+    it('errors when viz.y references a non-numeric field', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 'B' as label, 1 as val") extend {
+          # viz=bar { y=label }
+          view: q is {
+            group_by: cat, label
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "y-channel field 'label'");
+    });
+
+    it('no error when # y is on a numeric dimension in a bar chart', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 5 as num_dim, 1 as val") extend {
+          # viz=bar
+          view: q is {
+            group_by:
+              cat
+              # y
+              num_dim
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('no error when # y is on a measure in a bar chart', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # viz=bar
+          view: q is {
+            group_by: cat
+            aggregate:
+              # y
+              total is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('no error and no silent mis-render when a numeric dimension tagged # y precedes the intended x dimension', async () => {
+      // Regression: when a numeric dimension is tagged # y and appears before
+      // the intended x dimension, the implicit-x picker must skip the y-tagged
+      // field rather than double-assigning it as both x and y.
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 100 as total_sales, 'A' as brand") extend {
+          # viz=bar
+          view: q is {
+            group_by:
+              # y
+              total_sales
+              brand
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+    });
+
+    it('the only dimension being tagged # y leaves no dimension for x (instead of silently using it for both)', async () => {
+      // Sharper regression: if the sole dimension is claimed as y, auto-x
+      // should skip it and leave xChannel empty. Bar chart then correctly
+      // reports that no x dimension is available.
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 100 as total_sales") extend {
+          # viz=bar
+          view: q is {
+            group_by:
+              # y
+              total_sales
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, 'requires a dimension for the x axis');
+    });
+  });
+
   describe('no errors for valid tags', () => {
     it('no errors for # currency=usd on a number', async () => {
       const logs = await getValidationLogs(`
@@ -505,6 +625,111 @@ describe('render tag validation', () => {
             aggregate:
               # y
               b is count()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for bar chart top-level channel tags', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 'B' as series_val, 1 as val") extend {
+          # viz=bar { x=cat y=val series=series_val stack }
+          view: q is {
+            group_by: cat, series_val
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for bar chart channel settings (independent and limits)', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 'B' as series_val, 1 as val") extend {
+          # viz=bar { x.independent=true y.independent=true series.independent=false series.limit=5 x.limit=10 }
+          view: q is {
+            group_by: cat, series_val
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for bar chart disable_embedded and mode tags', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # viz=bar { disable_embedded mode=normal }
+          view: q is {
+            group_by: cat
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for line chart channel settings and mode', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # viz=line { x.independent=true y.independent=true series.independent=false series.limit=5 zero_baseline=true mode=normal disableEmbedded }
+          view: q is {
+            group_by: cat
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for bar chart legacy bar_chart tag', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # bar_chart
+          view: q is {
+            group_by: cat
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for line chart legacy line_chart tag', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as x_val, 2 as y_val") extend {
+          # line_chart
+          view: q is {
+            group_by: x_val
+            aggregate: y_val is y_val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectNoErrors(logs);
+      expectNoWarnings(logs);
+    });
+
+    it('no warnings for chart title and subtitle', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # viz=bar { title="My Chart" subtitle="Some data" }
+          view: q is {
+            group_by: cat
+            aggregate: val is val.sum()
           }
         }
         query: q is s -> q

--- a/test/src/render/render-validator.spec.ts
+++ b/test/src/render/render-validator.spec.ts
@@ -486,6 +486,77 @@ describe('render tag validation', () => {
       expectNoErrors(logs);
     });
 
+    it('errors when legacy # bar_chart has # y on a non-numeric dimension', async () => {
+      // Legacy # bar_chart { ... } tag must be validated through the same
+      // rules as # viz=bar.
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 'B' as label, 1 as val") extend {
+          # bar_chart
+          view: q is {
+            group_by:
+              cat
+              # y
+              label
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "Field 'label' is tagged '# y'");
+    });
+
+    it('errors when legacy # line_chart references a non-numeric y via viz.y', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as x_val, 'B' as label, 1 as val") extend {
+          # line_chart { y=label }
+          view: q is {
+            group_by: x_val, label
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "y-channel field 'label'");
+    });
+
+    it('logs (not throws) when # viz.x references a nonexistent field', async () => {
+      // Missing field refs should be reported via validateFieldTags with a
+      // source location — the chart must still render rather than replacing
+      // itself with a red-box plugin-creation error.
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 'A' as cat, 1 as val") extend {
+          # viz=bar { x=nonexistent }
+          view: q is {
+            group_by: cat
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "'nonexistent'");
+      // The error must be the validator's, not the wrapped plugin throw.
+      const wrapped = logs.filter(l => l.message.includes('Plugin bar failed'));
+      expect(wrapped).toHaveLength(0);
+    });
+
+    it('logs (not throws) when # viz.y references a nonexistent field on a line chart', async () => {
+      const logs = await getValidationLogs(`
+        source: s is duckdb.sql("SELECT 1 as x_val, 1 as val") extend {
+          # viz=line { y=nonexistent }
+          view: q is {
+            group_by: x_val
+            aggregate: val is val.sum()
+          }
+        }
+        query: q is s -> q
+      `);
+      expectError(logs, "'nonexistent'");
+      const wrapped = logs.filter(l =>
+        l.message.includes('Plugin line failed')
+      );
+      expect(wrapped).toHaveLength(0);
+    });
+
     it('the only dimension being tagged # y leaves no dimension for x (instead of silently using it for both)', async () => {
       // Sharper regression: if the sole dimension is claimed as y, auto-x
       // should skip it and leave xChannel empty. Bar chart then correctly


### PR DESCRIPTION
## Renderer Validation Contract

#2770 revealed a number of flaws in the exposure of the renderer validation system to an AI reading this code — the reviewer (me) ended up asking an author to follow rules that weren't written down, using a pattern (throw from `getLineChartSettings`) that every other chart plugin in the codebase also uses.

This PR:

1. **Publishes the rules of engagement** for renderer plugins so future PRs can be reviewed against a stated contract rather than invisible precedent.
2. **Fixes the built-in chart plugins** to follow those rules, so the documentation describes what the code actually does.
3. **Covers the two issues** raised in #2770 (auto-x skipping `# y` tagged fields, and source-located y-type validation).

## Docs

- **New `packages/malloy-render/docs/validation.md`** — the canonical rule set:
  - Setup-time reads are the default; render-time reads are exceptions that must be declared.
  - Throw vs log: throw from `matches()` / `create()` when the user asked for a specific renderer and that renderer cannot produce output — the red error tile is the feature. Log via `validateFieldTags()` with `log.error(msg, tagRef)` when the render still works with defaults and one setting is wrong.
  - Pre-PR checklist.
- `packages/malloy-render/CONTEXT.md` — point at `validation.md`, trim scattered/redundant validation subsections.
- `plugin-system.md`, `plugin-api-reference.md`, `plugin-quick-start.md` — stop implying throw is the default; link to `validation.md`. Document `getValidationSpec` and `RendererValidationSpec`, which were missing from the API reference entirely.

## Closes

Closes #2770 — both P2 (auto-x auto-selection skipping `# y`/`# series` tagged fields) and P3 (y-type check routed through `validateFieldTags` with source location) are covered here. Many thanks to @jswir for raising the issues that prompted the larger cleanup.