### PR TITLE
docs(render): cross-link package docs and clarify storybook iteration rules

### DIFF
--- a/packages/malloy-render/CONTEXT.md
+++ b/packages/malloy-render/CONTEXT.md
@@ -2,6 +2,8 @@
 
 The `malloy-render` package handles visualization and rendering of Malloy query results. It transforms query results into rich, interactive visualizations and tables.
 
+**Related docs:** [README.md](./README.md) for public-facing installation and usage, [DEVELOPING.md](./DEVELOPING.md) for the local development workflow, [docs/validation.md](./docs/validation.md) for the renderer validation contract.
+
 ## Purpose
 
 Malloy queries return structured data with metadata about how it should be displayed. The render package:

--- a/packages/malloy-render/DEVELOPING.md
+++ b/packages/malloy-render/DEVELOPING.md
@@ -21,16 +21,21 @@ $ npm run --prefix packages/malloy-render storybook-windows
 
 Then navigate to the URL provided. In this storybook, you can navigate between different stories that render Malloy queries from the Malloy source code.
 
-### Tips
+### Iteration rules
 
-This storybook does not hot reload, so you need to reload the page when:
+Storybook does not use hot module replacement (HMR), but the Vite dev server stays running while you work. Most changes are picked up by a browser page reload; only boot-time artifacts require restarting Storybook.
 
-- you make changes to malloy-render source code
-- you add a new story
+| You change… | What you do |
+|---|---|
+| `.ts` / `.tsx` / `.css` in `src/` | Reload the browser page — Vite serves source directly, so changes are picked up on refresh |
+| A `.stories.malloy` file | Restart Storybook — the story indexer runs once at boot |
+| `.storybook/` config or `registered_data.json` | Restart Storybook |
+| A file in `src/stories/static/data/` | Reload the browser page |
+| Anything in `packages/malloy/src/` (Malloy core) | Restart Storybook |
 
-If you make changes to the malloy core package, you need to relaunch the storybook.
+You do **not** need to run `npm run build` as part of normal iteration. `npm run build` produces the published library bundles (`dist/module/index.umd.js`, `index.mjs`), which Storybook does not consume — Storybook reads source directly via Vite.
 
-It is fairly common for Malloy compilation to randomly fail when opening the storybook. A simple reload of the page fixes the problem.
+It is fairly common for Malloy compilation to randomly fail when first opening Storybook. A simple page reload fixes it.
 
 ## Adding new stories for viewing the renderer
 

--- a/packages/malloy-render/README.md
+++ b/packages/malloy-render/README.md
@@ -56,4 +56,5 @@ The Malloy Renderer supports a plugin system for creating custom visualizations.
 
 # Developing
 
-See the [Developing README](./DEVELOPING.md)
+- [DEVELOPING.md](./DEVELOPING.md) — how to run Storybook, add stories, and debug renderers locally
+- [CONTEXT.md](./CONTEXT.md) — architectural overview for contributors and AI agents


### PR DESCRIPTION
## Summary

Three small doc edits in `packages/malloy-render/` that together make the package easier to navigate for new contributors and AI agents:

- **README** — the `Developing` section now lists both `DEVELOPING.md` and `CONTEXT.md` with one-line descriptions, so readers land in the right doc rather than always starting at the dev guide.
- **CONTEXT.md** — a `Related docs` line added under the opening paragraph, pointing at README (public usage), DEVELOPING (local dev loop), and `docs/validation.md` (validation contract).
- **DEVELOPING.md** — the old `Tips` section is now an `Iteration rules` table making it explicit which change types need a browser reload vs a Storybook restart, with a note that `npm run build` is **not** part of the normal storybook iteration loop (it builds the published library artifact, which Storybook does not consume).

No code or behavior changes.
