### PR TITLE
build(render): publish ESM entry with externalized peer deps

### DIFF
--- a/packages/malloy-render/femto-config.motly
+++ b/packages/malloy-render/femto-config.motly
@@ -3,11 +3,15 @@ build: {
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.css",
-    "vite.config.mts",
+    "vite.config.base.mts",
+    "vite.config.esm.mts",
+    "vite.config.umd.mts",
     "tsconfig.json"
   ]
-  outputs = ["dist/module/index.mjs"]
+  outputs = ["dist/module/index.mjs", "dist/module/index.umd.js"]
   commands = [
-    "npx vite build --outDir 'dist/module' --config vite.config.mts"
+    "rm -rf dist/module",
+    "npx vite build --outDir 'dist/module' --config vite.config.esm.mts",
+    "npx vite build --outDir 'dist/module' --config vite.config.umd.mts"
   ]
 }

--- a/packages/malloy-render/package.json
+++ b/packages/malloy-render/package.json
@@ -15,6 +15,8 @@
   "exports": {
     ".": {
       "types": "./dist/module/index.d.ts",
+      "import": "./dist/module/index.mjs",
+      "require": "./dist/module/index.umd.js",
       "default": "./dist/module/index.umd.js"
     }
   },

--- a/packages/malloy-render/vite.config.esm.mts
+++ b/packages/malloy-render/vite.config.esm.mts
@@ -1,0 +1,39 @@
+import {mergeConfig} from 'vite';
+import baseViteConfig from './vite.config.base.mts';
+
+// Peer deps that consumers of the ESM build resolve from their own
+// node_modules (enabling dedupe and tree-shaking). The UMD build keeps
+// everything inlined for script-tag and Node (require) consumers.
+//
+// This ESM artifact is bundler-only: it contains subpath imports
+// (e.g. lodash/startCase) and JSON imports (e.g. us-atlas/states-10m.json)
+// that a bundler resolves transparently but that Node's native ESM
+// resolver does not. Node consumers without a bundler should use the
+// `require` condition in package.json `exports`, which resolves to UMD.
+const external: (string | RegExp)[] = [
+  /^solid-js(\/.*)?$/,
+  /^lodash(\/.*)?$/,
+  /^luxon(\/.*)?$/,
+  /^ssf$/,
+  /^us-atlas(\/.*)?$/,
+  /^@tanstack\/solid-virtual$/,
+  /^@malloydata\/malloy-interfaces(\/.*)?$/,
+  /^@malloydata\/malloy-tag(\/.*)?$/,
+  /^vega(\/.*)?$/,
+  /^vega-[a-z-]+(\/.*)?$/,
+  /^d3-[a-z-]+(\/.*)?$/,
+];
+
+export default mergeConfig(baseViteConfig, {
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: 'src/index.ts',
+      formats: ['es'],
+      fileName: 'index',
+    },
+    rollupOptions: {
+      external,
+    },
+  },
+});

--- a/packages/malloy-render/vite.config.umd.mts
+++ b/packages/malloy-render/vite.config.umd.mts
@@ -1,11 +1,16 @@
 import {mergeConfig} from 'vite';
 import baseViteConfig from './vite.config.base.mts';
 
+// UMD build inlines every dependency so the artifact works as a
+// self-contained script-tag embed and as a CJS require target. Do not
+// externalize anything here — that is the ESM build's job.
 export default mergeConfig(baseViteConfig, {
   build: {
+    emptyOutDir: false,
     lib: {
       entry: 'src/index.ts',
       name: 'index',
+      formats: ['umd'],
       fileName: 'index',
     },
   },


### PR DESCRIPTION
## Summary

Splits the Vite library build for `@malloydata/render` into per-format configs:

- **`vite.config.esm.mts`** — ESM build. Externalizes the peer-dep families (Vega, Vega-Lite, Solid, d3, Luxon, Lodash, us-atlas, ssf, vega-interpreter, `@tanstack/solid-virtual`, `@malloydata/malloy-interfaces`, `@malloydata/malloy-tag`) so bundler consumers can dedupe and (eventually) tree-shake them from their own dep graph.
- **`vite.config.umd.mts`** — UMD build. Fully bundled, byte-equivalent to what shipped before. Preserves the CJS `require()` path used by `@malloydata/render-validator` and any direct `<script src>` consumers.
- **`femto-config.motly`** — orchestrates both builds sequentially into `dist/module/`.
- **`package.json` `exports`** — adds `import` and `require` conditions. Modern bundlers pick ESM automatically; CJS consumers keep getting UMD; the `default` condition points at UMD for tools that don't honor conditional exports.

## Why one change, not phased

An earlier draft of this plan phased the work as (1) advertise ESM as-is, (2) wait for opt-in, (3) externalize later. Phase 1 alone saves almost nothing; the risk of externalization isn't reduced by shipping a no-op ESM first. The primary consumers are either already configured for externalized peer deps (explorer) or have every peer dep in their node_modules today (VS Code extension, verified against `package-lock.json`). Going straight to externalized ESM in one PR.

## Scope note: ESM is bundler-only

The ESM artifact contains subpath imports (`lodash/startCase`) and JSON imports (`us-atlas/states-10m.json`) that bundlers resolve transparently but Node's native ESM resolver does not. Node consumers without a bundler use the `require` condition and get UMD. No known consumer needs Node ESM today; making the artifact Node-resolvable would require invasive source changes (top-level lodash imports, `with { type: "json" }` assertions) for zero current benefit.

## Measured impact (VS Code extension via `npm link`)

esbuild picked `dist/module/index.mjs` for the webview and renderer targets; all externalized deps resolved through the linked renderer's `node_modules`. No unresolved-import errors.

| Bundle | Delta |
|---|---|
| `malloy_entry.js` | −37 KB |
| `query_page.js` | −38 KB |
| `explorer_page.js` | +71 KB |
| `schema_entry.js` | ≈0 |

Net: roughly a wash. The larger tree-shake win projected earlier did not materialize because the renderer's top-level barrel (`src/index.ts`) re-exports `@/plugins`, which transitively imports every chart plugin and therefore the entire Vega stack. Bundlers can't eliminate "possibly-used" exports.

This PR is the **packaging prerequisite** for the follow-up work that narrows the barrel (or defers plugin registration to runtime), which is what will actually deliver bytes. Shipping ESM without changing source first gives bundlers *permission* to tree-shake; the source refactor gives them *something worth shaving*.

## Tests

- `render-validator.spec.ts`: 60/60 pass — confirms the UMD CJS-require path is byte-equivalent and still works with the fake-DOM shim.
- Renderer package jest: 90/90 pass.
- Lint: clean.
- VS Code extension rebuild via `npm link`: build succeeds end-to-end; all externalized deps resolve.

Runtime: Extension Development Host smoke (F5, render a chart) **not yet verified** and should be done before publishing the next renderer version.

## Non-goals

- Dropping UMD. Needed for render-validator and direct-script consumers.
- Migrating `dependencies` → `peerDependencies`. Separate cleanup that would break transitive resolvers.
- Narrowing the barrel or making plugins lazy. Separate, larger work that this PR enables.
- Rewriting the renderer's source imports to be Node-ESM resolvable. No consumer needs it.

## Shared plan

Detailed plan shared with app-ai-coders working on downstream consumers lives at `~/ctx/renderer-esm.md` on my workstation.

## Test plan

- [ ] Extension Development Host smoke: launch via F5, open a `.malloy` file, run a query, verify a chart (bar or line) renders correctly
- [ ] Bundle size delta confirmed by rebuilding the extension with `npm link` pointing at this branch vs main
- [ ] Unit tests and lint pass on CI